### PR TITLE
GH-49933: [Python] Fix test_table_column_subset_metadata to set freq on correct object

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -638,8 +638,8 @@ class TestConvertMetadata:
             table_subset = table.remove_column(1)
             result = table_subset.to_pandas()
             expected = df[['a']]
-            if isinstance(df.index, pd.DatetimeIndex):
-                df.index.freq = None
+            if isinstance(expected.index, pd.DatetimeIndex):
+                expected.index.freq = None
             tm.assert_frame_equal(result, expected)
 
             table_subset2 = table_subset.remove_column(1)


### PR DESCRIPTION
### Fix:#49933
### Rationale for this change

The nightly CI jobs for pandas failing with AssertionError: (None, <Day>) in test_table_column_subset_metadata. 

The test was incorrectly setting `df.index.freq = None` instead of `expected.index.freq = None `since `expected = df[["a"]] `creates an independent Index object. 

### What changes are included in this PR?
In file `python/pyarrow/tests/test_pandas.py` we have modified the `test_table_column_subset_metadata` test case.

### Are these changes tested?
Yes, Verified locally with pandas nightly (3.1.0.dev0)
before the code changes 

```
pytest /arrow/python/pyarrow/tests/test_pandas.py::TestConvertMetadata::test_table_column_subset_metadata -v
================================================================================================ test session starts =================================================================================================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /opt/homebrew/Caskroom/miniforge/base/envs/arrow-dev/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'dev' -> max_examples=50
rootdir: /arrow/python
configfile: setup.cfg
plugins: xdist-3.8.0, hypothesis-6.152.4
collected 1 item

arrow/python/pyarrow/tests/test_pandas.py::TestConvertMetadata::test_table_column_subset_metadata FAILED                                                          [100%]

====================================================================================================== **FAILURES** ======================================================================================================
_______________________________________________________________________________ TestConvertMetadata.test_table_column_subset_metadata ________________________________________________________________________________

self = <pyarrow.tests.test_pandas.TestConvertMetadata object at 0x116ef5fd0>

    def test_table_column_subset_metadata(self):
        # ARROW-1883
        # non-default index
        for index in [
                pd.Index(['a', 'b', 'c'], name='index'),
                pd.date_range("2017-01-01", periods=3, tz='Europe/Brussels')]:
            df = pd.DataFrame({'a': [1, 2, 3],
                               'b': [.1, .2, .3]}, index=index)
            table = pa.Table.from_pandas(df)

            table_subset = table.remove_column(1)
            result = table_subset.to_pandas()
            expected = df[['a']]
            if isinstance(df.index, pd.DatetimeIndex):
                df.index.freq = None
>           tm.assert_frame_equal(result, expected)
E           AssertionError: (None, <Day>)

arrow/python/pyarrow/tests/test_pandas.py:643: AssertionError
============================================================================================== short test summary info ===============================================================================================
FAILED Desktop/AnkitAhlawat/opensource_contribution/arrow/python/pyarrow/tests/test_pandas.py::TestConvertMetadata::test_table_column_subset_metadata - AssertionError: (None, <Day>)
================================================================================================= **1 failed in 0.32s** ========================================================================

```
After the code changes 

```
pytest arrow/python/pyarrow/tests/test_pandas.py::TestConvertMetadata::test_table_column_subset_metadata -v
================================================================================================ test session starts =================================================================================================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /opt/homebrew/Caskroom/miniforge/base/envs/arrow-dev/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'dev' -> max_examples=50
rootdir: /arrow/python
configfile: setup.cfg
plugins: xdist-3.8.0, hypothesis-6.152.4
collected 1 item

arrow/python/pyarrow/tests/test_pandas.py::TestConvertMetadata::test_table_column_subset_metadata PASSED                                                          [100%]

================================================================================================= 1 passed in 0.23s ==================================================================================================
```
### Are there any user-facing changes?

No — this is a test-only fix with no impact on public APIs or user-facing behavior.
* GitHub Issue: #49933