### PR TITLE
GH-49967: [Python][CI] Raise oldest NumPy wheel-test requirement to a patched release

### DIFF
--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -12,7 +12,7 @@ tzdata; sys_platform == 'win32'
 # version. However, there is no need to make this strictly the oldest version,
 # so it can be broadened to have a single version specification across platforms.
 # (`~=x.y.z` specifies a compatible release as `>=x.y.z, == x.y.*`)
-numpy~=1.22.0; python_version < "3.11"
+numpy~=1.23.2; python_version < "3.11"
 numpy~=1.23.2; python_version == "3.11"
 numpy~=1.26.0; python_version == "3.12"
 numpy~=2.1.0; python_version == "3.13"

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -12,7 +12,7 @@ tzdata; sys_platform == 'win32'
 # version. However, there is no need to make this strictly the oldest version,
 # so it can be broadened to have a single version specification across platforms.
 # (`~=x.y.z` specifies a compatible release as `>=x.y.z, == x.y.*`)
-numpy~=1.21.3; python_version < "3.11"
+numpy~=1.22.0; python_version < "3.11"
 numpy~=1.23.2; python_version == "3.11"
 numpy~=1.26.0; python_version == "3.12"
 numpy~=2.1.0; python_version == "3.13"


### PR DESCRIPTION
## Summary

- Update `python/requirements-wheel-test.txt` for Python `<3.11` from `numpy~=1.21.3` to `numpy~=1.23.2`.

(Previously this PR pinned to `numpy~=1.22.0`, which closes the advisory but is one minor short of what the wheel tests need: `numpy.from_dlpack` was added in numpy 1.23. After @raulcd's crossbow run failed on `AttributeError: module 'numpy' has no attribute 'from_dlpack'`, the floor was bumped to `~=1.23.2`, matching the cp311 line right below it.)

## Why

Dependabot flags `numpy < 1.22` in this requirements file (GHSA-fpfv-jqm9-f5jm / CVE-2021-34141, fixed in 1.22). `~=1.23.2` keeps that advisory closed and gives the wheel-test runtime `numpy.from_dlpack`, which arrow's test suite uses.

## Validation

- `python3 -m pip install -r python/requirements-wheel-test.txt` locally.
- The pin collapses to two distinct numpy floors across the matrix (cp310 + cp311 now share `~=1.23.2`).
- Awaiting another crossbow run for cp310 wheels.

* GitHub Issue: #49967