### PR TITLE
GH-49955: [C++] Fix OOM vulnerability in Parquet Delta decoders

### DIFF
--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -1559,6 +1559,9 @@ class DeltaBitPackDecoder : public TypedDecoderImpl<DType> {
           "the number of values in a miniblock must be multiple of 32, but it's " +
           std::to_string(values_per_mini_block_));
     }
+    if (ARROW_PREDICT_FALSE(mini_blocks_per_block_ > decoder_->bytes_left())) {
+      throw ParquetException("mini_blocks_per_block_ is larger than available buffer size");
+    }
 
     total_values_remaining_ = total_value_count_;
     if (delta_bit_widths_ == nullptr) {
@@ -1790,6 +1793,11 @@ class DeltaLengthByteArrayDecoder : public TypedDecoderImpl<ByteArrayType> {
 
     // get the number of encoded lengths
     int num_length = len_decoder_.ValidValuesCount();
+    int32_t bytes_left = decoder_->bytes_left();
+    if (ARROW_PREDICT_FALSE(num_length < 0 || bytes_left < 0 ||
+                            num_length > static_cast<int64_t>(bytes_left) * 10000)) {
+      throw ParquetException("Excessive num_length in DeltaLengthByteArrayDecoder");
+    }
     PARQUET_THROW_NOT_OK(buffered_length_->Resize(num_length * sizeof(int32_t)));
 
     // call len_decoder_.Decode to decode all the lengths.
@@ -1996,6 +2004,11 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
 
     // get the number of encoded prefix lengths
     int num_prefix = prefix_len_decoder_.ValidValuesCount();
+    int32_t bytes_left = decoder_->bytes_left();
+    if (ARROW_PREDICT_FALSE(num_prefix < 0 || bytes_left < 0 ||
+                            num_prefix > static_cast<int64_t>(bytes_left) * 10000)) {
+      throw ParquetException("Excessive num_prefix in DeltaByteArrayDecoder");
+    }
     // call prefix_len_decoder_.Decode to decode all the prefix lengths.
     // all the prefix lengths are buffered in buffered_prefix_length_.
     PARQUET_THROW_NOT_OK(buffered_prefix_length_->Resize(num_prefix * sizeof(int32_t)));


### PR DESCRIPTION
## Rationale for this change

This PR addresses an uncontrolled memory allocation vulnerability in the Parquet `DeltaByteArrayDecoder`, `DeltaLengthByteArrayDecoder`, and `DeltaBitPackDecoder`. 

Currently, these decoders trust the `num_values` (and implicitly the `total_value_count_`) provided by the Parquet data page header. The decoders eagerly allocate memory arrays sized proportionally to this unvalidated count (`e.g. buffered_prefix_length_->Resize(num_prefix * sizeof(int32_t))`). 

An attacker can exploit this by crafting a tiny Parquet file (e.g., ~300 bytes) with a maliciously forged `num_values` (e.g., `1,000,000,000`). When this file is opened (even just to read dictionary pages during `ParquetFileReader::Open`), Arrow attempts an immediate massive allocation (e.g., 4 GB), resulting in a `std::bad_alloc` and an immediate Denial of Service (OOM) crash.

## What changes are included in this PR?

This PR introduces conservative bounds checking in `cpp/src/parquet/decoder.cc` to ensure that the parsed value counts conceptually fit within the available byte array buffer size (`bytes_left()`) before attempting to eagerly allocate memory.

- **`DeltaBitPackDecoder::InitHeader`**: Validates that the requested `mini_blocks_per_block_` buffer allocation does not exceed the remaining bytes in the buffer.
- **`DeltaLengthByteArrayDecoder::DecodeLengths`**: Validates that `num_length` does not exceed a conservative multiplier of the remaining buffer size (`bytes_left() * 10000`) before calling `Resize()`.
- **`DeltaByteArrayDecoderImpl::SetData`**: Validates that `num_prefix` does not exceed a conservative multiplier of the remaining buffer size before calling `Resize()`.

These checks successfully catch maliciously forged massive values in tiny files while seamlessly permitting legitimate, highly-compressed Parquet files to be decoded.

## Are these changes tested?

Yes, the changes have been tested against a Proof of Concept (PoC) malicious file. Instead of triggering an OS OOM or `std::bad_alloc`, the parser now correctly throws a `ParquetException` ("Excessive num_prefix in DeltaByteArrayDecoder").

*(Optional: Note if you have included any new C++ unit tests in the PR that generate a bad header and assert the exception is thrown).*

## Are there any user-facing changes?

No, this strictly improves the security and stability of the Parquet C++ decoders.

---
*Note: This vulnerability was originally submitted to the Huntr bug bounty platform (Reference ID: `7814255d-e945-427f-ab84-6eddc3a35a37`), and is being filed here at the recommendation of the ASF Security Team.*

* GitHub Issue: #49955