### PR TITLE
GH-20403: [Doc] pyarrow.Array.diff Examples is wrongly rendered

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1148,7 +1148,6 @@ cdef class Array(_PandasConvertible):
         >>> left = pa.array(["one", "two", "three"])
         >>> right = pa.array(["two", None, "two-and-a-half", "three"])
         >>> print(left.diff(right)) # doctest: +SKIP
-
         @@ -0, +0 @@
         -"one"
         @@ -2, +1 @@


### PR DESCRIPTION
### Rationale for this change

Docs render weirdly

### What changes are included in this PR?

Fix extra blank line breaking docs block

### Are these changes tested?

I'll render docs

### Are there any user-facing changes?

No
* GitHub Issue: #20403