### PR TITLE
GH-50057: [C++] Avoid signed overflow in Decimal FromString exponent

### DIFF
--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -884,11 +884,9 @@ Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out
     // parsed_scale = -exponent + fractional_digits, computed with overflow
     // detection: an exponent of INT32_MIN ("0E-2147483648") makes the negation,
     // and a near-INT32_MIN exponent the addition, signed-overflow UB otherwise.
-    if (internal::SubtractWithOverflow(
-            static_cast<int32_t>(dec.fractional_digits.size()), dec.exponent,
-            &parsed_scale)) {
-      return Status::Invalid("The string '", s, "' cannot be represented as ",
-                             type_name);
+    if (internal::SubtractWithOverflow(static_cast<int32_t>(dec.fractional_digits.size()),
+                                       dec.exponent, &parsed_scale)) {
+      return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
     }
   } else {
     parsed_scale = static_cast<int32_t>(dec.fractional_digits.size());
@@ -954,11 +952,9 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
     // parsed_scale = -exponent + fractional_digits, computed with overflow
     // detection: an exponent of INT32_MIN ("0E-2147483648") makes the negation,
     // and a near-INT32_MIN exponent the addition, signed-overflow UB otherwise.
-    if (internal::SubtractWithOverflow(
-            static_cast<int32_t>(dec.fractional_digits.size()), dec.exponent,
-            &parsed_scale)) {
-      return Status::Invalid("The string '", s, "' cannot be represented as ",
-                             type_name);
+    if (internal::SubtractWithOverflow(static_cast<int32_t>(dec.fractional_digits.size()),
+                                       dec.exponent, &parsed_scale)) {
+      return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
     }
   } else {
     parsed_scale = static_cast<int32_t>(dec.fractional_digits.size());

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -881,9 +881,15 @@ Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out
 
   int32_t parsed_scale = 0;
   if (dec.has_exponent) {
-    auto adjusted_exponent = dec.exponent;
-    parsed_scale =
-        -adjusted_exponent + static_cast<int32_t>(dec.fractional_digits.size());
+    // parsed_scale = -exponent + fractional_digits, computed with overflow
+    // detection: an exponent of INT32_MIN ("0E-2147483648") makes the negation,
+    // and a near-INT32_MIN exponent the addition, signed-overflow UB otherwise.
+    if (internal::SubtractWithOverflow(
+            static_cast<int32_t>(dec.fractional_digits.size()), dec.exponent,
+            &parsed_scale)) {
+      return Status::Invalid("The string '", s, "' cannot be represented as ",
+                             type_name);
+    }
   } else {
     parsed_scale = static_cast<int32_t>(dec.fractional_digits.size());
   }
@@ -945,9 +951,15 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
 
   int32_t parsed_scale = 0;
   if (dec.has_exponent) {
-    auto adjusted_exponent = dec.exponent;
-    parsed_scale =
-        -adjusted_exponent + static_cast<int32_t>(dec.fractional_digits.size());
+    // parsed_scale = -exponent + fractional_digits, computed with overflow
+    // detection: an exponent of INT32_MIN ("0E-2147483648") makes the negation,
+    // and a near-INT32_MIN exponent the addition, signed-overflow UB otherwise.
+    if (internal::SubtractWithOverflow(
+            static_cast<int32_t>(dec.fractional_digits.size()), dec.exponent,
+            &parsed_scale)) {
+      return Status::Invalid("The string '", s, "' cannot be represented as ",
+                             type_name);
+    }
   } else {
     parsed_scale = static_cast<int32_t>(dec.fractional_digits.size());
   }

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -135,8 +135,8 @@ class DecimalFromStringTest : public ::testing::Test {
   void TestInvalidInput() {
     for (const std::string invalid_value :
          {"-", "0.0.0", "0-13-32", "a", "-23092.235-", "-+23092.235", "+-23092.235",
-          "00a", "1e1a", "0.00123D/3", "1.23eA8", "1.23E+3A", "-1.23E--5",
-          "1.2345E+++07", "0E-2147483648", "1.0E-2147483647"}) {
+          "00a", "1e1a", "0.00123D/3", "1.23eA8", "1.23E+3A", "-1.23E--5", "1.2345E+++07",
+          "0E-2147483648", "1.0E-2147483647"}) {
       ARROW_SCOPED_TRACE("invalid_value = '", invalid_value, "'");
       ASSERT_RAISES(Invalid, DecimalType::FromString(invalid_value));
     }

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -136,7 +136,7 @@ class DecimalFromStringTest : public ::testing::Test {
     for (const std::string invalid_value :
          {"-", "0.0.0", "0-13-32", "a", "-23092.235-", "-+23092.235", "+-23092.235",
           "00a", "1e1a", "0.00123D/3", "1.23eA8", "1.23E+3A", "-1.23E--5",
-          "1.2345E+++07"}) {
+          "1.2345E+++07", "0E-2147483648", "1.0E-2147483647"}) {
       ARROW_SCOPED_TRACE("invalid_value = '", invalid_value, "'");
       ASSERT_RAISES(Invalid, DecimalType::FromString(invalid_value));
     }


### PR DESCRIPTION
### Rationale for this change

`Decimal{32,64,128,256}::FromString` parse the exponent as `int32_t`, so a string like `0E-2147483648` reaches `DecimalFromString`/`SimpleDecimalFromString` with `dec.exponent == INT32_MIN` and negating it is UB:

```
decimal.cc: runtime error: negation of -2147483648 cannot be represented in type 'int32_t' (aka 'int')
```

A near-`INT32_MIN` exponent overflows the `-exponent + fractional_digits` addition the same way. Both helpers are reachable from the CSV/JSON readers parsing decimal columns.

### What changes are included in this PR?

Compute the scale via `internal::SubtractWithOverflow` and reject the unrepresentable exponents with `Status::Invalid`, in both helpers.

### Are these changes tested?

Yes, `0E-2147483648` and `1.0E-2147483647` added to `DecimalFromStringTest.InvalidInput` (runs for Decimal32/64/128/256).

### Are there any user-facing changes?

No.
* GitHub Issue: #50057