### PR TITLE
GH-49958: Do not merge [C++][Dataset] DEBUG -> blocked on upstream gcc-16 fix

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -366,40 +366,6 @@ jobs:
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
-      - name: Pin MSYS2 packages
-        # Temporary workaround for #49930: gcc 16 surfaces a cluster of 5
-        # MINGW64 test failures. Pinning gcc-libs to 15.2 (and C++ packages
-        # rebuilt against gcc-libs 16.1, for ABI compatibility) avoids all
-        # of them. #49272/#49462 cover one (arrow-json-test); the other 4
-        # (async-utility-test, threading-utility-test, dataset-writer-test
-        # `bad_weak_ptr`, dataset-file-test) need separate fixes — see #49930.
-        # Remove once all 5 pass on current upstream MSYS2 without these pins
-        if: matrix.msystem_upper == 'MINGW64'
-        shell: msys2 {0}
-        run: |
-          set -ex
-          base="https://repo.msys2.org/mingw/mingw64"
-          urls=(
-            "$base/mingw-w64-x86_64-gcc-libs-15.2.0-14-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-gcc-15.2.0-14-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-aws-crt-cpp-0.38.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-boost-libs-1.91.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-boost-1.91.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-ccache-4.13.2-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-clang-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-cmake-4.3.2-2-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-icu-78.3-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-llvm-tools-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-llvm-22.1.4-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-tbb-2022.3.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-thrift-0.22.0-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-zstd-1.5.7-1-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-gflags-2.2.2-7-any.pkg.tar.zst"
-            "$base/mingw-w64-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
-          )
-          pacman -U --noconfirm "${urls[@]}"
       - name: Cache ccache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -208,14 +208,50 @@ jobs:
       - name: Build and run repro
         shell: bash
         run: |
+          ${{ matrix.cxx }} -v
           ${{ matrix.cxx }} \
             -std=gnu++20 \
             -O2 \
             -g \
+            -Wall \
+            -Wextra \
             -pthread \
             cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
             -o gh-49958-mingw-bad-weak-ptr-repro
           ./gh-49958-mingw-bad-weak-ptr-repro 10
+      - name: Build and run repro (_GLIBCXX_ASSERTIONS)
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          ${{ matrix.cxx }} \
+            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
+            -D_GLIBCXX_ASSERTIONS \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro-assert
+          ./gh-49958-mingw-bad-weak-ptr-repro-assert 10
+      - name: Build and run repro (_GLIBCXX_DEBUG)
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          ${{ matrix.cxx }} \
+            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
+            -D_GLIBCXX_DEBUG \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro-debug \
+            || echo "build with -D_GLIBCXX_DEBUG failed (this is data, not blocking)"
+          if [ -x ./gh-49958-mingw-bad-weak-ptr-repro-debug ]; then
+            ./gh-49958-mingw-bad-weak-ptr-repro-debug 10
+          fi
+      - name: Build and run repro (compiler disable optim. flags)
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          ${{ matrix.cxx }} \
+            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
+            -fno-strict-aliasing -fwrapv -fno-aggressive-loop-optimizations \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro-noub
+          ./gh-49958-mingw-bad-weak-ptr-repro-noub 10
 
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++
@@ -406,14 +442,60 @@ jobs:
       - name: Run bad_weak_ptr repro
         shell: msys2 {0}
         run: |
+          ${{ matrix.cxx }} -v
           ${{ matrix.cxx }} \
             -std=gnu++20 \
             -O2 \
             -g \
+            -Wall \
+            -Wextra \
             -pthread \
+            -save-temps=cwd \
             cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
             -o gh-49958-mingw-bad-weak-ptr-repro.exe
           ./gh-49958-mingw-bad-weak-ptr-repro.exe 30
+      - name: Run bad_weak_ptr repro (_GLIBCXX_ASSERTIONS)
+        if: ${{ !cancelled() }}
+        shell: msys2 {0}
+        run: |
+          ${{ matrix.cxx }} \
+            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
+            -D_GLIBCXX_ASSERTIONS \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro-assert.exe
+          ./gh-49958-mingw-bad-weak-ptr-repro-assert.exe 30
+      - name: Run bad_weak_ptr repro (_GLIBCXX_DEBUG)
+        if: ${{ !cancelled() }}
+        shell: msys2 {0}
+        run: |
+          ${{ matrix.cxx }} \
+            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
+            -D_GLIBCXX_DEBUG \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro-debug.exe \
+            || echo "build with -D_GLIBCXX_DEBUG failed (this is data, not blocking)"
+          if [ -x ./gh-49958-mingw-bad-weak-ptr-repro-debug.exe ]; then
+            ./gh-49958-mingw-bad-weak-ptr-repro-debug.exe 30
+          fi
+      - name: Run bad_weak_ptr repro (compiler disable optim. flags)
+        if: ${{ !cancelled() }}
+        shell: msys2 {0}
+        run: |
+          ${{ matrix.cxx }} \
+            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
+            -fno-strict-aliasing -fwrapv -fno-aggressive-loop-optimizations \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro-noub.exe
+          ./gh-49958-mingw-bad-weak-ptr-repro-noub.exe 30
+      - name: Upload preprocessed source for Bugzilla
+        if: ${{ !cancelled() && matrix.msystem_lower == 'mingw64' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gh-49958-mingw64-preprocessed
+          path: |
+            gh-49958-mingw-bad-weak-ptr-repro.ii
+            gh-49958-mingw-bad-weak-ptr-repro.s
+          if-no-files-found: warn
       - name: Cache ccache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -443,7 +443,10 @@ jobs:
             -save-temps=cwd \
             cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
             -o gh-49958-mingw-bad-weak-ptr-repro.exe
-          ./gh-49958-mingw-bad-weak-ptr-repro.exe 30
+          ls -la ./gh-49958-mingw-bad-weak-ptr-repro.exe || echo "BINARY NOT FOUND"
+          ./gh-49958-mingw-bad-weak-ptr-repro.exe 30 || rc=$?
+          echo "===== program exit: ${rc:-0} ====="
+          exit "${rc:-0}"
       - name: Run bad_weak_ptr repro (_GLIBCXX_ASSERTIONS)
         if: ${{ !cancelled() }}
         shell: msys2 {0}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -242,16 +242,6 @@ jobs:
           if [ -x ./gh-49958-mingw-bad-weak-ptr-repro-debug ]; then
             ./gh-49958-mingw-bad-weak-ptr-repro-debug 10
           fi
-      - name: Build and run repro (compiler disable optim. flags)
-        if: ${{ !cancelled() }}
-        shell: bash
-        run: |
-          ${{ matrix.cxx }} \
-            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
-            -fno-strict-aliasing -fwrapv -fno-aggressive-loop-optimizations \
-            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
-            -o gh-49958-mingw-bad-weak-ptr-repro-noub
-          ./gh-49958-mingw-bad-weak-ptr-repro-noub 10
 
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++
@@ -478,7 +468,7 @@ jobs:
             ./gh-49958-mingw-bad-weak-ptr-repro-debug.exe 30
           fi
       - name: Run bad_weak_ptr repro (compiler disable optim. flags)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.msystem_lower == 'mingw64' }}
         shell: msys2 {0}
         run: |
           ${{ matrix.cxx }} \

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -182,6 +182,41 @@ jobs:
           cd cpp/examples/minimal_build
           docker compose run --rm minimal
 
+  bad-weak-ptr-repro:
+    name: bad_weak_ptr repro ${{ matrix.title }}
+    runs-on: ${{ matrix.runs-on }}
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - title: Ubuntu GCC
+            runs-on: ubuntu-24.04
+            cxx: g++
+          - title: Ubuntu Clang
+            runs-on: ubuntu-24.04
+            cxx: clang++
+          - title: macOS Clang
+            runs-on: macos-14
+            cxx: clang++
+    steps:
+      - name: Checkout Arrow
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Build and run repro
+        shell: bash
+        run: |
+          ${{ matrix.cxx }} \
+            -std=gnu++20 \
+            -O2 \
+            -g \
+            -pthread \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro
+          ./gh-49958-mingw-bad-weak-ptr-repro 10
+
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++
     runs-on: macos-${{ matrix.macos-version }}
@@ -310,8 +345,10 @@ jobs:
         include:
           - msystem_lower: mingw64
             msystem_upper: MINGW64
+            cxx: g++
           - msystem_lower: clang64
             msystem_upper: CLANG64
+            cxx: clang++
     env:
       ARROW_BUILD_SHARED: ON
       ARROW_BUILD_STATIC: OFF
@@ -366,11 +403,10 @@ jobs:
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
-      - name: Run MinGW bad_weak_ptr repro
-        if: ${{ matrix.msystem_lower == 'mingw64' }}
+      - name: Run bad_weak_ptr repro
         shell: msys2 {0}
         run: |
-          g++ \
+          ${{ matrix.cxx }} \
             -std=gnu++20 \
             -O2 \
             -g \

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -366,6 +366,18 @@ jobs:
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
+      - name: Run MinGW bad_weak_ptr repro
+        if: ${{ matrix.msystem_lower == 'mingw64' }}
+        shell: msys2 {0}
+        run: |
+          g++ \
+            -std=gnu++20 \
+            -O2 \
+            -g \
+            -pthread \
+            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
+            -o gh-49958-mingw-bad-weak-ptr-repro.exe
+          ./gh-49958-mingw-bad-weak-ptr-repro.exe 30
       - name: Cache ccache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -182,67 +182,6 @@ jobs:
           cd cpp/examples/minimal_build
           docker compose run --rm minimal
 
-  bad-weak-ptr-repro:
-    name: bad_weak_ptr repro ${{ matrix.title }}
-    runs-on: ${{ matrix.runs-on }}
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - title: Ubuntu GCC
-            runs-on: ubuntu-24.04
-            cxx: g++
-          - title: Ubuntu Clang
-            runs-on: ubuntu-24.04
-            cxx: clang++
-          - title: macOS Clang
-            runs-on: macos-14
-            cxx: clang++
-    steps:
-      - name: Checkout Arrow
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-      - name: Build and run repro
-        shell: bash
-        run: |
-          ${{ matrix.cxx }} -v
-          ${{ matrix.cxx }} \
-            -std=gnu++20 \
-            -O2 \
-            -g \
-            -Wall \
-            -Wextra \
-            -pthread \
-            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
-            -o gh-49958-mingw-bad-weak-ptr-repro
-          ./gh-49958-mingw-bad-weak-ptr-repro 10
-      - name: Build and run repro (_GLIBCXX_ASSERTIONS)
-        if: ${{ !cancelled() }}
-        shell: bash
-        run: |
-          ${{ matrix.cxx }} \
-            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
-            -D_GLIBCXX_ASSERTIONS \
-            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
-            -o gh-49958-mingw-bad-weak-ptr-repro-assert
-          ./gh-49958-mingw-bad-weak-ptr-repro-assert 10
-      - name: Build and run repro (_GLIBCXX_DEBUG)
-        if: ${{ !cancelled() }}
-        shell: bash
-        run: |
-          ${{ matrix.cxx }} \
-            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
-            -D_GLIBCXX_DEBUG \
-            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
-            -o gh-49958-mingw-bad-weak-ptr-repro-debug \
-            || echo "build with -D_GLIBCXX_DEBUG failed (this is data, not blocking)"
-          if [ -x ./gh-49958-mingw-bad-weak-ptr-repro-debug ]; then
-            ./gh-49958-mingw-bad-weak-ptr-repro-debug 10
-          fi
-
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++
     runs-on: macos-${{ matrix.macos-version }}
@@ -371,10 +310,8 @@ jobs:
         include:
           - msystem_lower: mingw64
             msystem_upper: MINGW64
-            cxx: g++
           - msystem_lower: clang64
             msystem_upper: CLANG64
-            cxx: clang++
     env:
       ARROW_BUILD_SHARED: ON
       ARROW_BUILD_STATIC: OFF
@@ -429,66 +366,55 @@ jobs:
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
-      - name: Run bad_weak_ptr repro
+      - name: Patch MSYS2 GCC atomic word builtins
+        # Diagnostic workaround for GCC Bug #125312 / GH-49958:
+        # GCC r16-427's configure test for _GLIBCXX_ATOMIC_WORD_BUILTINS uses a POSIX-style
+        # absolute path the Windows GCC being built can't open. libstdc++ falls back
+        # to non-lock-free atomic refcount ops
+        if: matrix.msystem_upper == 'MINGW64'
         shell: msys2 {0}
         run: |
-          ${{ matrix.cxx }} -v
-          ${{ matrix.cxx }} \
+          set -ex
+          g++ -v
+          pacman -Q "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+
+          config_header="$(
+            find "${MINGW_PREFIX}/include/c++" \
+              -path "*/${MINGW_CHOST}/bits/c++config.h" \
+              -print \
+              -quit
+          )"
+          test -n "${config_header}"
+
+          grep -n "GLIBCXX_ATOMIC_WORD_BUILTINS" "${config_header}" || true
+          cp "${config_header}" "${config_header}.before-gh-49958"
+
+          if grep -q "^#define _GLIBCXX_ATOMIC_WORD_BUILTINS 1" "${config_header}"; then
+            echo "_GLIBCXX_ATOMIC_WORD_BUILTINS already defined"
+          elif grep -q "^/\* #undef _GLIBCXX_ATOMIC_WORD_BUILTINS \*/" "${config_header}"; then
+            sed -i \
+              's|^/\* #undef _GLIBCXX_ATOMIC_WORD_BUILTINS \*/|#define _GLIBCXX_ATOMIC_WORD_BUILTINS 1|' \
+              "${config_header}"
+          else
+            printf "\n#define _GLIBCXX_ATOMIC_WORD_BUILTINS 1\n" >> "${config_header}"
+          fi
+
+          grep -n "GLIBCXX_ATOMIC_WORD_BUILTINS" "${config_header}"
+      - name: Run bad_weak_ptr repro
+        if: matrix.msystem_upper == 'MINGW64'
+        shell: msys2 {0}
+        run: |
+          set -ex
+          g++ \
             -std=gnu++20 \
             -O2 \
             -g \
             -Wall \
             -Wextra \
             -pthread \
-            -save-temps=cwd \
             cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
             -o gh-49958-mingw-bad-weak-ptr-repro.exe
-          ls -la ./gh-49958-mingw-bad-weak-ptr-repro.exe || echo "BINARY NOT FOUND"
-          ./gh-49958-mingw-bad-weak-ptr-repro.exe 30 || rc=$?
-          echo "===== program exit: ${rc:-0} ====="
-          exit "${rc:-0}"
-      - name: Run bad_weak_ptr repro (_GLIBCXX_ASSERTIONS)
-        if: ${{ !cancelled() }}
-        shell: msys2 {0}
-        run: |
-          ${{ matrix.cxx }} \
-            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
-            -D_GLIBCXX_ASSERTIONS \
-            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
-            -o gh-49958-mingw-bad-weak-ptr-repro-assert.exe
-          ./gh-49958-mingw-bad-weak-ptr-repro-assert.exe 30
-      - name: Run bad_weak_ptr repro (_GLIBCXX_DEBUG)
-        if: ${{ !cancelled() }}
-        shell: msys2 {0}
-        run: |
-          ${{ matrix.cxx }} \
-            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
-            -D_GLIBCXX_DEBUG \
-            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
-            -o gh-49958-mingw-bad-weak-ptr-repro-debug.exe \
-            || echo "build with -D_GLIBCXX_DEBUG failed (this is data, not blocking)"
-          if [ -x ./gh-49958-mingw-bad-weak-ptr-repro-debug.exe ]; then
-            ./gh-49958-mingw-bad-weak-ptr-repro-debug.exe 30
-          fi
-      - name: Run bad_weak_ptr repro (compiler disable optim. flags)
-        if: ${{ !cancelled() && matrix.msystem_lower == 'mingw64' }}
-        shell: msys2 {0}
-        run: |
-          ${{ matrix.cxx }} \
-            -std=gnu++20 -O2 -g -Wall -Wextra -pthread \
-            -fno-strict-aliasing -fwrapv -fno-aggressive-loop-optimizations \
-            cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc \
-            -o gh-49958-mingw-bad-weak-ptr-repro-noub.exe
-          ./gh-49958-mingw-bad-weak-ptr-repro-noub.exe 30
-      - name: Upload preprocessed source for Bugzilla
-        if: ${{ !cancelled() && matrix.msystem_lower == 'mingw64' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: gh-49958-mingw64-preprocessed
-          path: |
-            gh-49958-mingw-bad-weak-ptr-repro.ii
-            gh-49958-mingw-bad-weak-ptr-repro.s
-          if-no-files-found: warn
+          ./gh-49958-mingw-bad-weak-ptr-repro.exe 30
       - name: Cache ccache
         uses: actions/cache@v5
         with:

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/dataset/dataset_writer.h"
 
+#include <cstdio>
 #include <deque>
 #include <memory>
 #include <mutex>
@@ -140,13 +141,26 @@ class DatasetWriterFileQueue
                                   std::shared_ptr<DatasetWriterState> writer_state)
       : options_(options), schema_(schema), writer_state_(std::move(writer_state)) {}
 
+  // TEMP DEBUG: log shared_from_this() callsite throwing bad_weak_ptr
+  std::shared_ptr<DatasetWriterFileQueue> SfwDbg(int line) {
+    try {
+      return shared_from_this();
+    } catch (const std::bad_weak_ptr&) {
+      std::fprintf(stderr,
+                   "GH-49958: bad_weak_ptr DatasetWriterFileQueue dataset_writer.cc:%d\n",
+                   line);
+      std::fflush(stderr);
+      throw;
+    }
+  }
+
   void Start(std::unique_ptr<util::ThrottledAsyncTaskScheduler> file_tasks,
              std::string filename) {
     file_tasks_ = std::move(file_tasks);
     // Because the scheduler runs one task at a time we know the writer will
     // be opened before any attempt to write
     file_tasks_->AddSimpleTask(
-        [self = shared_from_this(), filename = std::move(filename)] {
+        [self = SfwDbg(__LINE__), filename = std::move(filename)] {
           Executor* io_executor = self->options_.filesystem->io_context().executor();
           return DeferNotOk(io_executor->Submit([self, filename = std::move(filename)]() {
             ARROW_ASSIGN_OR_RAISE(self->writer_,
@@ -195,7 +209,7 @@ class DatasetWriterFileQueue
 
   void ScheduleBatch(std::shared_ptr<RecordBatch> batch) {
     file_tasks_->AddSimpleTask(
-        [self = shared_from_this(), batch = std::move(batch)]() {
+        [self = SfwDbg(__LINE__), batch = std::move(batch)]() {
           return self->WriteNext(std::move(batch));
         },
         "DatasetWriter::WriteBatch"sv);
@@ -234,7 +248,7 @@ class DatasetWriterFileQueue
     // At this point all write tasks have been added.  Because the scheduler
     // is a 1-task FIFO we know this task will run at the very end and can
     // add it now.
-    file_tasks_->AddSimpleTask([self = shared_from_this()] { return self->DoFinish(); },
+    file_tasks_->AddSimpleTask([self = SfwDbg(__LINE__)] { return self->DoFinish(); },
                                "DatasetWriter::FinishFile"sv);
     file_tasks_.reset();
     return Status::OK();
@@ -244,7 +258,7 @@ class DatasetWriterFileQueue
   Future<> WriteNext(std::shared_ptr<RecordBatch> next) {
     // May want to prototype / measure someday pushing the async write down further
     return DeferNotOk(options_.filesystem->io_context().executor()->Submit(
-        [self = shared_from_this(), batch = std::move(next)]() {
+        [self = SfwDbg(__LINE__), batch = std::move(next)]() {
           int64_t rows_to_release = batch->num_rows();
           Status status = self->writer_->Write(batch);
           self->writer_state_->rows_in_flight_throttle.Release(rows_to_release);
@@ -258,7 +272,7 @@ class DatasetWriterFileQueue
       RETURN_NOT_OK(options_.writer_pre_finish(writer_.get()));
     }
     return writer_->Finish().Then(
-        [self = shared_from_this(), writer_post_finish = options_.writer_post_finish]() {
+        [self = SfwDbg(__LINE__), writer_post_finish = options_.writer_post_finish]() {
           std::lock_guard<std::mutex> lg(self->writer_state_->visitors_mutex);
           return writer_post_finish(self->writer_.get());
         });
@@ -297,6 +311,20 @@ class DatasetWriterDirectoryQueue
   ~DatasetWriterDirectoryQueue() {
     if (latest_open_file_) {
       latest_open_file_->Abort();
+    }
+  }
+
+  // TEMP DEBUG: log shared_from_this() callsite throwing bad_weak_ptr
+  std::shared_ptr<DatasetWriterDirectoryQueue> SfwDbg(int line) {
+    try {
+      return shared_from_this();
+    } catch (const std::bad_weak_ptr&) {
+      std::fprintf(
+          stderr,
+          "GH-49958: bad_weak_ptr DatasetWriterDirectoryQueue dataset_writer.cc:%d\n",
+          line);
+      std::fflush(stderr);
+      throw;
     }
   }
 
@@ -361,7 +389,7 @@ class DatasetWriterDirectoryQueue
   Status OpenFileQueue(const std::string& filename) {
     latest_open_file_.reset(
         new DatasetWriterFileQueue(schema_, write_options_, writer_state_));
-    auto file_finish_task = [self = shared_from_this()] {
+    auto file_finish_task = [self = SfwDbg(__LINE__)] {
       self->writer_state_->open_files_throttle.Release(1);
       return Status::OK();
     };

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -208,6 +208,12 @@ class DatasetWriterFileQueue
   }
 
   void ScheduleBatch(std::shared_ptr<RecordBatch> batch) {
+    // TEMP DIAG (2): control block already gone (use-after-free) by here?
+    if (auto wp = weak_from_this(); wp.expired()) {
+      std::fprintf(stderr, "GH-49958: ScheduleBatch this=%p EXPIRED use_count=%d\n",
+                   static_cast<void*>(this), static_cast<int>(wp.use_count()));
+      std::fflush(stderr);
+    }
     file_tasks_->AddSimpleTask(
         [self = SfwDbg(__LINE__), batch = std::move(batch)]() {
           return self->WriteNext(std::move(batch));
@@ -387,8 +393,9 @@ class DatasetWriterDirectoryQueue
   }
 
   Status OpenFileQueue(const std::string& filename) {
-    latest_open_file_.reset(
-        new DatasetWriterFileQueue(schema_, write_options_, writer_state_));
+    // TEMP DIAG (1): make_shared instead of reset to wire _M_weak_this
+    latest_open_file_ =
+        std::make_shared<DatasetWriterFileQueue>(schema_, write_options_, writer_state_);
     auto file_finish_task = [self = SfwDbg(__LINE__)] {
       self->writer_state_->open_files_throttle.Release(1);
       return Status::OK();

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -139,7 +139,18 @@ class DatasetWriterFileQueue
   explicit DatasetWriterFileQueue(const std::shared_ptr<Schema>& schema,
                                   const FileSystemDatasetWriteOptions& options,
                                   std::shared_ptr<DatasetWriterState> writer_state)
-      : options_(options), schema_(schema), writer_state_(std::move(writer_state)) {}
+      : options_(options), schema_(schema), writer_state_(std::move(writer_state)) {
+    std::fprintf(stderr, "GH-49958: +DatasetWriterFileQueue this=%p\n",
+                 static_cast<void*>(this));
+    std::fflush(stderr);
+  }
+
+  // TEMP DIAG (3): did the object actually get destroyed under us?
+  ~DatasetWriterFileQueue() {
+    std::fprintf(stderr, "GH-49958: ~DatasetWriterFileQueue this=%p\n",
+                 static_cast<void*>(this));
+    std::fflush(stderr);
+  }
 
   // TEMP DEBUG: log shared_from_this() callsite throwing bad_weak_ptr
   std::shared_ptr<DatasetWriterFileQueue> SfwDbg(int line) {

--- a/cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc
+++ b/cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Minimal standalone repro for GH-49958 (MinGW gcc 16.1)
-//   While one shared_ptr owner is known-alive, stress weak_ptr.lock() and
-//   shared_from_this() from many threads.
-//
+// Minimal standalone repro for MinGW gcc 16.1 shared_ptr/weak_ptr regression.
 // Build (MSYS2 MINGW64):
 //   g++ -std=gnu++20 -O2 -g -pthread gh-49958-mingw-bad-weak-ptr-repro.cc -o repro
 // Run (argument in seconds):
@@ -28,22 +25,68 @@
 #include <atomic>
 #include <chrono>
 #include <cinttypes>
-#include <cstdint>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <thread>
 #include <vector>
 
+namespace {
+
 struct State : public std::enable_shared_from_this<State> {
   void Check() {
-    // Must succeed whenever at least one owning shared_ptr exists.
+    check_enter.fetch_add(1, std::memory_order_relaxed);
+    stage.store(5, std::memory_order_relaxed);  // in shared_from_this
     auto self = shared_from_this();
     (void)self;
+    check_ok.fetch_add(1, std::memory_order_relaxed);
+    stage.store(6, std::memory_order_relaxed);  // shared_from_this returned
   }
+
+  static std::atomic<uint64_t> check_enter;
+  static std::atomic<uint64_t> check_ok;
+  static std::atomic<int> stage;
 };
 
+std::atomic<uint64_t> State::check_enter{0};
+std::atomic<uint64_t> State::check_ok{0};
+std::atomic<int> State::stage{0};
+
+std::atomic<uint64_t> lock_ok{0};
+std::atomic<uint64_t> lock_fail{0};
+std::atomic<uint64_t> checks{0};
+std::atomic<bool> saw_bad_weak_ptr{false};
+std::atomic<bool> saw_impossible_expired{false};
+
+void Dump(const char* tag) {
+  std::fprintf(stderr,
+               "%s: stage=%d checks=%" PRIu64 " lock_ok=%" PRIu64 " lock_fail=%" PRIu64
+               " check_enter=%" PRIu64 " check_ok=%" PRIu64
+               " bad_weak_ptr=%d impossible_expired=%d\n",
+               tag, State::stage.load(std::memory_order_relaxed),
+               checks.load(std::memory_order_relaxed),
+               lock_ok.load(std::memory_order_relaxed),
+               lock_fail.load(std::memory_order_relaxed),
+               State::check_enter.load(std::memory_order_relaxed),
+               State::check_ok.load(std::memory_order_relaxed),
+               saw_bad_weak_ptr.load(std::memory_order_relaxed) ? 1 : 0,
+               saw_impossible_expired.load(std::memory_order_relaxed) ? 1 : 0);
+}
+
+void OnSignal(int sig) {
+  std::fprintf(stderr, "caught signal %d\n", sig);
+  Dump("crash_state");
+  std::_Exit(128 + sig);
+}
+
+}  // namespace
+
 int main(int argc, char** argv) {
+  std::setvbuf(stderr, nullptr, _IONBF, 0);
+  std::signal(SIGSEGV, OnSignal);
+  std::signal(SIGABRT, OnSignal);
+
   int run_seconds = 10;
   if (argc > 1) {
     run_seconds = std::max(1, std::atoi(argv[1]));
@@ -57,17 +100,13 @@ int main(int argc, char** argv) {
   std::atomic<bool> stop{false};
   std::atomic<bool> owner_is_alive{true};
 
-  std::atomic<bool> saw_bad_weak_ptr{false};
-  std::atomic<bool> saw_impossible_expired{false};
-
-  std::atomic<uint64_t> lock_ok{0};
-  std::atomic<uint64_t> lock_fail{0};
-  std::atomic<uint64_t> checks{0};
-
   auto worker = [&] {
+    auto weak_local = weak;
     while (!stop.load(std::memory_order_relaxed)) {
-      auto sp = weak.lock();
+      State::stage.store(1, std::memory_order_relaxed);  // loop
+      auto sp = weak_local.lock();
       if (!sp) {
+        State::stage.store(3, std::memory_order_relaxed);  // lock failed
         lock_fail.fetch_add(1, std::memory_order_relaxed);
         if (owner_is_alive.load(std::memory_order_relaxed)) {
           saw_impossible_expired.store(true, std::memory_order_relaxed);
@@ -76,8 +115,10 @@ int main(int argc, char** argv) {
         continue;
       }
       lock_ok.fetch_add(1, std::memory_order_relaxed);
+      State::stage.store(2, std::memory_order_relaxed);  // sp obtained
 
       try {
+        State::stage.store(4, std::memory_order_relaxed);  // before Check
         sp->Check();
         checks.fetch_add(1, std::memory_order_relaxed);
       } catch (const std::bad_weak_ptr&) {
@@ -86,7 +127,6 @@ int main(int argc, char** argv) {
         return;
       }
 
-      // Cheap shared_ptr churn to exercise refcount paths
       std::shared_ptr<State> copies[8] = {sp, sp, sp, sp, sp, sp, sp, sp};
       (void)copies;
     }
@@ -98,8 +138,7 @@ int main(int argc, char** argv) {
     threads.emplace_back(worker);
   }
 
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::seconds(run_seconds);
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(run_seconds);
   while (std::chrono::steady_clock::now() < deadline &&
          !stop.load(std::memory_order_relaxed)) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -113,17 +152,13 @@ int main(int argc, char** argv) {
   owner_is_alive.store(false, std::memory_order_relaxed);
   owner.reset();
 
-  std::fprintf(stderr,
-               "done: checks=%" PRIu64 " lock_ok=%" PRIu64 " lock_fail=%" PRIu64
-               " bad_weak_ptr=%d impossible_expired=%d\n",
-               checks.load(), lock_ok.load(), lock_fail.load(),
-               saw_bad_weak_ptr.load() ? 1 : 0, saw_impossible_expired.load() ? 1 : 0);
+  Dump("done");
 
-  if (saw_bad_weak_ptr.load()) {
+  if (saw_bad_weak_ptr.load(std::memory_order_relaxed)) {
     std::fprintf(stderr, "REPRODUCED: unexpected std::bad_weak_ptr while object alive\n");
     return 3;
   }
-  if (saw_impossible_expired.load()) {
+  if (saw_impossible_expired.load(std::memory_order_relaxed)) {
     std::fprintf(
         stderr, "REPRODUCED: weak_ptr.lock() failed while owning shared_ptr was alive\n");
     return 2;

--- a/cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc
+++ b/cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc
@@ -16,17 +16,13 @@
 // under the License.
 
 // Minimal standalone repro for GH-49958 (MinGW gcc 16.1)
-//
-//   Stress weak_ptr -> shared_ptr promotion plus shared_from_this() on an object
-//   that stays alive for the whole run. Any std::bad_weak_ptr throw or impossible
-//   weak_ptr expiration while keep_alive is true indicates toolchain/runtime breakage.
+//   While one shared_ptr owner is known-alive, stress weak_ptr.lock() and
+//   shared_from_this() from many threads.
 //
 // Build (MSYS2 MINGW64):
 //   g++ -std=gnu++20 -O2 -g -pthread gh-49958-mingw-bad-weak-ptr-repro.cc -o repro
-//
-// Run:
+// Run (argument in seconds):
 //   ./repro 30
-//   (argument is runtime seconds; default 10)
 
 #include <algorithm>
 #include <atomic>
@@ -35,39 +31,17 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <deque>
 #include <memory>
-#include <mutex>
 #include <thread>
 #include <vector>
 
-namespace {
-
 struct State : public std::enable_shared_from_this<State> {
-  void Push(int value) {
-    // This should always succeed while the owning shared_ptr is alive.
+  void Check() {
+    // Must succeed whenever at least one owning shared_ptr exists.
     auto self = shared_from_this();
     (void)self;
-
-    std::lock_guard<std::mutex> guard(mu);
-    queue.push_back(value);
   }
-
-  bool Pop(int* out) {
-    std::lock_guard<std::mutex> guard(mu);
-    if (queue.empty()) {
-      return false;
-    }
-    *out = queue.front();
-    queue.pop_front();
-    return true;
-  }
-
-  std::mutex mu;
-  std::deque<int> queue;
 };
-
-}  // namespace
 
 int main(int argc, char** argv) {
   int run_seconds = 10;
@@ -75,94 +49,60 @@ int main(int argc, char** argv) {
     run_seconds = std::max(1, std::atoi(argv[1]));
   }
 
-  constexpr int kProducerThreads = 20;
-  constexpr int kLockOnlyThreads = 8;
+  constexpr int kThreads = 32;
 
-  auto state = std::make_shared<State>();
-  std::weak_ptr<State> weak = state;
+  auto owner = std::make_shared<State>();
+  std::weak_ptr<State> weak = owner;
 
   std::atomic<bool> stop{false};
-  std::atomic<bool> should_be_alive{true};
+  std::atomic<bool> owner_is_alive{true};
+
   std::atomic<bool> saw_bad_weak_ptr{false};
   std::atomic<bool> saw_impossible_expired{false};
 
-  std::atomic<uint64_t> pushes{0};
-  std::atomic<uint64_t> pops{0};
   std::atomic<uint64_t> lock_ok{0};
   std::atomic<uint64_t> lock_fail{0};
+  std::atomic<uint64_t> checks{0};
 
-  auto producer = [&] {
-    int value = 0;
+  auto worker = [&] {
     while (!stop.load(std::memory_order_relaxed)) {
       auto sp = weak.lock();
       if (!sp) {
         lock_fail.fetch_add(1, std::memory_order_relaxed);
-        if (should_be_alive.load(std::memory_order_relaxed)) {
+        if (owner_is_alive.load(std::memory_order_relaxed)) {
           saw_impossible_expired.store(true, std::memory_order_relaxed);
+          stop.store(true, std::memory_order_relaxed);
         }
         continue;
       }
       lock_ok.fetch_add(1, std::memory_order_relaxed);
 
       try {
-        sp->Push(value++);
-        pushes.fetch_add(1, std::memory_order_relaxed);
+        sp->Check();
+        checks.fetch_add(1, std::memory_order_relaxed);
       } catch (const std::bad_weak_ptr&) {
         saw_bad_weak_ptr.store(true, std::memory_order_relaxed);
         stop.store(true, std::memory_order_relaxed);
         return;
       }
 
-      // Extra allocator churn to make races/miscompiles show up faster.
-      std::vector<std::shared_ptr<int>> churn;
-      churn.reserve(32);
-      for (int i = 0; i < 32; ++i) {
-        churn.push_back(std::make_shared<int>(value + i));
-      }
-    }
-  };
-
-  auto lock_only = [&] {
-    while (!stop.load(std::memory_order_relaxed)) {
-      auto sp = weak.lock();
-      if (sp) {
-        lock_ok.fetch_add(1, std::memory_order_relaxed);
-      } else {
-        lock_fail.fetch_add(1, std::memory_order_relaxed);
-        if (should_be_alive.load(std::memory_order_relaxed)) {
-          saw_impossible_expired.store(true, std::memory_order_relaxed);
-        }
-      }
-    }
-  };
-
-  auto consumer = [&] {
-    int out = 0;
-    while (!stop.load(std::memory_order_relaxed)) {
-      if (state->Pop(&out)) {
-        (void)out;
-        pops.fetch_add(1, std::memory_order_relaxed);
-      } else {
-        std::this_thread::yield();
-      }
+      // Cheap shared_ptr churn to exercise refcount paths
+      std::shared_ptr<State> copies[8] = {sp, sp, sp, sp, sp, sp, sp, sp};
+      (void)copies;
     }
   };
 
   std::vector<std::thread> threads;
-  threads.reserve(kProducerThreads + kLockOnlyThreads + 1);
-  for (int i = 0; i < kProducerThreads; ++i) {
-    threads.emplace_back(producer);
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back(worker);
   }
-  for (int i = 0; i < kLockOnlyThreads; ++i) {
-    threads.emplace_back(lock_only);
-  }
-  threads.emplace_back(consumer);
 
   const auto deadline =
       std::chrono::steady_clock::now() + std::chrono::seconds(run_seconds);
   while (std::chrono::steady_clock::now() < deadline &&
          !stop.load(std::memory_order_relaxed)) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
   stop.store(true, std::memory_order_relaxed);
@@ -170,13 +110,13 @@ int main(int argc, char** argv) {
     t.join();
   }
 
-  should_be_alive.store(false, std::memory_order_relaxed);
-  state.reset();
+  owner_is_alive.store(false, std::memory_order_relaxed);
+  owner.reset();
 
   std::fprintf(stderr,
-               "done: pushes=%" PRIu64 " pops=%" PRIu64 " lock_ok=%" PRIu64
-               " lock_fail=%" PRIu64 " bad_weak_ptr=%d impossible_expired=%d\n",
-               pushes.load(), pops.load(), lock_ok.load(), lock_fail.load(),
+               "done: checks=%" PRIu64 " lock_ok=%" PRIu64 " lock_fail=%" PRIu64
+               " bad_weak_ptr=%d impossible_expired=%d\n",
+               checks.load(), lock_ok.load(), lock_fail.load(),
                saw_bad_weak_ptr.load() ? 1 : 0, saw_impossible_expired.load() ? 1 : 0);
 
   if (saw_bad_weak_ptr.load()) {

--- a/cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc
+++ b/cpp/tools/gh-49958-mingw-bad-weak-ptr-repro.cc
@@ -1,0 +1,194 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Minimal standalone repro for GH-49958 (MinGW gcc 16.1)
+//
+//   Stress weak_ptr -> shared_ptr promotion plus shared_from_this() on an object
+//   that stays alive for the whole run. Any std::bad_weak_ptr throw or impossible
+//   weak_ptr expiration while keep_alive is true indicates toolchain/runtime breakage.
+//
+// Build (MSYS2 MINGW64):
+//   g++ -std=gnu++20 -O2 -g -pthread gh-49958-mingw-bad-weak-ptr-repro.cc -o repro
+//
+// Run:
+//   ./repro 30
+//   (argument is runtime seconds; default 10)
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace {
+
+struct State : public std::enable_shared_from_this<State> {
+  void Push(int value) {
+    // This should always succeed while the owning shared_ptr is alive.
+    auto self = shared_from_this();
+    (void)self;
+
+    std::lock_guard<std::mutex> guard(mu);
+    queue.push_back(value);
+  }
+
+  bool Pop(int* out) {
+    std::lock_guard<std::mutex> guard(mu);
+    if (queue.empty()) {
+      return false;
+    }
+    *out = queue.front();
+    queue.pop_front();
+    return true;
+  }
+
+  std::mutex mu;
+  std::deque<int> queue;
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  int run_seconds = 10;
+  if (argc > 1) {
+    run_seconds = std::max(1, std::atoi(argv[1]));
+  }
+
+  constexpr int kProducerThreads = 20;
+  constexpr int kLockOnlyThreads = 8;
+
+  auto state = std::make_shared<State>();
+  std::weak_ptr<State> weak = state;
+
+  std::atomic<bool> stop{false};
+  std::atomic<bool> should_be_alive{true};
+  std::atomic<bool> saw_bad_weak_ptr{false};
+  std::atomic<bool> saw_impossible_expired{false};
+
+  std::atomic<uint64_t> pushes{0};
+  std::atomic<uint64_t> pops{0};
+  std::atomic<uint64_t> lock_ok{0};
+  std::atomic<uint64_t> lock_fail{0};
+
+  auto producer = [&] {
+    int value = 0;
+    while (!stop.load(std::memory_order_relaxed)) {
+      auto sp = weak.lock();
+      if (!sp) {
+        lock_fail.fetch_add(1, std::memory_order_relaxed);
+        if (should_be_alive.load(std::memory_order_relaxed)) {
+          saw_impossible_expired.store(true, std::memory_order_relaxed);
+        }
+        continue;
+      }
+      lock_ok.fetch_add(1, std::memory_order_relaxed);
+
+      try {
+        sp->Push(value++);
+        pushes.fetch_add(1, std::memory_order_relaxed);
+      } catch (const std::bad_weak_ptr&) {
+        saw_bad_weak_ptr.store(true, std::memory_order_relaxed);
+        stop.store(true, std::memory_order_relaxed);
+        return;
+      }
+
+      // Extra allocator churn to make races/miscompiles show up faster.
+      std::vector<std::shared_ptr<int>> churn;
+      churn.reserve(32);
+      for (int i = 0; i < 32; ++i) {
+        churn.push_back(std::make_shared<int>(value + i));
+      }
+    }
+  };
+
+  auto lock_only = [&] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      auto sp = weak.lock();
+      if (sp) {
+        lock_ok.fetch_add(1, std::memory_order_relaxed);
+      } else {
+        lock_fail.fetch_add(1, std::memory_order_relaxed);
+        if (should_be_alive.load(std::memory_order_relaxed)) {
+          saw_impossible_expired.store(true, std::memory_order_relaxed);
+        }
+      }
+    }
+  };
+
+  auto consumer = [&] {
+    int out = 0;
+    while (!stop.load(std::memory_order_relaxed)) {
+      if (state->Pop(&out)) {
+        (void)out;
+        pops.fetch_add(1, std::memory_order_relaxed);
+      } else {
+        std::this_thread::yield();
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kProducerThreads + kLockOnlyThreads + 1);
+  for (int i = 0; i < kProducerThreads; ++i) {
+    threads.emplace_back(producer);
+  }
+  for (int i = 0; i < kLockOnlyThreads; ++i) {
+    threads.emplace_back(lock_only);
+  }
+  threads.emplace_back(consumer);
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(run_seconds);
+  while (std::chrono::steady_clock::now() < deadline &&
+         !stop.load(std::memory_order_relaxed)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  should_be_alive.store(false, std::memory_order_relaxed);
+  state.reset();
+
+  std::fprintf(stderr,
+               "done: pushes=%" PRIu64 " pops=%" PRIu64 " lock_ok=%" PRIu64
+               " lock_fail=%" PRIu64 " bad_weak_ptr=%d impossible_expired=%d\n",
+               pushes.load(), pops.load(), lock_ok.load(), lock_fail.load(),
+               saw_bad_weak_ptr.load() ? 1 : 0, saw_impossible_expired.load() ? 1 : 0);
+
+  if (saw_bad_weak_ptr.load()) {
+    std::fprintf(stderr, "REPRODUCED: unexpected std::bad_weak_ptr while object alive\n");
+    return 3;
+  }
+  if (saw_impossible_expired.load()) {
+    std::fprintf(
+        stderr, "REPRODUCED: weak_ptr.lock() failed while owning shared_ptr was alive\n");
+    return 2;
+  }
+
+  std::fprintf(stderr, "No failure observed in this run\n");
+  return 0;
+}


### PR DESCRIPTION
### Rationale for this change
Do not merge - diagnostic record of #49958 investigation.

Not an Arrow bug. Reported upstream as [GCC bug 125312](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125312).
([GCC r16-427](https://gcc.gnu.org/cgit/gcc/commit/?id=86627faec10da5)'s configure test for `_GLIBCXX_ATOMIC_WORD_BUILTINS` uses a POSIX-style absolute path the Windows GCC being built can't open. `libstdc++` falls back to non-lock-free atomic refcount ops.)

Use PR #49945 (to revert workaround MSYS2 pin step) once GCC fixes upstream + MSYS2 rebuilds.

### What changes are included in this PR?
Only debug for now.

### Are these changes tested?
CI debug

### Are there any user-facing changes?
No
* GitHub Issue: #49958