### PR TITLE
GH-50054: [C++][IPC] Validate indices buffer size in ReadSparseCOOIndex

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -2294,10 +2294,9 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
                                      /*allow_short_read=*/false));
   std::vector<int64_t> indices_shape({non_zero_length, ndim});
   int64_t indices_minimum_bytes;
-  if (MultiplyWithOverflow(non_zero_length, ndim,
-                                            &indices_minimum_bytes) ||
+  if (MultiplyWithOverflow(non_zero_length, ndim, &indices_minimum_bytes) ||
       MultiplyWithOverflow(indices_minimum_bytes, indices_elsize,
-                                            &indices_minimum_bytes) ||
+                           &indices_minimum_bytes) ||
       indices_minimum_bytes > indices_buffer->length()) {
     return Status::Invalid("shape is inconsistent to the size of indices buffer");
   }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -2294,9 +2294,9 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
                                      /*allow_short_read=*/false));
   std::vector<int64_t> indices_shape({non_zero_length, ndim});
   int64_t indices_minimum_bytes;
-  if (arrow::internal::MultiplyWithOverflow(non_zero_length, ndim,
+  if (MultiplyWithOverflow(non_zero_length, ndim,
                                             &indices_minimum_bytes) ||
-      arrow::internal::MultiplyWithOverflow(indices_minimum_bytes, indices_elsize,
+      MultiplyWithOverflow(indices_minimum_bytes, indices_elsize,
                                             &indices_minimum_bytes) ||
       indices_minimum_bytes > indices_buffer->length()) {
     return Status::Invalid("shape is inconsistent to the size of indices buffer");

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -2293,6 +2293,14 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
                         file->ReadAt(indices_buffer->offset(), indices_buffer->length(),
                                      /*allow_short_read=*/false));
   std::vector<int64_t> indices_shape({non_zero_length, ndim});
+  int64_t indices_minimum_bytes;
+  if (arrow::internal::MultiplyWithOverflow(non_zero_length, ndim,
+                                            &indices_minimum_bytes) ||
+      arrow::internal::MultiplyWithOverflow(indices_minimum_bytes, indices_elsize,
+                                            &indices_minimum_bytes) ||
+      indices_minimum_bytes > indices_buffer->length()) {
+    return Status::Invalid("shape is inconsistent to the size of indices buffer");
+  }
   auto* indices_strides = sparse_index->indicesStrides();
   std::vector<int64_t> strides(2);
   if (indices_strides && indices_strides->size() > 0) {


### PR DESCRIPTION
### Rationale for this change

`ReadSparseCOOIndex` builds the indices `Tensor` of shape `{non_zero_length, ndim}` over `indicesBuffer` with no size check, unlike the sibling `ReadSparseCSXIndex`. A crafted COO message with a large `non_zero_length` and a small buffer produces an index tensor that overruns its buffer, giving an out-of-bounds read when the sparse tensor is consumed (for example, converted to dense). A `non_zero_length` near `INT64_MAX` also overflows the `non_zero_length * ndim * byte_width` size product.

### What changes are included in this PR?

A minimum-size guard on `indicesBuffer` in `ReadSparseCOOIndex`, mirroring the existing check in `ReadSparseCSXIndex` and using `MultiplyWithOverflow` for the size computation.

### Are these changes tested?

The guard is a no-op for the valid inputs covered by the round-trip tests in `cpp/src/arrow/ipc/tensor_test.cc`; the rejection and overflow behaviour was checked against a standalone reproducer of the size computation.

### Are there any user-facing changes?

Reading a malformed sparse COO tensor message now returns `Status::Invalid` instead of constructing an out-of-bounds index tensor.

**This PR contains a "Critical Fix".** A malformed IPC SparseTensor (COO) message could trigger an out-of-bounds read when the resulting sparse tensor is consumed.
* GitHub Issue: #50054