### PR TITLE
GH-50063: [C++] Validate buffer size for row-major tensors

### DIFF
--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -216,6 +216,7 @@ Status ValidateTensorParameters(const std::shared_ptr<DataType>& type,
     std::vector<int64_t> tmp_strides;
     RETURN_NOT_OK(ComputeRowMajorStrides(checked_cast<const FixedWidthType&>(*type),
                                          shape, &tmp_strides));
+    RETURN_NOT_OK(CheckTensorStridesValidity(data, shape, tmp_strides, type));
   }
   if (dim_names.size() > shape.size()) {
     return Status::Invalid("too many dim_names are supplied");

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -268,6 +268,9 @@ TEST(TestTensor, MakeFailureCases) {
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
                                       {sizeof(double) * 12, sizeof(double)}));
 
+  // row-major (implicit strides) shape larger than the backing buffer
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {3, 100}));
+
   // too many dim_names are supplied
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {}, {"foo", "bar", "baz"}));
 }


### PR DESCRIPTION
### Rationale for this change

`ValidateTensorParameters` in cpp/src/arrow/tensor.cc only runs the `CheckTensorStridesValidity` buffer-overrun guard when strides are passed explicitly. With implicit (row-major) strides it computes strides for overflow but never checks the data buffer is large enough for the shape, so a tensor whose shape exceeds its buffer is accepted and later read out of bounds. This is reachable from IPC `ReadTensor`, where the shape comes from the flatbuffer and the body size is independent of it.

### What changes are included in this PR?

Run `CheckTensorStridesValidity` on the computed row-major strides too.

### Are these changes tested?

Added a case to `TestTensor.MakeFailureCases`.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** Crafted IPC tensor metadata (or any caller building a row-major tensor over an undersized buffer) bypassed the bounds check, enabling an out-of-bounds read.
* GitHub Issue: #50063