### PR TITLE
GH-50067: [C++] bounds-check Feather V1 column buffer slices

### DIFF
--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -272,6 +272,10 @@ class ReaderV1 : public Reader {
                     std::shared_ptr<ArrayData>* out) {
     std::vector<std::shared_ptr<Buffer>> buffers;
 
+    if (meta->length() < 0 || meta->null_count() < 0) {
+      return Status::Invalid("Feather file contains a column with negative length");
+    }
+
     // Buffer data from the source (may or may not perform a copy depending on
     // input source)
     ARROW_ASSIGN_OR_RAISE(
@@ -285,10 +289,14 @@ class ReaderV1 : public Reader {
       type = checked_cast<const DictionaryType&>(*type).index_type();
     }
 
-    // If there are nulls, the null bitmask is first
+    // If there are nulls, the null bitmask is first. The sub-buffer sizes are
+    // derived from meta->length(), which is independent of the buffer actually
+    // read above, so slice with bounds checking to reject inconsistent metadata.
     if (meta->null_count() > 0) {
       int64_t null_bitmap_size = GetOutputLength(bit_util::BytesForBits(meta->length()));
-      buffers.push_back(SliceBuffer(buffer, offset, null_bitmap_size));
+      ARROW_ASSIGN_OR_RAISE(auto null_bitmap,
+                            SliceBufferSafe(buffer, offset, null_bitmap_size));
+      buffers.push_back(std::move(null_bitmap));
       offset += null_bitmap_size;
     } else {
       buffers.push_back(nullptr);
@@ -296,15 +304,18 @@ class ReaderV1 : public Reader {
 
     if (is_binary_like(type->id())) {
       int64_t offsets_size = GetOutputLength((meta->length() + 1) * sizeof(int32_t));
-      buffers.push_back(SliceBuffer(buffer, offset, offsets_size));
+      ARROW_ASSIGN_OR_RAISE(auto offsets, SliceBufferSafe(buffer, offset, offsets_size));
+      buffers.push_back(std::move(offsets));
       offset += offsets_size;
     } else if (is_large_binary_like(type->id())) {
       int64_t offsets_size = GetOutputLength((meta->length() + 1) * sizeof(int64_t));
-      buffers.push_back(SliceBuffer(buffer, offset, offsets_size));
+      ARROW_ASSIGN_OR_RAISE(auto offsets, SliceBufferSafe(buffer, offset, offsets_size));
+      buffers.push_back(std::move(offsets));
       offset += offsets_size;
     }
 
-    buffers.push_back(SliceBuffer(buffer, offset, buffer->size() - offset));
+    ARROW_ASSIGN_OR_RAISE(auto values, SliceBufferSafe(buffer, offset));
+    buffers.push_back(std::move(values));
 
     *out = ArrayData::Make(type, meta->length(), std::move(buffers), meta->null_count());
     return Status::OK();

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -21,6 +21,7 @@
 #include <tuple>
 #include <utility>
 
+#include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
@@ -36,6 +37,8 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
 #include "arrow/util/config.h"
+
+#include "generated/feather_generated.h"
 
 namespace arrow {
 
@@ -382,6 +385,38 @@ TEST_P(TestFeatherRoundTrip, RoundTrip) {
 
 INSTANTIATE_TEST_SUITE_P(FeatherRoundTripTests, TestFeatherRoundTrip,
                          ::testing::ValuesIn(kBatchCases));
+
+TEST(TestFeatherV1, InconsistentColumnLength) {
+  // A V1 footer can declare a column length unrelated to the size of the data
+  // buffer that backs it. Here total_bytes is 8 but length is 2^20, so the
+  // computed null-bitmap/values slices fall outside the buffer. The reader must
+  // reject this rather than build out-of-bounds buffer views.
+  std::string data("FEA1", 4);  // leading magic so Reader::Open dispatches to V1
+  data.resize(8, '\0');
+
+  flatbuffers::FlatBufferBuilder fbb;
+  auto name = fbb.CreateString("c");
+  auto values =
+      fbs::CreatePrimitiveArray(fbb, fbs::Type::Type_INT32, fbs::Encoding::Encoding_PLAIN,
+                                /*offset=*/0, /*length=*/1 << 20, /*null_count=*/1,
+                                /*total_bytes=*/8);
+  auto column = fbs::CreateColumn(fbb, name, values);
+  auto columns = fbb.CreateVector(std::vector<flatbuffers::Offset<fbs::Column>>{column});
+  auto root = fbs::CreateCTable(fbb, /*description=*/0, /*num_rows=*/1 << 20, columns,
+                                kFeatherV1Version, /*metadata=*/0);
+  fbb.Finish(root);
+
+  std::string file = data;
+  file.append(reinterpret_cast<const char*>(fbb.GetBufferPointer()), fbb.GetSize());
+  uint32_t metadata_size = static_cast<uint32_t>(fbb.GetSize());
+  file.append(reinterpret_cast<const char*>(&metadata_size), sizeof(uint32_t));
+  file.append("FEA1", 4);
+
+  auto source = std::make_shared<io::BufferReader>(Buffer::FromString(std::move(file)));
+  ASSERT_OK_AND_ASSIGN(auto reader, Reader::Open(source));
+  std::shared_ptr<Table> table;
+  ASSERT_RAISES(IndexError, reader->Read(&table));
+}
 
 }  // namespace feather
 }  // namespace ipc


### PR DESCRIPTION
`ReaderV1::LoadValues` reads `total_bytes` for a column, then slices null-bitmap/offsets/values sub-buffers using sizes from `meta->length()`, which the footer flatbuffer supplies independently and unverified. A length larger than the data buffer makes the plain `SliceBuffer` calls run past the buffer (and the final `buffer->size() - offset` underflow), so the array is read out of bounds when consumed. Reachable from `feather::Reader::Open` on any Feather V1 file. Reject negative length/null_count and switch the three slices to `SliceBufferSafe`.

* GitHub Issue: #50067