### PR TITLE
GH-50037: [Python] test_table_uses_memory_pool flaky on macOS 14 job

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3966,6 +3966,7 @@ def test_table_uses_memory_pool():
     arr = pa.array(np.arange(N, dtype=np.int64))
     t = pa.table([arr, arr, arr], ['f0', 'f1', 'f2'])
 
+    gc.collect()
     prior_allocation = pa.total_allocated_bytes()
     x = t.to_pandas()
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3901,6 +3901,7 @@ def test_singleton_blocks_zero_copy():
 
 
 def _check_to_pandas_memory_unchanged(obj, **kwargs):
+    gc.collect()
     prior_allocation = pa.total_allocated_bytes()
     x = obj.to_pandas(**kwargs)  # noqa
 


### PR DESCRIPTION
### Rationale for this change
Fixes #50037 

### What changes are included in this PR?
Add `gc.collect()` before `prior_allocation = pa.total_allocated_bytes()` in `test_table_uses_memory_pool`
and also add to `_check_to_pandas_memory_unchanged` helper with the same pattern.
Same fix as #44793

### Are these changes tested?
Not reproduced locally yet.

### Are there any user-facing changes?
No.
* GitHub Issue: #50037