### PR TITLE
GH-50292: [C++][Parquet] Avoid int64 overflow in CheckReadRangeOrThrow

### DIFF
--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -336,10 +336,13 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
 
     /// Page index location must be within the range of the read range.
     int64_t index_end = 0;
-    if (::arrow::internal::AddWithOverflow(index_location.offset, index_location.length,
+    int64_t range_end = 0;
+    if (index_location.offset < index_read_range->offset ||
+        ::arrow::internal::AddWithOverflow(index_location.offset, index_location.length,
                                            &index_end) ||
-        index_location.offset < index_read_range->offset ||
-        index_end > index_read_range->offset + index_read_range->length) {
+        ::arrow::internal::AddWithOverflow(index_read_range->offset,
+                                           index_read_range->length, &range_end) ||
+        index_end > range_end) {
       throw ParquetException("Page index location [offset:", index_location.offset,
                              ",length:", index_location.length,
                              "] is out of range from previous WillNeed request [offset:",

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -335,9 +335,11 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
     }
 
     /// Page index location must be within the range of the read range.
-    if (index_location.offset < index_read_range->offset ||
-        index_location.offset + index_location.length >
-            index_read_range->offset + index_read_range->length) {
+    int64_t index_end = 0;
+    if (::arrow::internal::AddWithOverflow(index_location.offset, index_location.length,
+                                           &index_end) ||
+        index_location.offset < index_read_range->offset ||
+        index_end > index_read_range->offset + index_read_range->length) {
       throw ParquetException("Page index location [offset:", index_location.offset,
                              ",length:", index_location.length,
                              "] is out of range from previous WillNeed request [offset:",


### PR DESCRIPTION
CheckReadRangeOrThrow adds index_location.offset + length unchecked, so a column-chunk page-index location near INT64_MAX wraps past the bounds check and yields an out-of-range buffer offset at read time; guard it with AddWithOverflow as merge_range already does.
* GitHub Issue: #50292