### PR TITLE
GH-50022: [Dev] Enable auto GitHub Copilot review

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,6 +37,11 @@ github:
     - hiroyuki-sato
     - HyukjinKwon
 
+  copilot_code_review:
+    enabled: true
+    review_drafts: true
+    review_on_push: true
+
 notifications:
   commits:      commits@arrow.apache.org
   issues_status: issues@arrow.apache.org


### PR DESCRIPTION
### Rationale for this change

GitHub Copilot may reduce required review resource by committers.

### What changes are included in this PR?

Add a configuration to `.asf.yaml`.

See also: https://github.com/apache/infrastructure-asfyaml#copilot_code_review

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #50022