### PR TITLE
GH-50075: [C++][Gandiva] fix buffer overrun in to_hex int32/int64

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2857,8 +2857,9 @@ const char* to_hex_binary(int64_t context, const char* text, int32_t text_len,
 FORCE_INLINE
 const char* to_hex_int64(int64_t context, int64_t data, int32_t* out_len) {
   const int64_t hex_long_max_size = 2 * sizeof(int64_t);
-  auto ret =
-      reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, hex_long_max_size));
+  // Allocate one extra byte for the null terminator written by snprintf.
+  auto ret = reinterpret_cast<char*>(
+      gdv_fn_context_arena_malloc(context, hex_long_max_size + 1));
 
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
@@ -2874,7 +2875,8 @@ const char* to_hex_int64(int64_t context, int64_t data, int32_t* out_len) {
 FORCE_INLINE
 const char* to_hex_int32(int64_t context, int32_t data, int32_t* out_len) {
   const int32_t max_size = 2 * sizeof(int32_t);
-  auto ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, max_size));
+  // Allocate one extra byte for the null terminator written by snprintf.
+  auto ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, max_size + 1));
 
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");


### PR DESCRIPTION
### Rationale for this change

`to_hex_int64` and `to_hex_int32` in `cpp/src/gandiva/precompiled/string_ops.cc` allocate the arena buffer with the bare hex-digit count (16 and 8 bytes) but pass that size + 1 as the `snprintf` bound. For any full-width value (`to_hex(-1::bigint)` -> `FFFFFFFFFFFFFFFF`, `INT64_MIN`, `INT32_MIN`, ...) `snprintf` writes all digits plus the trailing NUL, one byte past the end of the allocation. `gdv_fn_context_arena_malloc` returns exactly the requested bytes, so the NUL corrupts the adjacent arena allocation. Reachable from the `to_hex(bigint)` / `to_hex(int)` Gandiva functions over untrusted column data.

### What changes are included in this PR?

Allocate one extra byte in both functions so the allocation matches the `snprintf` bound, the same fix as GH-49752 applied to the identical pattern in `hash_utils.cc`.

### Are these changes tested?

Yes. The existing `TestToHexInt64` / `TestToHexInt32` cases already exercise the full-width path (`INT64_MIN`, `INT32_MIN`, -1) and run clean under ASAN with this change. Output behaviour is unchanged.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** It fixes a one-byte out-of-bounds heap write reachable from the `to_hex` Gandiva functions over untrusted input.

* GitHub Issue: #50075