### PR TITLE
GH-50052: [CI][C++] Bump vcpkg to newest version

### DIFF
--- a/.env
+++ b/.env
@@ -92,11 +92,11 @@ TZ=UTC
 # Used through compose.yaml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the
 # docker tags more readable.
-VCPKG="66c0373dc7fca549e5803087b9487edfe3aca0a1"    # 2026.01.16 Release
+VCPKG="9b965a116838c6cdcd36bca60d1b81b030c8ab8d"    # 2026.05.27 (not release, upstream commit)
 
 # This must be updated when we update
 # ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-03-04
-PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-03-04
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-05-27
+PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-05-27

--- a/ci/docker/cpp-jni.dockerfile
+++ b/ci/docker/cpp-jni.dockerfile
@@ -58,6 +58,11 @@ ARG ccache=4.1
 COPY ci/scripts/install_ccache.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ccache.sh ${ccache} /usr/local
 
+# Install bison (> 3.7 required for building thrift)
+ARG bison=3.7.6
+COPY ci/scripts/install_bison.sh arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_bison.sh ${bison} /usr/local
+
 # Install vcpkg
 ARG vcpkg
 COPY ci/vcpkg/*.patch \

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -50,6 +50,11 @@ ARG ccache=4.1
 COPY ci/scripts/install_ccache.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ccache.sh ${ccache} /usr/local
 
+# Install newer bison (required for building thrift)
+ARG bison=3.7.6
+COPY ci/scripts/install_bison.sh arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_bison.sh ${bison} /usr/local
+
 # Install vcpkg
 ARG vcpkg
 COPY ci/vcpkg/*.patch \

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -50,7 +50,7 @@ ARG ccache=4.1
 COPY ci/scripts/install_ccache.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ccache.sh ${ccache} /usr/local
 
-# Install newer bison (required for building thrift)
+# Install bison (> 3.7 required for building thrift)
 ARG bison=3.7.6
 COPY ci/scripts/install_bison.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_bison.sh ${bison} /usr/local

--- a/ci/scripts/install_bison.sh
+++ b/ci/scripts/install_bison.sh
@@ -33,7 +33,7 @@ url="https://ftp.gnu.org/gnu/bison/bison-${version}.tar.gz"
 wget -q "${url}" -O - | tar -xzf - --directory /tmp/bison --strip-components=1
 
 pushd /tmp/bison
-./configure --prefix=${prefix}
+./configure --prefix="${prefix}"
 make -j$(nproc)
 make install
 popd

--- a/ci/scripts/install_bison.sh
+++ b/ci/scripts/install_bison.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <version> <prefix>"
+  exit 1
+fi
+
+version=$1
+prefix=$2
+
+mkdir -p /tmp/bison
+url="https://ftp.gnu.org/gnu/bison/bison-${version}.tar.gz"
+
+wget -q "${url}" -O - | tar -xzf - --directory /tmp/bison --strip-components=1
+
+pushd /tmp/bison
+./configure --prefix=${prefix}
+make -j$(nproc)
+make install
+popd
+
+rm -rf /tmp/bison

--- a/ci/vcpkg/ports.patch
+++ b/ci/vcpkg/ports.patch
@@ -1,17 +1,20 @@
 diff --git a/ports/curl/portfile.cmake b/ports/curl/portfile.cmake
-index 6788bc7b7f..6b689dedf0 100644
+index 73f5aece46..68cdb3966f 100644
 --- a/ports/curl/portfile.cmake
 +++ b/ports/curl/portfile.cmake
-@@ -83,10 +83,13 @@ vcpkg_cmake_configure(
+@@ -89,6 +89,8 @@ vcpkg_cmake_configure(
          -DENABLE_CURL_MANUAL=OFF
          -DIMPORT_LIB_SUFFIX=   # empty
          -DSHARE_LIB_OBJECT=OFF
 +        -DCURL_CA_PATH=none
 +        -DCURL_CA_BUNDLE=none
+         -DCURL_USE_CMAKECONFIG=ON
          -DCURL_USE_PKGCONFIG=ON
          -DCMAKE_DISABLE_FIND_PACKAGE_Perl=ON
-     MAYBE_UNUSED_VARIABLES
-         PKG_CONFIG_EXECUTABLE
+@@ -98,6 +100,7 @@ vcpkg_cmake_configure(
+         VCPKG_LOCK_FIND_PACKAGE_Libidn2
+         VCPKG_LOCK_FIND_PACKAGE_Libssh2
+         VCPKG_LOCK_FIND_PACKAGE_NGHTTP2
 +        ${EXTRA_ARGS_DEBUG}
  )
  vcpkg_cmake_install()


### PR DESCRIPTION
### Rationale for this change

We require newer vcpkg for other PRs like upgrading xsimd, see:
- https://github.com/apache/arrow/issues/49921

### What changes are included in this PR?

- Update vcpkg version
- Update required patches
- Manually install required bison for newer Thrift from vcpkg

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?

No

* GitHub Issue: #50052