### PR TITLE
GH-49942: [Python] Protect PyBuffer and NumPyBuffer destructors against interpreter finalization

### DIFF
--- a/python/pyarrow/src/arrow/python/common.cc
+++ b/python/pyarrow/src/arrow/python/common.cc
@@ -236,7 +236,8 @@ Result<std::shared_ptr<Buffer>> PyBuffer::FromPyObject(PyObject* obj) {
 }
 
 PyBuffer::~PyBuffer() {
-  if (data_ != nullptr) {
+  // GH-38626: destructor may be called after the Python interpreter is finalized.
+  if (Py_IsInitialized() && data_ != nullptr) {
     PyAcquireGIL lock;
     PyBuffer_Release(&py_buf_);
   }

--- a/python/pyarrow/src/arrow/python/numpy_convert.cc
+++ b/python/pyarrow/src/arrow/python/numpy_convert.cc
@@ -53,8 +53,11 @@ NumPyBuffer::NumPyBuffer(PyObject* ao) : Buffer(nullptr, 0) {
 }
 
 NumPyBuffer::~NumPyBuffer() {
-  PyAcquireGIL lock;
-  Py_XDECREF(arr_);
+  // GH-38626: destructor may be called after the Python interpreter is finalized.
+  if (Py_IsInitialized()) {
+    PyAcquireGIL lock;
+    Py_XDECREF(arr_);
+  }
 }
 
 #define TO_ARROW_TYPE_CASE(NPY_NAME, FACTORY) \


### PR DESCRIPTION
### Rationale for this change

In https://github.com/apache/arrow/pull/38637 we protected the `OwnedRef` and `OwnedRefNoGIL` destructors against being called when the Python interpreter is being finalized, but we didn't address other classes with custom destructors, such as `PyBuffer` and `NumPyBuffer`.

### What changes are included in this PR?

Avoid executing Python C API code if the interpreter is finalized while a C++ destructor runs.

### Are these changes tested?

Only manually, using the initial reproducer in https://github.com/apache/arrow/issues/45214.

### Are there any user-facing changes?

No.

* GitHub Issue: #49942