### PR TITLE
GH-49689: [R][C++] Parquets do not support list-columns of ordered factors (ordered dictionaries)

### DIFF
--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1768,8 +1768,8 @@ TEST(TestDictionaryBuilderOrdered, TypePreservesOrderedFlag) {
   std::unique_ptr<ArrayBuilder> boxed_builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
 
-  const auto& builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
-  ASSERT_TRUE(builder_type.ordered());
+  auto builder_type = boxed_builder->type();
+  ASSERT_TRUE(checked_cast<const DictionaryType&>(*builder_type).ordered());
 }
 
 TEST(TestDictionaryBuilderOrdered, UnorderedTypeStaysUnordered) {
@@ -1777,8 +1777,8 @@ TEST(TestDictionaryBuilderOrdered, UnorderedTypeStaysUnordered) {
   std::unique_ptr<ArrayBuilder> boxed_builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), unordered_type, &boxed_builder));
 
-  const auto& builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
-  ASSERT_FALSE(builder_type.ordered());
+  auto builder_type = boxed_builder->type();
+  ASSERT_FALSE(checked_cast<const DictionaryType&>(*builder_type).ordered());
 }
 
 TEST(TestDictionaryBuilderOrdered, FinishPreservesOrderedFlag) {
@@ -1834,8 +1834,8 @@ TEST(TestDictionaryBuilderOrdered, MakeDictionaryBuilderPreservesOrdered) {
   ASSERT_OK(MakeDictionaryBuilder(default_memory_pool(), ordered_type,
                                   /*dictionary=*/nullptr, &builder));
 
-  const auto& builder_type = checked_cast<const DictionaryType&>(*builder->type());
-  ASSERT_TRUE(builder_type.ordered());
+  auto builder_type = builder->type();
+  ASSERT_TRUE(checked_cast<const DictionaryType&>(*builder_type).ordered());
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1768,7 +1768,7 @@ TEST(TestDictionaryBuilderOrdered, TypePreservesOrderedFlag) {
   std::unique_ptr<ArrayBuilder> boxed_builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
 
-  auto builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
+  const auto& builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
   ASSERT_TRUE(builder_type.ordered());
 }
 
@@ -1777,7 +1777,7 @@ TEST(TestDictionaryBuilderOrdered, UnorderedTypeStaysUnordered) {
   std::unique_ptr<ArrayBuilder> boxed_builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), unordered_type, &boxed_builder));
 
-  auto builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
+  const auto& builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
   ASSERT_FALSE(builder_type.ordered());
 }
 
@@ -1794,7 +1794,7 @@ TEST(TestDictionaryBuilderOrdered, FinishPreservesOrderedFlag) {
   std::shared_ptr<Array> result;
   ASSERT_OK(builder.Finish(&result));
 
-  auto result_type = checked_cast<const DictionaryType&>(*result->type());
+  const auto& result_type = checked_cast<const DictionaryType&>(*result->type());
   ASSERT_TRUE(result_type.ordered());
 
   auto ex_dict = ArrayFromJSON(utf8(), R"(["a", "b"])");
@@ -1822,8 +1822,8 @@ TEST(TestDictionaryBuilderOrdered, ListOfOrderedDictionary) {
   std::shared_ptr<Array> result;
   ASSERT_OK(list_builder.Finish(&result));
 
-  auto result_list_type = checked_cast<const ListType&>(*result->type());
-  auto result_dict_type =
+  const auto& result_list_type = checked_cast<const ListType&>(*result->type());
+  const auto& result_dict_type =
       checked_cast<const DictionaryType&>(*result_list_type.value_type());
   ASSERT_TRUE(result_dict_type.ordered());
 }
@@ -1834,7 +1834,7 @@ TEST(TestDictionaryBuilderOrdered, MakeDictionaryBuilderPreservesOrdered) {
   ASSERT_OK(MakeDictionaryBuilder(default_memory_pool(), ordered_type,
                                   /*dictionary=*/nullptr, &builder));
 
-  auto builder_type = checked_cast<const DictionaryType&>(*builder->type());
+  const auto& builder_type = checked_cast<const DictionaryType&>(*builder->type());
   ASSERT_TRUE(builder_type.ordered());
 }
 

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1761,4 +1761,81 @@ TEST(TestDictionaryUnifier, TableZeroColumns) {
   AssertTablesEqual(*table, *unified);
 }
 
+// GH-49689: Ordered dictionary tests
+
+TEST(TestDictionaryBuilderOrdered, TypePreservesOrderedFlag) {
+  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
+
+  auto builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
+  ASSERT_TRUE(builder_type.ordered());
+}
+
+TEST(TestDictionaryBuilderOrdered, UnorderedTypeStaysUnordered) {
+  auto unordered_type = dictionary(int8(), utf8(), /*ordered=*/false);
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), unordered_type, &boxed_builder));
+
+  auto builder_type = checked_cast<const DictionaryType&>(*boxed_builder->type());
+  ASSERT_FALSE(builder_type.ordered());
+}
+
+TEST(TestDictionaryBuilderOrdered, FinishPreservesOrderedFlag) {
+  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
+  auto& builder = checked_cast<DictionaryBuilder<StringType>&>(*boxed_builder);
+
+  ASSERT_OK(builder.Append("a"));
+  ASSERT_OK(builder.Append("b"));
+  ASSERT_OK(builder.Append("a"));
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(builder.Finish(&result));
+
+  auto result_type = checked_cast<const DictionaryType&>(*result->type());
+  ASSERT_TRUE(result_type.ordered());
+
+  auto ex_dict = ArrayFromJSON(utf8(), R"(["a", "b"])");
+  auto ex_indices = ArrayFromJSON(int8(), "[0, 1, 0]");
+  DictionaryArray expected(ordered_type, ex_indices, ex_dict);
+  AssertArraysEqual(expected, *result);
+}
+
+TEST(TestDictionaryBuilderOrdered, ListOfOrderedDictionary) {
+  auto ordered_dict_type = dictionary(int8(), utf8(), /*ordered=*/true);
+  auto list_type = list(field("item", ordered_dict_type));
+
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), list_type, &boxed_builder));
+  auto& list_builder = checked_cast<ListBuilder&>(*boxed_builder);
+  auto& dict_builder =
+      checked_cast<DictionaryBuilder<StringType>&>(*list_builder.value_builder());
+
+  ASSERT_OK(list_builder.Append());
+  ASSERT_OK(dict_builder.Append("a"));
+  ASSERT_OK(dict_builder.Append("b"));
+  ASSERT_OK(list_builder.Append());
+  ASSERT_OK(dict_builder.Append("a"));
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(list_builder.Finish(&result));
+
+  auto result_list_type = checked_cast<const ListType&>(*result->type());
+  auto result_dict_type =
+      checked_cast<const DictionaryType&>(*result_list_type.value_type());
+  ASSERT_TRUE(result_dict_type.ordered());
+}
+
+TEST(TestDictionaryBuilderOrdered, MakeDictionaryBuilderPreservesOrdered) {
+  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
+  std::unique_ptr<ArrayBuilder> builder;
+  ASSERT_OK(MakeDictionaryBuilder(default_memory_pool(), ordered_type,
+                                  /*dictionary=*/nullptr, &builder));
+
+  auto builder_type = checked_cast<const DictionaryType&>(*builder->type());
+  ASSERT_TRUE(builder_type.ordered());
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1829,7 +1829,8 @@ TEST(TestDictionaryBuilderOrdered, MakeDictionaryBuilderPreservesOrdered) {
   for (bool ordered : {true, false}) {
     ARROW_SCOPED_TRACE("ordered = ", ordered);
     auto dict_type = dictionary(int8(), utf8(), ordered);
-    ASSERT_OK_AND_ASSIGN(auto builder, MakeDictionaryBuilder(dict_type));
+    ASSERT_OK_AND_ASSIGN(auto builder,
+                         MakeDictionaryBuilder(dict_type, /*dictionary=*/nullptr));
 
     auto builder_type = builder->type();
     ASSERT_EQ(checked_cast<const DictionaryType&>(*builder_type).ordered(), ordered);

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1764,78 +1764,81 @@ TEST(TestDictionaryUnifier, TableZeroColumns) {
 // GH-49689: Ordered dictionary tests
 
 TEST(TestDictionaryBuilderOrdered, TypePreservesOrderedFlag) {
-  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
-  std::unique_ptr<ArrayBuilder> boxed_builder;
-  ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
+  for (bool ordered : {true, false}) {
+    ARROW_SCOPED_TRACE("ordered = ", ordered);
+    auto dict_type = dictionary(int8(), utf8(), ordered);
+    std::unique_ptr<ArrayBuilder> boxed_builder;
+    ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &boxed_builder));
 
-  auto builder_type = boxed_builder->type();
-  ASSERT_TRUE(checked_cast<const DictionaryType&>(*builder_type).ordered());
-}
-
-TEST(TestDictionaryBuilderOrdered, UnorderedTypeStaysUnordered) {
-  auto unordered_type = dictionary(int8(), utf8(), /*ordered=*/false);
-  std::unique_ptr<ArrayBuilder> boxed_builder;
-  ASSERT_OK(MakeBuilder(default_memory_pool(), unordered_type, &boxed_builder));
-
-  auto builder_type = boxed_builder->type();
-  ASSERT_FALSE(checked_cast<const DictionaryType&>(*builder_type).ordered());
+    auto builder_type = boxed_builder->type();
+    ASSERT_EQ(checked_cast<const DictionaryType&>(*builder_type).ordered(), ordered);
+  }
 }
 
 TEST(TestDictionaryBuilderOrdered, FinishPreservesOrderedFlag) {
-  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
-  std::unique_ptr<ArrayBuilder> boxed_builder;
-  ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
-  auto& builder = checked_cast<DictionaryBuilder<StringType>&>(*boxed_builder);
+  for (bool ordered : {true, false}) {
+    ARROW_SCOPED_TRACE("ordered = ", ordered);
+    auto dict_type = dictionary(int8(), utf8(), ordered);
+    std::unique_ptr<ArrayBuilder> boxed_builder;
+    ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &boxed_builder));
+    auto& builder = checked_cast<DictionaryBuilder<StringType>&>(*boxed_builder);
 
-  ASSERT_OK(builder.Append("a"));
-  ASSERT_OK(builder.Append("b"));
-  ASSERT_OK(builder.Append("a"));
+    ASSERT_OK(builder.Append("a"));
+    ASSERT_OK(builder.Append("b"));
+    ASSERT_OK(builder.Append("a"));
 
-  std::shared_ptr<Array> result;
-  ASSERT_OK(builder.Finish(&result));
+    std::shared_ptr<Array> result;
+    ASSERT_OK(builder.Finish(&result));
 
-  const auto& result_type = checked_cast<const DictionaryType&>(*result->type());
-  ASSERT_TRUE(result_type.ordered());
+    const auto& result_type = checked_cast<const DictionaryType&>(*result->type());
+    ASSERT_EQ(result_type.ordered(), ordered);
 
-  auto ex_dict = ArrayFromJSON(utf8(), R"(["a", "b"])");
-  auto ex_indices = ArrayFromJSON(int8(), "[0, 1, 0]");
-  DictionaryArray expected(ordered_type, ex_indices, ex_dict);
-  AssertArraysEqual(expected, *result);
+    auto ex_dict = ArrayFromJSON(utf8(), R"(["a", "b"])");
+    auto ex_indices = ArrayFromJSON(int8(), "[0, 1, 0]");
+    DictionaryArray expected(dict_type, ex_indices, ex_dict);
+    AssertArraysEqual(expected, *result);
+  }
 }
 
 TEST(TestDictionaryBuilderOrdered, ListOfOrderedDictionary) {
-  auto ordered_dict_type = dictionary(int8(), utf8(), /*ordered=*/true);
-  auto list_type = list(field("item", ordered_dict_type));
+  for (bool ordered : {true, false}) {
+    ARROW_SCOPED_TRACE("ordered = ", ordered);
+    auto dict_type = dictionary(int8(), utf8(), ordered);
+    auto list_type = list(field("item", dict_type));
 
-  std::unique_ptr<ArrayBuilder> boxed_builder;
-  ASSERT_OK(MakeBuilder(default_memory_pool(), list_type, &boxed_builder));
-  auto& list_builder = checked_cast<ListBuilder&>(*boxed_builder);
-  auto& dict_builder =
-      checked_cast<DictionaryBuilder<StringType>&>(*list_builder.value_builder());
+    std::unique_ptr<ArrayBuilder> boxed_builder;
+    ASSERT_OK(MakeBuilder(default_memory_pool(), list_type, &boxed_builder));
+    auto& list_builder = checked_cast<ListBuilder&>(*boxed_builder);
+    auto& dict_builder =
+        checked_cast<DictionaryBuilder<StringType>&>(*list_builder.value_builder());
 
-  ASSERT_OK(list_builder.Append());
-  ASSERT_OK(dict_builder.Append("a"));
-  ASSERT_OK(dict_builder.Append("b"));
-  ASSERT_OK(list_builder.Append());
-  ASSERT_OK(dict_builder.Append("a"));
+    ASSERT_OK(list_builder.Append());
+    ASSERT_OK(dict_builder.Append("a"));
+    ASSERT_OK(dict_builder.Append("b"));
+    ASSERT_OK(list_builder.Append());
+    ASSERT_OK(dict_builder.Append("a"));
 
-  std::shared_ptr<Array> result;
-  ASSERT_OK(list_builder.Finish(&result));
+    std::shared_ptr<Array> result;
+    ASSERT_OK(list_builder.Finish(&result));
 
-  const auto& result_list_type = checked_cast<const ListType&>(*result->type());
-  const auto& result_dict_type =
-      checked_cast<const DictionaryType&>(*result_list_type.value_type());
-  ASSERT_TRUE(result_dict_type.ordered());
+    const auto& result_list_type = checked_cast<const ListType&>(*result->type());
+    const auto& result_dict_type =
+        checked_cast<const DictionaryType&>(*result_list_type.value_type());
+    ASSERT_EQ(result_dict_type.ordered(), ordered);
+  }
 }
 
 TEST(TestDictionaryBuilderOrdered, MakeDictionaryBuilderPreservesOrdered) {
-  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
-  std::unique_ptr<ArrayBuilder> builder;
-  ASSERT_OK(MakeDictionaryBuilder(default_memory_pool(), ordered_type,
-                                  /*dictionary=*/nullptr, &builder));
+  for (bool ordered : {true, false}) {
+    ARROW_SCOPED_TRACE("ordered = ", ordered);
+    auto dict_type = dictionary(int8(), utf8(), ordered);
+    std::unique_ptr<ArrayBuilder> builder;
+    ASSERT_OK(MakeDictionaryBuilder(default_memory_pool(), dict_type,
+                                    /*dictionary=*/nullptr, &builder));
 
-  auto builder_type = builder->type();
-  ASSERT_TRUE(checked_cast<const DictionaryType&>(*builder_type).ordered());
+    auto builder_type = builder->type();
+    ASSERT_EQ(checked_cast<const DictionaryType&>(*builder_type).ordered(), ordered);
+  }
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1767,8 +1767,7 @@ TEST(TestDictionaryBuilderOrdered, TypePreservesOrderedFlag) {
   for (bool ordered : {true, false}) {
     ARROW_SCOPED_TRACE("ordered = ", ordered);
     auto dict_type = dictionary(int8(), utf8(), ordered);
-    std::unique_ptr<ArrayBuilder> boxed_builder;
-    ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &boxed_builder));
+    ASSERT_OK_AND_ASSIGN(auto boxed_buider, MakeBuilder(dict_type));
 
     auto builder_type = boxed_builder->type();
     ASSERT_EQ(checked_cast<const DictionaryType&>(*builder_type).ordered(), ordered);

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1767,7 +1767,7 @@ TEST(TestDictionaryBuilderOrdered, TypePreservesOrderedFlag) {
   for (bool ordered : {true, false}) {
     ARROW_SCOPED_TRACE("ordered = ", ordered);
     auto dict_type = dictionary(int8(), utf8(), ordered);
-    ASSERT_OK_AND_ASSIGN(auto boxed_buider, MakeBuilder(dict_type));
+    ASSERT_OK_AND_ASSIGN(auto boxed_builder, MakeBuilder(dict_type));
 
     auto builder_type = boxed_builder->type();
     ASSERT_EQ(checked_cast<const DictionaryType&>(*builder_type).ordered(), ordered);
@@ -1778,8 +1778,7 @@ TEST(TestDictionaryBuilderOrdered, FinishPreservesOrderedFlag) {
   for (bool ordered : {true, false}) {
     ARROW_SCOPED_TRACE("ordered = ", ordered);
     auto dict_type = dictionary(int8(), utf8(), ordered);
-    std::unique_ptr<ArrayBuilder> boxed_builder;
-    ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &boxed_builder));
+    ASSERT_OK_AND_ASSIGN(auto boxed_builder, MakeBuilder(dict_type));
     auto& builder = checked_cast<DictionaryBuilder<StringType>&>(*boxed_builder);
 
     ASSERT_OK(builder.Append("a"));
@@ -1805,8 +1804,7 @@ TEST(TestDictionaryBuilderOrdered, ListOfOrderedDictionary) {
     auto dict_type = dictionary(int8(), utf8(), ordered);
     auto list_type = list(field("item", dict_type));
 
-    std::unique_ptr<ArrayBuilder> boxed_builder;
-    ASSERT_OK(MakeBuilder(default_memory_pool(), list_type, &boxed_builder));
+    ASSERT_OK_AND_ASSIGN(auto boxed_builder, MakeBuilder(list_type));
     auto& list_builder = checked_cast<ListBuilder&>(*boxed_builder);
     auto& dict_builder =
         checked_cast<DictionaryBuilder<StringType>&>(*list_builder.value_builder());
@@ -1831,9 +1829,7 @@ TEST(TestDictionaryBuilderOrdered, MakeDictionaryBuilderPreservesOrdered) {
   for (bool ordered : {true, false}) {
     ARROW_SCOPED_TRACE("ordered = ", ordered);
     auto dict_type = dictionary(int8(), utf8(), ordered);
-    std::unique_ptr<ArrayBuilder> builder;
-    ASSERT_OK(MakeDictionaryBuilder(default_memory_pool(), dict_type,
-                                    /*dictionary=*/nullptr, &builder));
+    ASSERT_OK_AND_ASSIGN(auto builder, MakeDictionaryBuilder(dict_type));
 
     auto builder_type = builder->type();
     ASSERT_EQ(checked_cast<const DictionaryType&>(*builder_type).ordered(), ordered);

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -160,7 +160,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(start_int_size, pool, alignment),
-        value_type_(value_type) {}
+        value_type_(value_type),
+        ordered_(false) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -173,7 +174,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(pool, alignment),
-        value_type_(value_type) {}
+        value_type_(value_type),
+        ordered_(false) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -187,7 +189,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(index_type, pool, alignment),
-        value_type_(value_type) {}
+        value_type_(value_type),
+        ordered_(false) {}
 
   template <typename B = BuilderType, typename T1 = T>
   DictionaryBuilderBase(uint8_t start_int_size,
@@ -202,7 +205,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         delta_offset_(0),
         byte_width_(static_cast<const T1&>(*value_type).byte_width()),
         indices_builder_(start_int_size, pool, alignment),
-        value_type_(value_type) {}
+        value_type_(value_type),
+        ordered_(false) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -214,7 +218,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         delta_offset_(0),
         byte_width_(static_cast<const T1&>(*value_type).byte_width()),
         indices_builder_(pool, alignment),
-        value_type_(value_type) {}
+        value_type_(value_type),
+        ordered_(false) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -227,7 +232,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         delta_offset_(0),
         byte_width_(static_cast<const T1&>(*value_type).byte_width()),
         indices_builder_(index_type, pool, alignment),
-        value_type_(value_type) {}
+        value_type_(value_type),
+        ordered_(false) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -243,7 +249,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(pool, alignment),
-        value_type_(dictionary->type()) {}
+        value_type_(dictionary->type()),
+        ordered_(false) {}
 
   ~DictionaryBuilderBase() override = default;
 
@@ -490,8 +497,10 @@ class DictionaryBuilderBase : public ArrayBuilder {
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
   std::shared_ptr<DataType> type() const override {
-    return ::arrow::dictionary(indices_builder_.type(), value_type_);
+    return ::arrow::dictionary(indices_builder_.type(), value_type_, ordered_);
   }
+
+  void set_ordered(bool ordered) { ordered_ = ordered; }
 
  protected:
   template <typename c_type>
@@ -561,6 +570,7 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   BuilderType indices_builder_;
   std::shared_ptr<DataType> value_type_;
+  bool ordered_;
 };
 
 template <typename BuilderType>
@@ -647,7 +657,7 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override {
     ARROW_RETURN_NOT_OK(indices_builder_.FinishInternal(out));
-    (*out)->type = dictionary((*out)->type, null());
+    (*out)->type = dictionary((*out)->type, null(), ordered_);
     (*out)->dictionary = NullArray(0).data();
     return Status::OK();
   }
@@ -659,11 +669,14 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
   std::shared_ptr<DataType> type() const override {
-    return ::arrow::dictionary(indices_builder_.type(), null());
+    return ::arrow::dictionary(indices_builder_.type(), null(), ordered_);
   }
+
+  void set_ordered(bool ordered) { ordered_ = ordered; }
 
  protected:
   BuilderType indices_builder_;
+  bool ordered_ = false;
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -154,28 +154,28 @@ class DictionaryBuilderBase : public ArrayBuilder {
                                     const std::shared_ptr<DataType>&>
                             value_type,
                         MemoryPool* pool = default_memory_pool(),
-                        int64_t alignment = kDefaultBufferAlignment)
+                        int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(start_int_size, pool, alignment),
         value_type_(value_type),
-        ordered_(false) {}
+        ordered_(ordered) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
       enable_if_t<!is_fixed_size_binary_type<T1>::value, const std::shared_ptr<DataType>&>
           value_type,
       MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+      int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(pool, alignment),
         value_type_(value_type),
-        ordered_(false) {}
+        ordered_(ordered) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -183,14 +183,14 @@ class DictionaryBuilderBase : public ArrayBuilder {
       enable_if_t<!is_fixed_size_binary_type<T1>::value, const std::shared_ptr<DataType>&>
           value_type,
       MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+      int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(index_type, pool, alignment),
         value_type_(value_type),
-        ordered_(false) {}
+        ordered_(ordered) {}
 
   template <typename B = BuilderType, typename T1 = T>
   DictionaryBuilderBase(uint8_t start_int_size,
@@ -199,41 +199,41 @@ class DictionaryBuilderBase : public ArrayBuilder {
                                     const std::shared_ptr<DataType>&>
                             value_type,
                         MemoryPool* pool = default_memory_pool(),
-                        int64_t alignment = kDefaultBufferAlignment)
+                        int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
         byte_width_(static_cast<const T1&>(*value_type).byte_width()),
         indices_builder_(start_int_size, pool, alignment),
         value_type_(value_type),
-        ordered_(false) {}
+        ordered_(ordered) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
       enable_if_fixed_size_binary<T1, const std::shared_ptr<DataType>&> value_type,
       MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+      int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
         byte_width_(static_cast<const T1&>(*value_type).byte_width()),
         indices_builder_(pool, alignment),
         value_type_(value_type),
-        ordered_(false) {}
+        ordered_(ordered) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
       const std::shared_ptr<DataType>& index_type,
       enable_if_fixed_size_binary<T1, const std::shared_ptr<DataType>&> value_type,
       MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+      int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
         byte_width_(static_cast<const T1&>(*value_type).byte_width()),
         indices_builder_(index_type, pool, alignment),
         value_type_(value_type),
-        ordered_(false) {}
+        ordered_(ordered) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -243,14 +243,15 @@ class DictionaryBuilderBase : public ArrayBuilder {
   // This constructor doesn't check for errors. Use InsertMemoValues instead.
   explicit DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
                                  MemoryPool* pool = default_memory_pool(),
-                                 int64_t alignment = kDefaultBufferAlignment)
+                                 int64_t alignment = kDefaultBufferAlignment,
+                                 bool ordered = false)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, dictionary)),
         delta_offset_(0),
         byte_width_(-1),
         indices_builder_(pool, alignment),
         value_type_(dictionary->type()),
-        ordered_(false) {}
+        ordered_(ordered) {}
 
   ~DictionaryBuilderBase() override = default;
 
@@ -500,8 +501,6 @@ class DictionaryBuilderBase : public ArrayBuilder {
     return ::arrow::dictionary(indices_builder_.type(), value_type_, ordered_);
   }
 
-  void set_ordered(bool ordered) { ordered_ = ordered; }
-
  protected:
   template <typename c_type>
   Status AppendArraySliceImpl(const typename TypeTraits<T>::ArrayType& dict,
@@ -570,7 +569,7 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   BuilderType indices_builder_;
   std::shared_ptr<DataType> value_type_;
-  bool ordered_;
+  bool ordered_ = false;
 };
 
 template <typename BuilderType>
@@ -581,31 +580,53 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
       enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value, uint8_t>
           start_int_size,
       const std::shared_ptr<DataType>& value_type,
-      MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(pool), indices_builder_(start_int_size, pool) {}
+      MemoryPool* pool = default_memory_pool(),
+      int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
+      : ArrayBuilder(pool, alignment),
+        indices_builder_(start_int_size, pool, alignment),
+        ordered_(ordered) {}
 
   explicit DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
-                                 MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(pool), indices_builder_(pool) {}
+                                 MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment,
+                                 bool ordered = false)
+      : ArrayBuilder(pool, alignment),
+        indices_builder_(pool, alignment),
+        ordered_(ordered) {}
 
   explicit DictionaryBuilderBase(const std::shared_ptr<DataType>& index_type,
                                  const std::shared_ptr<DataType>& value_type,
-                                 MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(pool), indices_builder_(index_type, pool) {}
+                                 MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment,
+                                 bool ordered = false)
+      : ArrayBuilder(pool, alignment),
+        indices_builder_(index_type, pool, alignment),
+        ordered_(ordered) {}
 
   template <typename B = BuilderType>
   explicit DictionaryBuilderBase(
       enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value, uint8_t>
           start_int_size,
-      MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(pool), indices_builder_(start_int_size, pool) {}
+      MemoryPool* pool = default_memory_pool(),
+      int64_t alignment = kDefaultBufferAlignment, bool ordered = false)
+      : ArrayBuilder(pool, alignment),
+        indices_builder_(start_int_size, pool, alignment),
+        ordered_(ordered) {}
 
-  explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(pool), indices_builder_(pool) {}
+  explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment,
+                                 bool ordered = false)
+      : ArrayBuilder(pool, alignment),
+        indices_builder_(pool, alignment),
+        ordered_(ordered) {}
 
   explicit DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
-                                 MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(pool), indices_builder_(pool) {}
+                                 MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment,
+                                 bool ordered = false)
+      : ArrayBuilder(pool, alignment),
+        indices_builder_(pool, alignment),
+        ordered_(ordered) {}
 
   /// \brief Append a scalar null value
   Status AppendNull() final {
@@ -671,8 +692,6 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
   std::shared_ptr<DataType> type() const override {
     return ::arrow::dictionary(indices_builder_.type(), null(), ordered_);
   }
-
-  void set_ordered(bool ordered) { ordered_ = ordered; }
 
  protected:
   BuilderType indices_builder_;

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -195,7 +195,7 @@ struct DictionaryBuilderCase {
   MemoryPool* pool;
   const std::shared_ptr<DataType>& index_type;
   const std::shared_ptr<DataType>& value_type;
-  const std::shared_ptr<Array>& dictionary;
+  std::shared_ptr<Array> dictionary;
   bool exact_index_type;
   bool ordered;
   std::unique_ptr<ArrayBuilder>* out;

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -168,17 +168,24 @@ struct DictionaryBuilderCase {
   template <typename ValueType>
   Status CreateFor() {
     using AdaptiveBuilderType = DictionaryBuilder<ValueType>;
+    using ExactBuilderType =
+        internal::DictionaryBuilderBase<TypeErasedIntBuilder, ValueType>;
     if (dictionary != nullptr) {
-      out->reset(new AdaptiveBuilderType(dictionary, pool));
+      auto builder = new AdaptiveBuilderType(dictionary, pool);
+      builder->set_ordered(ordered);
+      out->reset(builder);
     } else if (exact_index_type) {
       if (!is_integer(index_type->id())) {
         return Status::TypeError("MakeBuilder: invalid index type ", *index_type);
       }
-      out->reset(new internal::DictionaryBuilderBase<TypeErasedIntBuilder, ValueType>(
-          index_type, value_type, pool));
+      auto builder = new ExactBuilderType(index_type, value_type, pool);
+      builder->set_ordered(ordered);
+      out->reset(builder);
     } else {
       auto start_int_size = index_type->byte_width();
-      out->reset(new AdaptiveBuilderType(start_int_size, value_type, pool));
+      auto builder = new AdaptiveBuilderType(start_int_size, value_type, pool);
+      builder->set_ordered(ordered);
+      out->reset(builder);
     }
     return Status::OK();
   }
@@ -190,6 +197,7 @@ struct DictionaryBuilderCase {
   const std::shared_ptr<DataType>& value_type;
   const std::shared_ptr<Array>& dictionary;
   bool exact_index_type;
+  bool ordered;
   std::unique_ptr<ArrayBuilder>* out;
 };
 
@@ -206,6 +214,7 @@ struct MakeBuilderImpl {
                                      dict_type.value_type(),
                                      /*dictionary=*/nullptr,
                                      exact_index_type,
+                                     dict_type.ordered(),
                                      &out};
     return visitor.Make();
   }
@@ -332,9 +341,13 @@ Status MakeDictionaryBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& 
                              const std::shared_ptr<Array>& dictionary,
                              std::unique_ptr<ArrayBuilder>* out) {
   const auto& dict_type = static_cast<const DictionaryType&>(*type);
-  DictionaryBuilderCase visitor = {
-      pool,       dict_type.index_type(),     dict_type.value_type(),
-      dictionary, /*exact_index_type=*/false, out};
+  DictionaryBuilderCase visitor = {pool,
+                                   dict_type.index_type(),
+                                   dict_type.value_type(),
+                                   dictionary,
+                                   /*exact_index_type=*/false,
+                                   dict_type.ordered(),
+                                   out};
   return visitor.Make();
 }
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -171,21 +171,18 @@ struct DictionaryBuilderCase {
     using ExactBuilderType =
         internal::DictionaryBuilderBase<TypeErasedIntBuilder, ValueType>;
     if (dictionary != nullptr) {
-      auto builder = new AdaptiveBuilderType(dictionary, pool);
-      builder->set_ordered(ordered);
-      out->reset(builder);
+      out->reset(
+          new AdaptiveBuilderType(dictionary, pool, kDefaultBufferAlignment, ordered));
     } else if (exact_index_type) {
       if (!is_integer(index_type->id())) {
         return Status::TypeError("MakeBuilder: invalid index type ", *index_type);
       }
-      auto builder = new ExactBuilderType(index_type, value_type, pool);
-      builder->set_ordered(ordered);
-      out->reset(builder);
+      out->reset(new ExactBuilderType(index_type, value_type, pool,
+                                      kDefaultBufferAlignment, ordered));
     } else {
       auto start_int_size = index_type->byte_width();
-      auto builder = new AdaptiveBuilderType(start_int_size, value_type, pool);
-      builder->set_ordered(ordered);
-      out->reset(builder);
+      out->reset(new AdaptiveBuilderType(start_int_size, value_type, pool,
+                                         kDefaultBufferAlignment, ordered));
     }
     return Status::OK();
   }

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -996,14 +996,6 @@ class RDictionaryConverter<ValueType, enable_if_has_string_view<ValueType>>
   Result<std::shared_ptr<ChunkedArray>> ToChunkedArray() override {
     ARROW_ASSIGN_OR_RAISE(auto result, this->builder_->Finish());
 
-    auto result_type = checked_cast<DictionaryType*>(result->type().get());
-    if (this->dict_type_->ordered() && !result_type->ordered()) {
-      // TODO: we should not have to do that, there is probably something wrong
-      //       in the DictionaryBuilder code
-      result->data()->type =
-          arrow::dictionary(result_type->index_type(), result_type->value_type(), true);
-    }
-
     return std::make_shared<ChunkedArray>(
         std::make_shared<DictionaryArray>(result->data()));
   }

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -643,6 +643,13 @@ test_that("arrow_array() handles vector -> list arrays (ARROW-7662)", {
   expect_array_roundtrip(list(factor(c("b", "a"), levels = c("a", "b"))), list_of(dictionary(int8(), utf8())))
   expect_array_roundtrip(list(factor(NA, levels = c("a", "b"))), list_of(dictionary(int8(), utf8())))
 
+  # ordered factor (GH-49689)
+  expect_array_roundtrip(
+    list(ordered(c("b", "a"), levels = c("a", "b"))),
+    list_of(dictionary(int8(), utf8(), ordered = TRUE))
+  )
+  expect_array_roundtrip(list(ordered(NA, levels = c("a", "b"))), list_of(dictionary(int8(), utf8(), ordered = TRUE)))
+
   # struct
   expect_array_roundtrip(
     list(tibble::tibble(a = integer(0), b = integer(0), c = character(0), d = logical(0))),
@@ -742,6 +749,13 @@ test_that("arrow_array() handles vector -> large list arrays", {
     as = large_list_of(dictionary(int8(), utf8()))
   )
 
+  # ordered factor (GH-49689)
+  expect_array_roundtrip(
+    list(ordered(c("b", "a"), levels = c("a", "b"))),
+    large_list_of(dictionary(int8(), utf8(), ordered = TRUE)),
+    as = large_list_of(dictionary(int8(), utf8(), ordered = TRUE))
+  )
+
   # struct
   expect_array_roundtrip(
     list(tibble::tibble(a = integer(0), b = integer(0), c = character(0), d = logical(0))),
@@ -807,6 +821,13 @@ test_that("arrow_array() handles vector -> fixed size list arrays", {
     list(factor(c("b", "a"), levels = c("a", "b"))),
     fixed_size_list_of(dictionary(int8(), utf8()), 2L),
     as = fixed_size_list_of(dictionary(int8(), utf8()), 2L)
+  )
+
+  # ordered factor (GH-49689)
+  expect_array_roundtrip(
+    list(ordered(c("b", "a"), levels = c("a", "b"))),
+    fixed_size_list_of(dictionary(int8(), utf8(), ordered = TRUE), 2L),
+    as = fixed_size_list_of(dictionary(int8(), utf8(), ordered = TRUE), 2L)
   )
 
   # struct


### PR DESCRIPTION
### Rationale for this change

Ordered dictionaries inside nested types lose their `ordered` flag during construction, because `DictionaryBuilder` doesn't track it.

### What changes are included in this PR?

Store the `ordered` flag in `DictionaryBuilderBase` and pass it through when reconstructing the `DictionaryType` in `type()` and `FinishInternal()`. 

Remove the R-side workaround that was patching this for top-level columns only.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

### AI usage 

Written by Claude, reviewed by me and Codex (via [roborev](https://github.com/roborev-dev/roborev)).  I had Claude create the tests first, to make sure they failed as expected, then had Claude make the fixes and checked the tests passed.  I questioned the approach as I went.

* GitHub Issue: #49689