### PR TITLE
GH-49994: [CI] Remove `brew uninstall pkg-config` workarounds

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -231,11 +231,6 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         run: |
-          # pkg-config formula is deprecated but it's still installed
-          # in GitHub Actions runner now. We can remove this once
-          # pkg-config formula is removed from GitHub Actions runner.
-          brew uninstall pkg-config || :
-          brew uninstall pkg-config@0.29.2 || :
           # Workaround for https://github.com/grpc/grpc/issues/41755
           # Remove once the runner ships a newer Homebrew.
           brew update

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -198,11 +198,6 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          # pkg-config formula is deprecated but it's still installed
-          # in GitHub Actions runner now. We can remove this once
-          # pkg-config formula is removed from GitHub Actions runner.
-          brew uninstall pkg-config || :
-          brew uninstall pkg-config@0.29.2 || :
           # Workaround for https://github.com/grpc/grpc/issues/41755
           # Remove once the runner ships a newer Homebrew.
           brew update

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -42,14 +42,6 @@ jobs:
       - name: Install System Dependencies
         shell: bash
         run: |
-          {% if github_runner in ("macos-14", "macos-latest") %}
-          # pkg-config formula is deprecated but it's still installed
-          # in GitHub Actions runner now. We can remove this once
-          # pkg-config formula is removed from GitHub Actions runner.
-          brew uninstall pkg-config || :
-          brew uninstall pkg-config@0.29.2 || :
-          {% endif %}
-
           # Workaround for https://github.com/grpc/grpc/issues/41755
           # Remove once the runner ships a newer Homebrew.
           brew update


### PR DESCRIPTION
### Rationale for this change

Recent GitHub Actions runners for macOS doesn't ship `pkg-config` formula. So we don't need to uninstall them explicitly.

### What changes are included in this PR?

Remove `brew uninstall pkg-config` family.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #49994