### PR TITLE
GH-17081: [C++] arrow::stl::TupleRangeFromTable docs incorrect

### DIFF
--- a/docs/source/cpp/examples/tuple_range_conversion.rst
+++ b/docs/source/cpp/examples/tuple_range_conversion.rst
@@ -41,7 +41,9 @@ type conversion is then inferred at compile time.
    }
 
 In reverse, you can use ``TupleRangeFromTable`` to fill an already
-pre-allocated range with the data from a ``Table`` instance.
+pre-allocated range with the data from a ``Table`` instance. You need to
+provide ``CastOptions`` to control type conversions and an ``ExecContext``
+for the compute functions used during conversion.
 
 .. code::
 
@@ -50,11 +52,14 @@ pre-allocated range with the data from a ``Table`` instance.
     // is unnamed, matching is done on positions.
     std::shared_ptr<Table> table = ..
 
+    arrow::compute::ExecContext ctx;
+    arrow::compute::CastOptions cast_options;
+
     // The range needs to be pre-allocated to the respective amount of rows.
     // This allows us to pass in an arbitrary range object, not only
     // `std::vector`.
     std::vector<std::tuple<double, std::string>> rows(2);
-    if (!arrow::stl::TupleRangeFromTable(*table, &rows).ok()) {
+    if (!arrow::stl::TupleRangeFromTable(*table, cast_options, &ctx, &rows).ok()) {
       // Error handling code should go here.
     }
 

--- a/docs/source/cpp/examples/tuple_range_conversion.rst
+++ b/docs/source/cpp/examples/tuple_range_conversion.rst
@@ -41,9 +41,7 @@ type conversion is then inferred at compile time.
    }
 
 In reverse, you can use ``TupleRangeFromTable`` to fill an already
-pre-allocated range with the data from a ``Table`` instance. You need to
-provide ``CastOptions`` to control type conversions and an ``ExecContext``
-for the compute functions used during conversion.
+pre-allocated range with the data from a ``Table`` instance.
 
 .. code::
 


### PR DESCRIPTION
### Rationale for this change

The documentation example for TupleRangeFromTable was missing the cast_options and ctx parameters, so it didn't match the actual function signature

### What changes are included in this PR?

Add them

### Are these changes tested?

No

### Are there any user-facing changes?

Better docs
* GitHub Issue: #17081