### PR TITLE
GH-49776: [CI][C++] Install libc6-dbg in apt-based Linux C++ images

### DIFF
--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update -y -q && \
         libboost-system-dev \
         libbrotli-dev \
         libbz2-dev \
+        libc6-dbg \
         libcurl4-openssl-dev \
         libgflags-dev \
         libgmock-dev \

--- a/ci/docker/debian-experimental-cpp.dockerfile
+++ b/ci/docker/debian-experimental-cpp.dockerfile
@@ -49,6 +49,7 @@ RUN if [ -n "${gcc}" ]; then \
         libbrotli-dev \
         libbz2-dev \
         libc-ares-dev \
+        libc6-dbg \
         libcurl4-openssl-dev \
         libgflags-dev \
         libgmock-dev \

--- a/ci/docker/ubuntu-22.04-cpp-minimal.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp-minimal.dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -y -q && \
         curl \
         gdb \
         git \
+        libc6-dbg \
         libssl-dev \
         libcurl4-openssl-dev \
         patch \

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update -y -q && \
         libbrotli-dev \
         libbz2-dev \
         libc-ares-dev \
+        libc6-dbg \
         libcurl4-openssl-dev \
         libgflags-dev \
         libgmock-dev \

--- a/ci/docker/ubuntu-24.04-cpp-minimal.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp-minimal.dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -y -q && \
         curl \
         gdb \
         git \
+        libc6-dbg \
         libssl-dev \
         libcurl4-openssl-dev \
         patch \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -71,6 +71,7 @@ RUN apt-get update -y -q && \
         cmake \
         curl \
         gdb \
+        libc6-dbg \
         git \
         libbenchmark-dev \
         libboost-filesystem-dev \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -71,7 +71,6 @@ RUN apt-get update -y -q && \
         cmake \
         curl \
         gdb \
-        libc6-dbg \
         git \
         libbenchmark-dev \
         libboost-filesystem-dev \
@@ -79,6 +78,7 @@ RUN apt-get update -y -q && \
         libbrotli-dev \
         libbz2-dev \
         libc-ares-dev \
+        libc6-dbg \
         libcurl4-openssl-dev \
         libgflags-dev \
         libgmock-dev \


### PR DESCRIPTION
### Rationale for this change
Fixes #49776. `libc6-dbg` lets gdb resolve symbols inside `/lib*/ld-linux-x86-64.so.2`

### What changes are included in this PR?
Add `libc6-dbg` to the apt-install list in `ci/docker/ubuntu-24.04-cpp.dockerfile`.
Additionally add it also to `ci/docker/ubuntu-24.04-cpp-minimal.dockerfile`, `ci/docker/ubuntu-22.04-cpp.dockerfile`, `ci/docker/ubuntu-22.04-cpp-minimal.dockerfile`, `ci/docker/debian-13-cpp.dockerfile` and `ci/docker/debian-experimental-cpp.dockerfile`.

### Are these changes tested?
Yes, already used to symbolize the [#49767](https://github.com/apache/arrow/issues/49767#issuecomment-4520516388).

### Are there any user-facing changes?
No.
* GitHub Issue: #49776