### PR TITLE
GH-50103: [C++] Missing iosfwd include in cpp/src/arrow/util/string_util.h

### DIFF
--- a/cpp/src/arrow/util/string_util.h
+++ b/cpp/src/arrow/util/string_util.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/cpp/src/arrow/util/string_util.h
+++ b/cpp/src/arrow/util/string_util.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
+#include <iosfwd>
 #include <memory>
 #include <ostream>
-#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
`std::ostringstream` requires corresponding header inclusion.

Bug raised while building with gcc-17

https://bugs.gentoo.org/976604
* GitHub Issue: #50103