### PR TITLE
GH-50046: [CI][C++] Improve caching with apache/infrastructure-actions/stash and more general cache keys

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -119,11 +119,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@v5
+      - name: Restore Docker Volumes
+        uses: actions/cache/restore@v5
         with:
           path: .docker
-          key: ${{ matrix.image }}-${{ hashFiles('cpp/**') }}
+          key: ${{ matrix.image }}-${{ github.run_id }}
           restore-keys: ${{ matrix.image }}-
       - name: Setup Python on hosted runner
         if: |
@@ -149,6 +149,12 @@ jobs:
           sudo sysctl -w vm.mmap_rnd_bits=28
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ${{ matrix.image }}
+      - name: Save Docker Volumes
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: .docker
+          key: ${{ matrix.image }}-${{ github.run_id }}
       - name: Docker Push
         if: >-
           success() &&
@@ -254,11 +260,11 @@ jobs:
         id: ccache-info
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-macos-${{ matrix.macos-version }}-${{ hashFiles('cpp/**') }}
+          key: cpp-ccache-macos-${{ matrix.macos-version }}-${{ github.run_id }}
           restore-keys: cpp-ccache-macos-${{ matrix.macos-version }}-
       - name: Build
         run: |
@@ -283,6 +289,12 @@ jobs:
           sudo sysctl -w kern.corefile=/tmp/core.%N.%P
           ulimit -c unlimited  # must enable within the same shell
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
+      - name: Save ccache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-ccache-macos-${{ matrix.macos-version }}-${{ github.run_id }}
 
   windows:
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
@@ -361,11 +373,11 @@ jobs:
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ccache
-          key: cpp-ccache-${{ matrix.msystem_lower}}-${{ hashFiles('cpp/**') }}
+          key: cpp-ccache-${{ matrix.msystem_lower}}-${{ github.run_id }}
           restore-keys: cpp-ccache-${{ matrix.msystem_lower}}-
       - name: Build
         shell: msys2 {0}
@@ -405,3 +417,9 @@ jobs:
         shell: msys2 {0}
         run: |
           ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"
+      - name: Save ccache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ccache
+          key: cpp-ccache-${{ matrix.msystem_lower}}-${{ github.run_id }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -151,6 +151,7 @@ jobs:
           archery docker run ${{ matrix.image }}
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -284,6 +285,7 @@ jobs:
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
@@ -386,6 +388,7 @@ jobs:
           ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: ccache

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -63,6 +63,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -120,11 +121,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Restore Docker Volumes
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ${{ matrix.image }}-${{ github.run_id }}
-          restore-keys: ${{ matrix.image }}-
+          key: ${{ matrix.image }}
       - name: Setup Python on hosted runner
         if: |
           matrix.runs-on == 'ubuntu-latest'
@@ -152,10 +152,11 @@ jobs:
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ${{ matrix.image }}-${{ github.run_id }}
+          key: ${{ matrix.image }}
+          include-hidden-files: true
       - name: Docker Push
         if: >-
           success() &&
@@ -262,11 +263,10 @@ jobs:
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
       - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-macos-${{ matrix.macos-version }}-${{ github.run_id }}
-          restore-keys: cpp-ccache-macos-${{ matrix.macos-version }}-
+          key: cpp-ccache-macos-${{ matrix.macos-version }}
       - name: Build
         run: |
           if [ "${{ matrix.macos-version }}" = "15-intel" ]; then
@@ -286,10 +286,10 @@ jobs:
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-macos-${{ matrix.macos-version }}-${{ github.run_id }}
+          key: cpp-ccache-macos-${{ matrix.macos-version }}
       - name: Test
         shell: bash
         run: |
@@ -376,11 +376,10 @@ jobs:
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
       - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ccache
-          key: cpp-ccache-${{ matrix.msystem_lower}}-${{ github.run_id }}
-          restore-keys: cpp-ccache-${{ matrix.msystem_lower}}-
+          key: cpp-ccache-${{ matrix.msystem_lower}}
       - name: Build
         shell: msys2 {0}
         run: |
@@ -389,10 +388,10 @@ jobs:
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ccache
-          key: cpp-ccache-${{ matrix.msystem_lower}}-${{ github.run_id }}
+          key: cpp-ccache-${{ matrix.msystem_lower}}
       - name: Download Timezone Database
         if: matrix.msystem_upper == 'CLANG64'
         shell: bash

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -150,7 +150,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ${{ matrix.image }}
       - name: Save Docker Volumes
-        if: github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -282,6 +282,12 @@ jobs:
             export BUILD_WARNING_LEVEL=PRODUCTION
           fi
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
+      - name: Save ccache
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-ccache-macos-${{ matrix.macos-version }}-${{ github.run_id }}
       - name: Test
         shell: bash
         run: |
@@ -289,12 +295,6 @@ jobs:
           sudo sysctl -w kern.corefile=/tmp/core.%N.%P
           ulimit -c unlimited  # must enable within the same shell
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
-      - name: Save ccache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-macos-${{ matrix.macos-version }}-${{ github.run_id }}
 
   windows:
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
@@ -384,6 +384,12 @@ jobs:
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$NUMBER_OF_PROCESSORS
           ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
+      - name: Save ccache
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ccache
+          key: cpp-ccache-${{ matrix.msystem_lower}}-${{ github.run_id }}
       - name: Download Timezone Database
         if: matrix.msystem_upper == 'CLANG64'
         shell: bash
@@ -417,9 +423,3 @@ jobs:
         shell: msys2 {0}
         run: |
           ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"
-      - name: Save ccache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
-        with:
-          path: ccache
-          key: cpp-ccache-${{ matrix.msystem_lower}}-${{ github.run_id }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -124,7 +124,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ${{ matrix.image }}
+          key: cpp-${{ matrix.image }}
       - name: Setup Python on hosted runner
         if: |
           matrix.runs-on == 'ubuntu-latest'
@@ -155,7 +155,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ${{ matrix.image }}
+          key: cpp-${{ matrix.image }}
           include-hidden-files: true
       - name: Docker Push
         if: >-

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -150,7 +150,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ${{ matrix.image }}
       - name: Save Docker Volumes
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -284,7 +284,7 @@ jobs:
           fi
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Save ccache
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -386,7 +386,7 @@ jobs:
           export CMAKE_BUILD_PARALLEL_LEVEL=$NUMBER_OF_PROCESSORS
           ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
       - name: Save ccache
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -171,6 +171,7 @@ jobs:
           archery docker run ${{ matrix.run-options || '' }} ${{ matrix.image }}
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -256,6 +257,7 @@ jobs:
           archery docker run cpp-jni
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -361,6 +363,7 @@ jobs:
           ../minimal_build.build/arrow-example
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: ccache
@@ -413,6 +416,7 @@ jobs:
           archery docker run ubuntu-cpp-odbc
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -512,6 +516,7 @@ jobs:
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
@@ -662,6 +667,7 @@ jobs:
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -142,11 +142,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Restore Docker Volumes
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: extra-${{ matrix.image }}-${{ github.run_id }}
-          restore-keys: extra-${{ matrix.image }}-
+          key: extra-${{ matrix.image }}
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -172,10 +171,11 @@ jobs:
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: extra-${{ matrix.image }}-${{ github.run_id }}
+          key: extra-${{ matrix.image }}
+          include-hidden-files: true
       - name: Docker Push
         if: >-
           success() &&
@@ -211,6 +211,8 @@ jobs:
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
     timeout-minutes: 240
     permissions:
+      actions: read
+      contents: read
       # This is for using GitHub Packages for vcpkg cache
       packages: write
     strategy:
@@ -235,11 +237,10 @@ jobs:
         run: |
           ci/scripts/util_free_space.sh
       - name: Restore Docker Volumes
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: jni-${{ matrix.platform.runs-on }}-${{ github.run_id }}
-          restore-keys: jni-${{ matrix.platform.runs-on }}-
+          key: jni-${{ matrix.platform.runs-on }}
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -258,10 +259,11 @@ jobs:
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: jni-${{ matrix.platform.runs-on }}-${{ github.run_id }}
+          key: jni-${{ matrix.platform.runs-on }}
+          include-hidden-files: true
       - name: Docker Push
         if: >-
           success() &&
@@ -315,11 +317,10 @@ jobs:
         run: |
           echo "CCACHE_DIR=${PWD}/ccache" >> ${GITHUB_ENV}
       - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ccache
-          key: jni-macos-${{ github.run_id }}
-          restore-keys: jni-macos-
+          key: jni-macos
       - name: CMake
         run: |
           cmake \
@@ -364,10 +365,10 @@ jobs:
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ccache
-          key: jni-macos-${{ github.run_id }}
+          key: jni-macos
 
   odbc-linux:
     needs: check-labels
@@ -394,11 +395,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Restore Docker Volumes
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ubuntu-cpp-odbc-${{ github.run_id }}
-          restore-keys: ubuntu-cpp-odbc-
+          key: ubuntu-cpp-odbc
       - name: Setup Python on hosted runner
         uses: actions/setup-python@v6
         with:
@@ -417,10 +417,11 @@ jobs:
       - name: Save Docker Volumes
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ubuntu-cpp-odbc-${{ github.run_id }}
+          key: ubuntu-cpp-odbc
+          include-hidden-files: true
       - name: Docker Push
         if: >-
           success() &&
@@ -493,11 +494,10 @@ jobs:
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
       - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ github.run_id }}
-          restore-keys: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-
+          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}
       - name: Build
         run: |
           # Homebrew uses /usr/local as prefix. So packages
@@ -517,10 +517,10 @@ jobs:
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ github.run_id }}
+          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -576,6 +576,8 @@ jobs:
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
     timeout-minutes: 240
     permissions:
+      actions: read
+      contents: read
       packages: write
     env:
       ARROW_BUILD_SHARED: ON
@@ -625,11 +627,10 @@ jobs:
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
       - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-windows-x64-${{ github.run_id }}
-          restore-keys: cpp-odbc-ccache-windows-x64-
+          key: cpp-odbc-ccache-windows-x64
       - name: Checkout vcpkg
         uses: actions/checkout@v6
         with:
@@ -668,10 +669,10 @@ jobs:
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-windows-x64-${{ github.run_id }}
+          key: cpp-odbc-ccache-windows-x64
       - name: Register Flight SQL ODBC Driver
         shell: cmd
         run: |

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -169,7 +169,7 @@ jobs:
           fi
           archery docker run ${{ matrix.run-options || '' }} ${{ matrix.image }}
       - name: Save Docker Volumes
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -257,7 +257,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run cpp-jni
       - name: Save Docker Volumes
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -363,7 +363,7 @@ jobs:
           cd cpp/examples/minimal_build
           ../minimal_build.build/arrow-example
       - name: Save ccache
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -415,7 +415,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ubuntu-cpp-odbc
       - name: Save Docker Volumes
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -515,7 +515,7 @@ jobs:
           export CXXFLAGS="$CXXFLAGS -I$ODBC_INCLUDE_DIR"
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Save ccache
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -667,7 +667,7 @@ jobs:
           set VCPKG_ROOT=%VCPKG_ROOT_KEEP%
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Save ccache
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -141,11 +141,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@v5
+      - name: Restore Docker Volumes
+        uses: actions/cache/restore@v5
         with:
           path: .docker
-          key: extra-${{ matrix.image }}-${{ hashFiles('cpp/**') }}
+          key: extra-${{ matrix.image }}-${{ github.run_id }}
           restore-keys: extra-${{ matrix.image }}-
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -169,6 +169,12 @@ jobs:
             done
           fi
           archery docker run ${{ matrix.run-options || '' }} ${{ matrix.image }}
+      - name: Save Docker Volumes
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: .docker
+          key: extra-${{ matrix.image }}-${{ github.run_id }}
       - name: Docker Push
         if: >-
           success() &&
@@ -227,11 +233,11 @@ jobs:
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
-      - name: Cache Docker Volumes
-        uses: actions/cache@v5
+      - name: Restore Docker Volumes
+        uses: actions/cache/restore@v5
         with:
           path: .docker
-          key: jni-${{ matrix.platform.runs-on }}-${{ hashFiles('cpp/**') }}
+          key: jni-${{ matrix.platform.runs-on }}-${{ github.run_id }}
           restore-keys: jni-${{ matrix.platform.runs-on }}-
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -248,6 +254,12 @@ jobs:
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run cpp-jni
+      - name: Save Docker Volumes
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: .docker
+          key: jni-${{ matrix.platform.runs-on }}-${{ github.run_id }}
       - name: Docker Push
         if: >-
           success() &&
@@ -300,11 +312,11 @@ jobs:
       - name: Prepare ccache
         run: |
           echo "CCACHE_DIR=${PWD}/ccache" >> ${GITHUB_ENV}
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ccache
-          key: jni-macos-${{ hashFiles('cpp/**') }}
+          key: jni-macos-${{ github.run_id }}
           restore-keys: jni-macos-
       - name: CMake
         run: |
@@ -347,6 +359,12 @@ jobs:
           cmake --build cpp/examples/minimal_build.build
           cd cpp/examples/minimal_build
           ../minimal_build.build/arrow-example
+      - name: Save ccache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ccache
+          key: jni-macos-${{ github.run_id }}
 
   odbc-linux:
     needs: check-labels
@@ -372,11 +390,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@v5
+      - name: Restore Docker Volumes
+        uses: actions/cache/restore@v5
         with:
           path: .docker
-          key: ubuntu-cpp-odbc-${{ hashFiles('cpp/**') }}
+          key: ubuntu-cpp-odbc-${{ github.run_id }}
           restore-keys: ubuntu-cpp-odbc-
       - name: Setup Python on hosted runner
         uses: actions/setup-python@v6
@@ -393,6 +411,12 @@ jobs:
           sudo sysctl -w vm.mmap_rnd_bits=28
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ubuntu-cpp-odbc
+      - name: Save Docker Volumes
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: .docker
+          key: ubuntu-cpp-odbc-${{ github.run_id }}
       - name: Docker Push
         if: >-
           success() &&
@@ -464,11 +488,11 @@ jobs:
         id: ccache-info
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v5.0.2
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ hashFiles('cpp/**') }}
+          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ github.run_id }}
           restore-keys: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-
       - name: Build
         run: |
@@ -530,6 +554,12 @@ jobs:
           sudo mkdir -p /Library/ODBC
           sudo chown -R $USER /Library/ODBC
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
+      - name: Save ccache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ github.run_id }}
 
   odbc-msvc:
     needs: check-labels
@@ -589,11 +619,11 @@ jobs:
         shell: bash
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-windows-x64-${{ hashFiles('cpp/**') }}
+          key: cpp-odbc-ccache-windows-x64-${{ github.run_id }}
           restore-keys: cpp-odbc-ccache-windows-x64-
       - name: Checkout vcpkg
         uses: actions/checkout@v6
@@ -697,6 +727,12 @@ jobs:
 
           Write-Error "ODBC DLL not found"
           exit 1
+      - name: Save ccache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-odbc-ccache-windows-x64-${{ github.run_id }}
 
   odbc-nightly:
     needs: odbc-msvc

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -145,7 +145,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: extra-${{ matrix.image }}
+          key: cpp-extra-${{ matrix.image }}
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -174,7 +174,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: extra-${{ matrix.image }}
+          key: cpp-extra-${{ matrix.image }}
           include-hidden-files: true
       - name: Docker Push
         if: >-

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -170,7 +170,7 @@ jobs:
           fi
           archery docker run ${{ matrix.run-options || '' }} ${{ matrix.image }}
       - name: Save Docker Volumes
-        if: github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -255,7 +255,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run cpp-jni
       - name: Save Docker Volumes
-        if: github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -360,7 +360,7 @@ jobs:
           cd cpp/examples/minimal_build
           ../minimal_build.build/arrow-example
       - name: Save ccache
-        if: github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v5
         with:
           path: ccache
@@ -412,7 +412,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ubuntu-cpp-odbc
       - name: Save Docker Volumes
-        if: github.ref == 'refs/heads/main'
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         uses: actions/cache/save@v5
         with:
           path: .docker
@@ -510,6 +510,12 @@ jobs:
           export ARROW_CMAKE_ARGS="-DODBC_INCLUDE_DIR=$ODBC_INCLUDE_DIR"
           export CXXFLAGS="$CXXFLAGS -I$ODBC_INCLUDE_DIR"
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
+      - name: Save ccache
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ github.run_id }}
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -554,12 +560,6 @@ jobs:
           sudo mkdir -p /Library/ODBC
           sudo chown -R $USER /Library/ODBC
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
-      - name: Save ccache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ github.run_id }}
 
   odbc-msvc:
     needs: check-labels
@@ -660,6 +660,12 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           set VCPKG_ROOT=%VCPKG_ROOT_KEEP%
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
+      - name: Save ccache
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-odbc-ccache-windows-x64-${{ github.run_id }}
       - name: Register Flight SQL ODBC Driver
         shell: cmd
         run: |
@@ -727,12 +733,6 @@ jobs:
 
           Write-Error "ODBC DLL not found"
           exit 1
-      - name: Save ccache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-windows-x64-${{ github.run_id }}
 
   odbc-nightly:
     needs: odbc-msvc

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -120,6 +120,12 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
+      - name: Save ccache
+        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-ccache-windows-${{ inputs.arch }}-${{ github.run_id }}
       - name: Test
         shell: cmd
         env:
@@ -130,9 +136,3 @@ jobs:
           # For ORC
           set TZDIR=%MSYS2_LOCATION%\usr\share\zoneinfo
           bash -c "ci/scripts/cpp_test.sh $(pwd) $(pwd)/build"
-      - name: Save ccache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-windows-${{ inputs.arch }}-${{ github.run_id }}

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -107,11 +107,11 @@ jobs:
         shell: bash
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: actions/cache/restore@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-windows-${{ inputs.arch }}-${{ hashFiles('cpp/**') }}
+          key: cpp-ccache-windows-${{ inputs.arch }}-${{ github.run_id }}
           restore-keys: cpp-ccache-windows-${{ inputs.arch }}-
       - name: Build
         shell: cmd
@@ -130,3 +130,9 @@ jobs:
           # For ORC
           set TZDIR=%MSYS2_LOCATION%\usr\share\zoneinfo
           bash -c "ci/scripts/cpp_test.sh $(pwd) $(pwd)/build"
+      - name: Save ccache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-ccache-windows-${{ inputs.arch }}-${{ github.run_id }}

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -34,6 +34,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -108,11 +109,10 @@ jobs:
         run: |
           echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
       - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-windows-${{ inputs.arch }}-${{ github.run_id }}
-          restore-keys: cpp-ccache-windows-${{ inputs.arch }}-
+          key: cpp-ccache-windows-${{ inputs.arch }}
       - name: Build
         shell: cmd
         env:
@@ -123,10 +123,10 @@ jobs:
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
-        uses: actions/cache/save@v5
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-windows-${{ inputs.arch }}-${{ github.run_id }}
+          key: cpp-ccache-windows-${{ inputs.arch }}
       - name: Test
         shell: cmd
         env:

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -121,7 +121,7 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Save ccache
-        if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -122,6 +122,7 @@ jobs:
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Save ccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}


### PR DESCRIPTION
### Rationale for this change

C++ CI jobs currently key `ccache`/Docker volume caches with `hashFiles('cpp/**')`. This creates new immutable GitHub Actions cache entries whenever any C++ file changes, even though `ccache` already handles per-file invalidation internally.

Recent CI logs show that when caches are restored, C++ jobs get high ccache hit rates, but GitHub cache restore misses are common and cause large CI runtime regressions.

### What changes are included in this PR?

* Replace `actions/cache` with `apache/infrastructure-actions/stash/restore` and `apache/infrastructure-actions/stash/save`.
* Remove `hashFiles('cpp/**')` from cache keys.
* Use stable restore prefixes per job/config.

### Are these changes tested?

By CI?

### Are there any user-facing changes?

CI users should see faster builds..

* GitHub Issue: #50046