### PR TITLE
[C++][Parquet] Saturate ApplicationVersion components instead of atoi UB

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -18,7 +18,10 @@
 #include "parquet/metadata.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cinttypes>
+#include <cstdlib>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <random>
@@ -1274,6 +1277,24 @@ ApplicationVersion::ApplicationVersion(std::string application, int major, int m
     : application_(std::move(application)), version{major, minor, patch, "", "", ""} {}
 
 namespace {
+// Parse a digit-only ASCII string into an int, saturating to INT_MAX on
+// overflow. The version components in a file's `created_by` string are
+// attacker-controlled, and std::atoi has undefined behavior when the
+// converted value falls outside the range of int (see [c.strtoint]).
+int ParseUnsignedVersionComponent(const std::string& s) {
+  if (s.empty()) {
+    return 0;
+  }
+  errno = 0;
+  char* end = nullptr;
+  unsigned long value = std::strtoul(s.c_str(), &end, 10);
+  if (errno == ERANGE ||
+      value > static_cast<unsigned long>(std::numeric_limits<int>::max())) {
+    return std::numeric_limits<int>::max();
+  }
+  return static_cast<int>(value);
+}
+
 // Parse the application version format and set parsed values to
 // ApplicationVersion.
 //
@@ -1441,7 +1462,7 @@ class ApplicationVersionParser {
     }
     auto version_major_string = version_string_.substr(
         version_major_start, version_major_end - version_major_start);
-    application_version_.version.major = atoi(version_major_string.c_str());
+    application_version_.version.major = ParseUnsignedVersionComponent(version_major_string);
     return true;
   }
 
@@ -1466,7 +1487,7 @@ class ApplicationVersionParser {
     }
     auto version_minor_string = version_string_.substr(
         version_minor_start, version_minor_end - version_minor_start);
-    application_version_.version.minor = atoi(version_minor_string.c_str());
+    application_version_.version.minor = ParseUnsignedVersionComponent(version_minor_string);
     return true;
   }
 
@@ -1484,7 +1505,7 @@ class ApplicationVersionParser {
     }
     auto version_patch_string = version_string_.substr(
         version_patch_start, version_patch_end - version_patch_start);
-    application_version_.version.patch = atoi(version_patch_string.c_str());
+    application_version_.version.patch = ParseUnsignedVersionComponent(version_patch_string);
     version_parsing_position_ = version_patch_end;
     return true;
   }

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -17,6 +17,8 @@
 
 #include "parquet/metadata.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "arrow/util/key_value_metadata.h"
@@ -729,6 +731,32 @@ TEST(ApplicationVersion, VersionNoUnknownBuildInfoPreRelease) {
   ASSERT_EQ("", version.version.unknown);
   ASSERT_EQ("", version.version.pre_release);
   ASSERT_EQ("cd-cdh5.5.0", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionComponentOverflow) {
+  // Version components in `created_by` are attacker-controlled. std::atoi
+  // exhibits undefined behavior when the converted value overflows int, so
+  // the parser must clamp instead of calling atoi.
+  ApplicationVersion version(
+      "parquet-mr version 99999999999999999999.88888888888888888888."
+      "77777777777777777777 (build abcd)");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("abcd", version.build_);
+  ASSERT_EQ(std::numeric_limits<int>::max(), version.version.major);
+  ASSERT_EQ(std::numeric_limits<int>::max(), version.version.minor);
+  ASSERT_EQ(std::numeric_limits<int>::max(), version.version.patch);
+
+  // Boundary cases: INT_MAX is representable, INT_MAX+1 saturates.
+  ApplicationVersion at_max("parquet-mr version 2147483647.2147483647.2147483647");
+  ASSERT_EQ(std::numeric_limits<int>::max(), at_max.version.major);
+  ASSERT_EQ(std::numeric_limits<int>::max(), at_max.version.minor);
+  ASSERT_EQ(std::numeric_limits<int>::max(), at_max.version.patch);
+
+  ApplicationVersion just_over("parquet-mr version 2147483648.2147483648.2147483648");
+  ASSERT_EQ(std::numeric_limits<int>::max(), just_over.version.major);
+  ASSERT_EQ(std::numeric_limits<int>::max(), just_over.version.minor);
+  ASSERT_EQ(std::numeric_limits<int>::max(), just_over.version.patch);
 }
 
 TEST(ApplicationVersion, FullWithSpaces) {


### PR DESCRIPTION
### What

When reading a Parquet file, `ApplicationVersion::ApplicationVersion(const std::string& created_by)` parses the writer-supplied `created_by` metadata string into three integer fields (`version.major`, `version.minor`, `version.patch`). The current implementation in `cpp/src/parquet/metadata.cc` does this with `std::atoi`:

```cpp
application_version_.version.major = atoi(version_major_string.c_str());  // line 1444
application_version_.version.minor = atoi(version_minor_string.c_str());  // line 1469
application_version_.version.patch = atoi(version_patch_string.c_str());  // line 1487
```

The substrings here are already filtered to be digit-only, but their length is not bounded. The `created_by` field is fully attacker-controlled in any untrusted Parquet file, so an input like

```
parquet-mr version 99999999999999999999.0.0 (build abcd)
```

reaches `atoi` with a value far outside the range of `int`. Per the C++ standard, `std::atoi` has **undefined behavior** when the result cannot be represented as an `int` (`[c.strtoint]`). In practice the value is unspecified, and the negative or otherwise garbage value that comes out then drives `VersionLt` / `HasCorrectStatistics`, controlling whether the reader chooses to trust the column statistics block of the file.

### How to observe

A small reproducer in the same C++17 mode as Arrow:

```cpp
#include <cstdio>
#include <cstdlib>
#include <string>
int main() {
    std::string s = "99999999999999999999";
    std::printf("atoi -> %d\n", std::atoi(s.c_str())); // UB; observed -1 here
}
```

UBSan flags the overflow inside the underlying `strtol`. The existing tests in `metadata_test.cc` only cover small inputs, which is why this has not been caught.

### The fix

Replace the three `atoi` call sites with a small `ParseUnsignedVersionComponent` helper inside the anonymous namespace in `metadata.cc`. The helper uses `std::strtoul` (which is defined to set `errno = ERANGE` and return `ULONG_MAX` on overflow rather than invoking UB) and saturates to `std::numeric_limits<int>::max()` when the parsed value would not fit in `int`. The fix is local to the callee – callers (the constructor of `ApplicationVersion`, called from `FileMetaData`'s thrift deserializer) are unchanged.

A new `ApplicationVersion.VersionComponentOverflow` test exercises:

* very long all-digit components (saturate to `INT_MAX`),
* exactly `INT_MAX` (representable),
* `INT_MAX + 1` (saturates).

### Build/test evidence

Built `parquet_objlib` and `parquet-internals-test` locally; all 18 `ApplicationVersion.*` tests pass, including the new overflow case:

```
[----------] 18 tests from ApplicationVersion (0 ms total)
[  PASSED  ] 18 tests.
```