### PR TITLE
GH-50098: [C++][Parquet] Enable filesystem support when building Parquet utilities

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -582,11 +582,12 @@ takes precedence over ccache if a storage backend is configured" ON)
   set_option_category("Parquet")
 
   define_option(PARQUET_BUILD_EXECUTABLES
-                "Build the Parquet executable CLI tools. Requires static libraries to be built."
-                OFF)
+                "Build the Parquet executable CLI tools."
+                OFF
+                DEPENDS
+                ARROW_FILESYSTEM)
 
-  define_option(PARQUET_BUILD_EXAMPLES
-                "Build the Parquet examples. Requires static libraries to be built." OFF)
+  define_option(PARQUET_BUILD_EXAMPLES "Build the Parquet examples." OFF)
 
   define_option(PARQUET_REQUIRE_ENCRYPTION
                 "Build support for encryption. Fail if OpenSSL is not found"

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -70,6 +70,7 @@ set(ARROW_COMPUTE_TEST_ARGS PREFIX ${ARROW_COMPUTE_TEST_PREFIX} LABELS
 # Also see: GH-34388, GH-34615
 function(ADD_ARROW_COMPUTE_TEST REL_TEST_NAME)
   if(NOT ARROW_COMPUTE)
+    # libarrow_compute is not enabled, skip building test
     return()
   endif()
 
@@ -109,6 +110,11 @@ endfunction()
 # part of libarrow.
 # It will also link the compute libraries to the benchmark target.
 function(add_arrow_compute_benchmark REL_TEST_NAME)
+  if(NOT ARROW_COMPUTE)
+    # libarrow_compute is not enabled, skip building benchmark
+    return()
+  endif()
+
   set(options)
   set(one_value_args PREFIX)
   set(multi_value_args EXTRA_SOURCES EXTRA_LINK_LIBS)


### PR DESCRIPTION
### Rationale for this change

Some Parquet utilities call the Arrow filesystem API.

Also make sure that compute benchmarks are not built when the full compute kernels registry is not enabled.

### Are these changes tested?

Manually.

### Are there any user-facing changes?

No.


* GitHub Issue: #50098