### PR TITLE
GH-49948: [CI][C++] Revert PR 49931 (Pin MinGW MSYS2 packages) but keep bumped minIO version

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -366,40 +366,6 @@ jobs:
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
-      - name: Pin MSYS2 packages
-        # Temporary workaround for #49930: gcc 16 surfaces a cluster of 5
-        # MINGW64 test failures. Pinning gcc-libs to 15.2 (and C++ packages
-        # rebuilt against gcc-libs 16.1, for ABI compatibility) avoids all
-        # of them. #49272/#49462 cover one (arrow-json-test); the other 4
-        # (async-utility-test, threading-utility-test, dataset-writer-test
-        # `bad_weak_ptr`, dataset-file-test) need separate fixes — see #49930.
-        # Remove once all 5 pass on current upstream MSYS2 without these pins
-        if: matrix.msystem_upper == 'MINGW64'
-        shell: msys2 {0}
-        run: |
-          set -ex
-          base="https://repo.msys2.org/mingw/mingw64"
-          urls=(
-            "$base/mingw-w64-x86_64-gcc-libs-15.2.0-14-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-gcc-15.2.0-14-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-aws-crt-cpp-0.38.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-boost-libs-1.91.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-boost-1.91.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-ccache-4.13.2-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-clang-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-cmake-4.3.2-2-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-icu-78.3-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-llvm-tools-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-llvm-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-tbb-2022.3.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-thrift-0.22.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-zstd-1.5.7-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-gflags-2.2.2-7-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
-          )
-          pacman -U --noconfirm "${urls[@]}"
       - name: Cache ccache
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
### Rationale for this change

Ready to revert pinned packages on MINGW64 with tests all passing now - see updated umbrella issue #49948 and #49958.
Past origin PR discussion https://github.com/apache/arrow/pull/49931#pullrequestreview-4242036956

### What changes are included in this PR?
Reverting PR #49931's temporary pins workaround - so completely removing step `- name: Pin MSYS2 packages`.

### Are these changes tested?
Yes, tests now pass on current upstream MSYS2

### Are there any user-facing changes?
No.
* GitHub Issue: #49948