### PR TITLE
GH-50041: [CI][Python] Make test_string_to_tzinfo_pytz_fallback more robust for platforms supporting lower case tz names

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -511,11 +511,16 @@ def test_string_to_tzinfo_prefer_zoneinfo_false():
     assert result == pytz.FixedOffset(90)
 
 
-@pytest.mark.skipif(
-    sys.platform == 'darwin', reason="macOS supports those lower-case names"
-)
 def test_string_to_tzinfo_pytz_fallback():
     pytz = pytest.importorskip("pytz")
+
+    try:
+        zoneinfo.ZoneInfo("europe/brussels")
+    except zoneinfo.ZoneInfoNotFoundError:
+        pass
+    else:
+        pytest.skip("zoneinfo supports lower-case names on this platform")
+
     result = pa.lib.string_to_tzinfo("europe/brussels")
     expected = pytz.timezone("Europe/Brussels")
     assert result == expected


### PR DESCRIPTION
### Rationale for this change

Fix failing test on CI as reported in https://github.com/apache/arrow/issues/50041, for a test added in https://github.com/apache/arrow/pull/49694

### What changes are included in this PR?

The test relies on the lower case "europe/brussels" time zone name not being recognized by `zoneinfo` (and it generally is by `pytz`). But apparently on some platforms, `zoneinfo` does accept this. Updating the test to first test this, and thus skip the test dynamically.
* GitHub Issue: #50041