### PR TITLE
GH-50065: [Packaging][CI][C++] Drop unused libboost-system-dev

### DIFF
--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -53,7 +53,6 @@ RUN apt-get update -y -q && \
         git \
         libbenchmark-dev \
         libboost-filesystem-dev \
-        libboost-system-dev \
         libbrotli-dev \
         libbz2-dev \
         libc6-dbg \

--- a/ci/docker/debian-experimental-cpp.dockerfile
+++ b/ci/docker/debian-experimental-cpp.dockerfile
@@ -45,7 +45,6 @@ RUN if [ -n "${gcc}" ]; then \
         git \
         libbenchmark-dev \
         libboost-filesystem-dev \
-        libboost-system-dev \
         libbrotli-dev \
         libbz2-dev \
         libc-ares-dev \

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -73,7 +73,6 @@ RUN apt-get update -y -q && \
         git \
         libbenchmark-dev \
         libboost-filesystem-dev \
-        libboost-system-dev \
         libbrotli-dev \
         libbz2-dev \
         libc-ares-dev \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -74,7 +74,6 @@ RUN apt-get update -y -q && \
         git \
         libbenchmark-dev \
         libboost-filesystem-dev \
-        libboost-system-dev \
         libbrotli-dev \
         libbz2-dev \
         libc-ares-dev \

--- a/cpp/examples/minimal_build/system_dependency.dockerfile
+++ b/cpp/examples/minimal_build/system_dependency.dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -y -q && \
       cmake \
       libboost-filesystem-dev \
       libboost-regex-dev \
-      libboost-system-dev \
       libbrotli-dev \
       libbz2-dev \
       libgflags-dev \

--- a/cpp/subprojects/boost.wrap
+++ b/cpp/subprojects/boost.wrap
@@ -24,4 +24,3 @@ method = cmake
 
 [provide]
 boost_filesystem = boost_filesystem_dep
-boost_system = boost_system_dep

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
@@ -45,7 +45,6 @@ RUN \
     gi-docgen \
     git \
     libboost-filesystem-dev \
-    libboost-system-dev \
     libbrotli-dev \
     libbz2-dev \
     libc-ares-dev \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-forky/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-forky/Dockerfile
@@ -46,7 +46,6 @@ RUN \
     gi-docgen \
     git \
     libboost-filesystem-dev \
-    libboost-system-dev \
     libbrotli-dev \
     libbz2-dev \
     libc-ares-dev \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-trixie/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-trixie/Dockerfile
@@ -47,7 +47,6 @@ RUN \
     gi-docgen \
     git \
     libboost-filesystem-dev \
-    libboost-system-dev \
     libbrotli-dev \
     libbz2-dev \
     libc-ares-dev \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-jammy/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-jammy/Dockerfile
@@ -40,7 +40,6 @@ RUN \
     gi-docgen \
     git \
     libboost-filesystem-dev \
-    libboost-system-dev \
     libbrotli-dev \
     libbz2-dev \
     libc-ares-dev \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-noble/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-noble/Dockerfile
@@ -40,7 +40,6 @@ RUN \
     gi-docgen \
     git \
     libboost-filesystem-dev \
-    libboost-system-dev \
     libbrotli-dev \
     libbz2-dev \
     libc-ares-dev \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-resolute/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-resolute/Dockerfile
@@ -40,7 +40,6 @@ RUN \
     gi-docgen \
     git \
     libboost-filesystem-dev \
-    libboost-system-dev \
     libbrotli-dev \
     libbz2-dev \
     libc-ares-dev \

--- a/dev/tasks/linux-packages/apache-arrow/debian/control.in
+++ b/dev/tasks/linux-packages/apache-arrow/debian/control.in
@@ -9,7 +9,6 @@ Build-Depends:
   git,
   gobject-introspection,
   libboost-filesystem-dev,
-  libboost-system-dev,
   libbrotli-dev,
   libbz2-dev,
   libc-ares-dev,


### PR DESCRIPTION
### Rationale for this change

`debian-forky-arm64` and `debian-forky-amd64` Packaging Build jobs failing with `Error: Unable to locate package libboost-system-dev`.

### What changes are included in this PR?
Remove `libboost-system-dev` from `debian/control.in`
Remove apt-install line `    libboost-system-dev \` from apt Dockerfiles (debian-bookworm, debian-forky, debian-trixie, ubuntu-jammy, ubuntu-noble, ubuntu-resolute), C++ CI Dockerfiles (debian-13-cpp, debian-experimental-cpp, ubuntu-22.04-cpp, ubuntu-24.04-cpp) and from `cpp/examples/minimal_build/system_dependency.dockerfile`.
Remove unused `[provide]` `boost_system` reference from `cpp/subprojects/boost.wrap`.

### Are these changes tested?
By Packaging CI, jobs should pass.

### Are there any user-facing changes?
No.
* GitHub Issue: #50065