### PR TITLE
GH-49998: [CI][Python] Pin to an older release of miniforge to fix mamba hang

### DIFF
--- a/ci/docker/conda.dockerfile
+++ b/ci/docker/conda.dockerfile
@@ -30,9 +30,11 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# install conda and mamba via miniforge
+# Install conda and mamba via miniforge.
+# Temporarily pin to an old version of miniforge due to a regression in the mamba solver.
+# See https://github.com/apache/arrow/issues/49998.
 COPY ci/scripts/install_conda.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_conda.sh miniforge3 latest /opt/conda
+RUN /arrow/ci/scripts/install_conda.sh miniforge3 26.1.1-3 /opt/conda
 ENV PATH=/opt/conda/bin:$PATH
 
 # create a conda environment

--- a/ci/scripts/install_conda.sh
+++ b/ci/scripts/install_conda.sh
@@ -30,7 +30,11 @@ installer=$1
 version=$2
 prefix=$3
 
-download_url=https://github.com/conda-forge/miniforge/releases/${version}/download/${installer^}-${platform}-${arch}.sh
+if [ "$version" = "latest" ]; then
+  download_url=https://github.com/conda-forge/miniforge/releases/latest/download/${installer^}-${platform}-${arch}.sh
+else
+  download_url=https://github.com/conda-forge/miniforge/releases/download/${version}/${installer^}-${platform}-${arch}.sh
+fi
 
 echo "Downloading Miniconda installer from ${download_url} ..."
 


### PR DESCRIPTION
### Rationale for this change

See #49998. This prevents CI jobs from timing out after an hour.

### What changes are included in this PR?

Pins miniforge to 26.1.1-3.

### Are these changes tested?

Yes, I tested locally that this fixes the slow install.

### Are there any user-facing changes?

No, this only affects CI.

* GitHub Issue: #49998