### PR TITLE
GH-32320: [R] Docs unclear about potential disadvantages of dictionary encoding

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -769,6 +769,8 @@ use_dictionary : bool or list, default True
     When encoding the column, if the dictionary size is too large, the
     column will fallback to ``PLAIN`` encoding. Specially, ``BOOLEAN`` type
     doesn't support dictionary encoding.
+    On columns with many unique values, dictionary encoding can increase
+    file size and reduce compression effectiveness.
 compression : str or dict, default 'snappy'
     Specify the compression codec, either on a general basis or per-column.
     Valid values: {'NONE', 'SNAPPY', 'GZIP', 'BROTLI', 'LZ4', 'LZ4_RAW', 'ZSTD'}.

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -106,7 +106,9 @@ read_parquet <- function(
 #' @param compression compression algorithm. Default "snappy". See details.
 #' @param compression_level compression level. Meaning depends on compression
 #'    algorithm
-#' @param use_dictionary logical: use dictionary encoding? Default `TRUE`
+#' @param use_dictionary logical: use dictionary encoding? Default `TRUE`.
+#'    On columns with many unique values, dictionary encoding can increase
+#'    file size and reduce compression effectiveness.
 #' @param write_statistics logical: include statistics? Default `TRUE`
 #' @param data_page_size Set a target threshold for the approximate encoded
 #'    size of data pages within a column chunk (in bytes). Default 1 MiB.


### PR DESCRIPTION
### Rationale for this change

Unclear docs - dictionary encoding can slow stuff down but it's not apparent

### What changes are included in this PR?

Talk about it

### Are these changes tested?

Nah

### Are there any user-facing changes?

Nope
* GitHub Issue: #32320