### PR TITLE
GH-47447: [C++] Fix replace_with_mask for null type arrays

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -217,15 +217,15 @@ struct ReplaceMaskImpl<Type, enable_if_null<Type>> {
   static Result<int64_t> ExecScalarMask(KernelContext* ctx, const ArraySpan& array,
                                         const BooleanScalar& mask, ExecValue replacements,
                                         int64_t replacements_offset, ExecResult* out) {
-    out->value = array;
-    return Status::OK();
+    out->value = array.ToArrayData();
+    return replacements_offset;
   }
   static Result<int64_t> ExecArrayMask(KernelContext* ctx, const ArraySpan& array,
                                        const ArraySpan& mask, int64_t mask_offset,
                                        ExecValue replacements,
                                        int64_t replacements_offset, ExecResult* out) {
-    out->value = array;
-    return Status::OK();
+    out->value = array.ToArrayData();
+    return replacements_offset;
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -562,8 +562,8 @@ TEST_F(TestReplaceNull, ReplaceWithMask) {
 
       {this->array("[null, null]"), this->mask("[false, false]"), this->array("[]"),
        this->array("[null, null]")},
-      {this->array("[null, null]"), this->mask("[true, true]"), this->array("[null, null]"),
-       this->array("[null, null]")},
+      {this->array("[null, null]"), this->mask("[true, true]"),
+       this->array("[null, null]"), this->array("[null, null]")},
       {this->array("[null, null]"), this->mask("[null, null]"), this->array("[]"),
        this->array("[null, null]")},
   };

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -199,6 +199,13 @@ class TestReplaceBoolean : public TestReplaceKernel<BooleanType> {
   }
 };
 
+class TestReplaceNull : public TestReplaceKernel<NullType> {
+ protected:
+  std::shared_ptr<DataType> type() override {
+    return TypeTraits<NullType>::type_singleton();
+  }
+};
+
 class TestReplaceFixedSizeBinary : public TestReplaceKernel<FixedSizeBinaryType> {
  protected:
   std::shared_ptr<DataType> type() override { return fixed_size_binary(3); }
@@ -530,6 +537,35 @@ TEST_F(TestReplaceBoolean, ReplaceWithMask) {
        this->scalar("true"), this->array("[false, null, true]")},
       {this->array("[null, null]"), this->mask("[true, true]"),
        this->array("[true, true]"), this->array("[true, true]")},
+  };
+
+  for (auto test_case : cases) {
+    this->Assert(ReplaceWithMask, test_case.input, test_case.mask, test_case.replacements,
+                 test_case.expected);
+  }
+}
+
+TEST_F(TestReplaceNull, ReplaceWithMask) {
+  std::vector<ReplaceWithMaskCase> cases = {
+      {this->array("[]"), this->mask_scalar(false), this->array("[]"), this->array("[]")},
+      {this->array("[]"), this->mask_scalar(true), this->array("[]"), this->array("[]")},
+      {this->array("[]"), this->null_mask_scalar(), this->array("[]"), this->array("[]")},
+
+      {this->array("[null]"), this->mask_scalar(false), this->array("[]"),
+       this->array("[null]")},
+
+      {this->array("[null]"), this->mask_scalar(true), this->array("[null]"),
+       this->array("[null]")},
+
+      {this->array("[null]"), this->null_mask_scalar(), this->array("[]"),
+       this->array("[null]")},
+
+      {this->array("[null, null]"), this->mask("[false, false]"), this->array("[]"),
+       this->array("[null, null]")},
+      {this->array("[null, null]"), this->mask("[true, true]"), this->array("[null, null]"),
+       this->array("[null, null]")},
+      {this->array("[null, null]"), this->mask("[null, null]"), this->array("[]"),
+       this->array("[null, null]")},
   };
 
   for (auto test_case : cases) {

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1987,6 +1987,31 @@ def test_fill_null_array(arrow_type):
     assert result.equals(expected)
 
 
+def test_replace_with_mask_null_type():
+    # GH-47447: replace_with_mask crashed for null type arrays
+    a = pa.array([None], pa.null())
+    b = pa.array([None], pa.null())
+
+    result = pc.replace_with_mask(a, True, b)
+    assert result.type == pa.null()
+
+    result = pc.replace_with_mask(a, False, b)
+    assert result.type == pa.null()
+
+    mask = pa.array([True])
+    result = pc.replace_with_mask(a, mask, b)
+    assert result.type == pa.null()
+
+    mask = pa.array([False])
+    result = pc.replace_with_mask(a, mask, b)
+    assert result.type == pa.null()
+
+    import pandas as pd
+    s = pd.Series([None], dtype=pd.ArrowDtype(pa.null()))
+    result = s.combine_first(s)
+    assert result.dtype == pd.ArrowDtype(pa.null())
+
+
 @pytest.mark.parametrize('arrow_type', numerical_arrow_types)
 def test_fill_null_chunked_array(arrow_type):
     fill_value = pa.scalar(5, type=arrow_type)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1994,17 +1994,25 @@ def test_replace_with_mask_null_type():
 
     result = pc.replace_with_mask(a, True, b)
     assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
 
     result = pc.replace_with_mask(a, False, b)
     assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
 
     mask = pa.array([True])
     result = pc.replace_with_mask(a, mask, b)
     assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
 
     mask = pa.array([False])
     result = pc.replace_with_mask(a, mask, b)
     assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
 
 
 @pytest.mark.parametrize('arrow_type', numerical_arrow_types)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1997,19 +1997,19 @@ def test_replace_with_mask_null_type():
     result.validate(full=True)
     assert result.to_pylist() == [None]
 
-    result = pc.replace_with_mask(a, False, b)
+    result = pc.replace_with_mask(input, False, replacements)
     assert result.type == pa.null()
     result.validate(full=True)
     assert result.to_pylist() == [None]
 
     mask = pa.array([True])
-    result = pc.replace_with_mask(a, mask, b)
+    result = pc.replace_with_mask(input, mask, replacements)
     assert result.type == pa.null()
     result.validate(full=True)
     assert result.to_pylist() == [None]
 
     mask = pa.array([False])
-    result = pc.replace_with_mask(a, mask, b)
+    result = pc.replace_with_mask(input, mask, replacements)
     assert result.type == pa.null()
     result.validate(full=True)
     assert result.to_pylist() == [None]

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2006,11 +2006,6 @@ def test_replace_with_mask_null_type():
     result = pc.replace_with_mask(a, mask, b)
     assert result.type == pa.null()
 
-    import pandas as pd
-    s = pd.Series([None], dtype=pd.ArrowDtype(pa.null()))
-    result = s.combine_first(s)
-    assert result.dtype == pd.ArrowDtype(pa.null())
-
 
 @pytest.mark.parametrize('arrow_type', numerical_arrow_types)
 def test_fill_null_chunked_array(arrow_type):

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1269,6 +1269,34 @@ def test_extract_regex_span():
     assert struct.tolist() == expected
 
 
+def test_replace_with_mask_null_type():
+    # GH-47447: replace_with_mask crashed for null type arrays
+    input = pa.array([None], pa.null())
+    replacements = pa.array([None], pa.null())
+
+    result = pc.replace_with_mask(input, True, replacements)
+    assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
+
+    result = pc.replace_with_mask(input, False, replacements)
+    assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
+
+    mask = pa.array([True])
+    result = pc.replace_with_mask(input, mask, replacements)
+    assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
+
+    mask = pa.array([False])
+    result = pc.replace_with_mask(input, mask, replacements)
+    assert result.type == pa.null()
+    result.validate(full=True)
+    assert result.to_pylist() == [None]
+
+
 def test_binary_join():
     ar_list = pa.array([['foo', 'bar'], None, []])
     expected = pa.array(['foo-bar', None, ''])
@@ -1985,34 +2013,6 @@ def test_fill_null_array(arrow_type):
 
     result = arr.fill_null(pa.scalar(5, type='int8'))
     assert result.equals(expected)
-
-
-def test_replace_with_mask_null_type():
-    # GH-47447: replace_with_mask crashed for null type arrays
-    input = pa.array([None], pa.null())
-    replacements = pa.array([None], pa.null())
-
-    result = pc.replace_with_mask(input, True, replacements)
-    assert result.type == pa.null()
-    result.validate(full=True)
-    assert result.to_pylist() == [None]
-
-    result = pc.replace_with_mask(input, False, replacements)
-    assert result.type == pa.null()
-    result.validate(full=True)
-    assert result.to_pylist() == [None]
-
-    mask = pa.array([True])
-    result = pc.replace_with_mask(input, mask, replacements)
-    assert result.type == pa.null()
-    result.validate(full=True)
-    assert result.to_pylist() == [None]
-
-    mask = pa.array([False])
-    result = pc.replace_with_mask(input, mask, replacements)
-    assert result.type == pa.null()
-    result.validate(full=True)
-    assert result.to_pylist() == [None]
 
 
 @pytest.mark.parametrize('arrow_type', numerical_arrow_types)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1989,10 +1989,10 @@ def test_fill_null_array(arrow_type):
 
 def test_replace_with_mask_null_type():
     # GH-47447: replace_with_mask crashed for null type arrays
-    a = pa.array([None], pa.null())
-    b = pa.array([None], pa.null())
+    input = pa.array([None], pa.null())
+    replacements = pa.array([None], pa.null())
 
-    result = pc.replace_with_mask(a, True, b)
+    result = pc.replace_with_mask(input, True, replacements)
     assert result.type == pa.null()
     result.validate(full=True)
     assert result.to_pylist() == [None]


### PR DESCRIPTION
### Rationale for this change
replace_with_mask crashes when called with null type arrays because a code path incorrectly returns Status::OK() from a function with return type Result<int64_t>.
This PR fixes the issue by ensuring the function returns a valid int64_t value instead of Status::OK() for successful execution. 

### What changes are included in this PR?

1. Fixed the replace_with_mask kernel implementation for null type arrays.
2.  Replaced the invalid Status::OK() return path with a valid int64_t result.
3.  Prevented construction of Result<int64_t> with an OK Status.

### Are these changes tested?
Yes, manually run the test case  
### Are there any user-facing changes?
No 

**This PR contains a "Critical Fix".** 

This change fixes a crash in replace_with_mask when operating on null type arrays. The crash occurs due to an invalid successful return path internally constructing Result<T> with Status::OK().

* GitHub Issue: #47447