### PR TITLE
GH-49974: [C++][CMake] Add missing result variable initialization for `validate_apple_libtool()`

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -117,6 +117,7 @@ function(arrow_create_merged_static_lib output_target)
     if(CMAKE_LIBTOOL)
       set(LIBTOOL_MACOS ${CMAKE_LIBTOOL})
       # Validate that CMAKE_LIBTOOL is Apple's libtool
+      set(is_apple_libtool TRUE)
       validate_apple_libtool(is_apple_libtool "${LIBTOOL_MACOS}")
       if(NOT is_apple_libtool)
         get_libtool_version("${LIBTOOL_MACOS}" _libtool_version_output)


### PR DESCRIPTION
### Rationale for this change

`find_package()`'s `VALIDATOR`'s result variable must be initialized to `TRUE` by caller.

We reuse the `VALIDATOR` (`validate_apple_libtool()`) when we specify `CMAKE_LIBTOOL` explicitly. But we didn't initialize the result variable to `TRUE`.

### What changes are included in this PR?

Initialize `is_apple_libtool` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #49974