### PR TITLE
GH-49767: [CI][C++] Disable mold on Ubuntu 24.04 to work around mold#1247

### DIFF
--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -176,6 +176,11 @@ RUN /arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin
 # provided by the distribution:
 # - Abseil is old and we require a version that has CRC32C
 # - opentelemetry-cpp-dev is not packaged
+#
+# Ubuntu 24.04 apt mold is 2.30.0 which has a non-determinism bug in section placement:
+# https://github.com/rui314/mold/issues/1247 fixed in mold 2.31.0.
+# See https://github.com/apache/arrow/issues/49767
+# Re-enable ARROW_USE_MOLD if 2.31+ is released for apt Ubuntu 24.04.
 ENV absl_SOURCE=BUNDLED \
     ARROW_ACERO=ON \
     ARROW_AZURE=ON \
@@ -197,7 +202,7 @@ ENV absl_SOURCE=BUNDLED \
     ARROW_SUBSTRAIT=ON \
     ARROW_USE_ASAN=OFF \
     ARROW_USE_CCACHE=ON \
-    ARROW_USE_MOLD=ON \
+    ARROW_USE_MOLD=OFF \
     ARROW_USE_UBSAN=OFF \
     ARROW_WITH_BROTLI=ON \
     ARROW_WITH_BZ2=ON \

--- a/compose.yaml
+++ b/compose.yaml
@@ -516,17 +516,9 @@ services:
       ARROW_PARQUET: "OFF"
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
-      # GH-49767: Ubuntu 24.04 apt mold predates the fix for rui314/mold#1247
-      # (fixed in mold 2.31.0). Remove this if apt ships mold >= 2.31.0.
-      # see https://github.com/rui314/mold/issues/1247
-      MOLD_URL: "https://archive.ubuntu.com/ubuntu/pool/universe/m/mold/mold_2.37.1+dfsg-1_amd64.deb"
     # Register ODBC before running tests
     command: >
       /bin/bash -c "
-        curl -fsSL $$MOLD_URL -o /tmp/mold.deb &&
-        sudo apt-get update &&
-        sudo apt-get install -y /tmp/mold.deb &&
-        ld.mold --version &&
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         sudo /arrow/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc.sh /usr/local/lib/libarrow_flight_sql_odbc.so &&
         /arrow/ci/scripts/cpp_test.sh /arrow /build"

--- a/compose.yaml
+++ b/compose.yaml
@@ -518,14 +518,13 @@ services:
       ARROW_SUBSTRAIT: "OFF"
       # GH-49767: workaround for buggy apt mold 2.30.0
       # see https://github.com/rui314/mold/issues/1247
-      MOLD_URL: "https://github.com/rui314/mold/releases/download/v2.31.0/mold-2.31.0-x86_64-linux.tar.gz"
+      MOLD_URL: "http://archive.ubuntu.com/ubuntu/pool/universe/m/mold/mold_2.37.1+dfsg-1_amd64.deb"
     # Register ODBC before running tests
     command: >
       /bin/bash -c "
-        curl -fsSL $$MOLD_URL -o /tmp/mold.tgz &&
-        tar -C /tmp -xzf /tmp/mold.tgz &&
-        sudo install -m 0755 /tmp/mold-*/bin/ld.mold /usr/local/bin/ &&
-        export PATH=/usr/local/bin:$$PATH &&
+        curl -fsSL $$MOLD_URL -o /tmp/mold.deb &&
+        sudo apt-get update &&
+        sudo apt-get install -y /tmp/mold.deb &&
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         sudo /arrow/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc.sh /usr/local/lib/libarrow_flight_sql_odbc.so &&
         /arrow/ci/scripts/cpp_test.sh /arrow /build"

--- a/compose.yaml
+++ b/compose.yaml
@@ -516,9 +516,16 @@ services:
       ARROW_PARQUET: "OFF"
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
+      # GH-49767: workaround for buggy apt mold 2.30.0
+      # see https://github.com/rui314/mold/issues/1247
+      MOLD_URL: "https://github.com/rui314/mold/releases/download/v2.31.0/mold-2.31.0-x86_64-linux.tar.gz"
     # Register ODBC before running tests
     command: >
       /bin/bash -c "
+        curl -fsSL $$MOLD_URL -o /tmp/mold.tgz &&
+        tar -C /tmp -xzf /tmp/mold.tgz &&
+        sudo install -m 0755 /tmp/mold-*/bin/ld.mold /usr/local/bin/ &&
+        export PATH=/usr/local/bin:$$PATH &&
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         sudo /arrow/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc.sh /usr/local/lib/libarrow_flight_sql_odbc.so &&
         /arrow/ci/scripts/cpp_test.sh /arrow /build"

--- a/compose.yaml
+++ b/compose.yaml
@@ -516,15 +516,17 @@ services:
       ARROW_PARQUET: "OFF"
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
-      # GH-49767: workaround for buggy apt mold 2.30.0
+      # GH-49767: Ubuntu 24.04 apt mold predates the fix for rui314/mold#1247
+      # (fixed in mold 2.31.0). Remove this if apt ships mold >= 2.31.0.
       # see https://github.com/rui314/mold/issues/1247
-      MOLD_URL: "http://archive.ubuntu.com/ubuntu/pool/universe/m/mold/mold_2.37.1+dfsg-1_amd64.deb"
+      MOLD_URL: "https://archive.ubuntu.com/ubuntu/pool/universe/m/mold/mold_2.37.1+dfsg-1_amd64.deb"
     # Register ODBC before running tests
     command: >
       /bin/bash -c "
         curl -fsSL $$MOLD_URL -o /tmp/mold.deb &&
         sudo apt-get update &&
         sudo apt-get install -y /tmp/mold.deb &&
+        ld.mold --version &&
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         sudo /arrow/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc.sh /usr/local/lib/libarrow_flight_sql_odbc.so &&
         /arrow/ci/scripts/cpp_test.sh /arrow /build"


### PR DESCRIPTION
### Rationale for this change
Fixes #49767 - intermittent SIGSEGV in the ODBC Linux CI job, the crash occurs during `_dl_relocate_object` before `main()` : https://github.com/apache/arrow/issues/49767#issuecomment-4520516388

apt ships mold 2.30.0 on Ubuntu 24.04 'Noble Numbat'.
mold 2.30.0 has a non-determinism bug in section placement that causes this crash ([rui314/mold#1247](https://github.com/rui314/mold/issues/1247)). Fixed upstream in [mold 2.31.0](https://github.com/rui314/mold/releases/tag/v2.31.0).

### What changes are included in this PR?
Disable mold on Ubuntu 24.04 in `ubuntu-24.04-cpp.dockerfile` by setting `ARROW_USE_MOLD=OFF`.
Re-enable if apt mold reaches 2.31+ - note that Ubuntu 24.04 'Noble Numbat' might never update to 2.31+ https://launchpad.net/ubuntu/noble/+source/mold - its mold release is over 2 years old.

A follow-up issue tracking apt mold updates and other CI jobs using mold (more added with #49898/#49899) will be opened separately.

### Are these changes tested?
Yes, ODBC Linux job runs complete successfully on fork: [1st](https://github.com/tadeja/arrow/actions/runs/26389905866/job/77676883090), [2nd](https://github.com/tadeja/arrow/actions/runs/26389905866/job/77684025003) , [3rd](https://github.com/tadeja/arrow/actions/runs/26389905866/job/77685765548) , [4th](https://github.com/tadeja/arrow/actions/runs/26389905866/job/77693037433) 

### Are there any user-facing changes?
No.
* GitHub Issue: #49767