### PR TITLE
GH-49907: [Python] FixedShapeTensor to_pandas_dtype returns NotImplementedError

### DIFF
--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -53,6 +53,11 @@ def test_type_integers():
 
 
 @pytest.mark.pandas
+def test_extension_type_to_pandas_dtype():
+    pa.fixed_shape_tensor(pa.float32(),[2,2]).to_pandas_dtype()
+
+
+@pytest.mark.pandas
 def test_type_to_pandas_dtype():
     M8 = np.dtype('datetime64[ms]')
     if Version(pd.__version__) < Version("2.0.0"):


### PR DESCRIPTION
### Rationale for this change
method needs to be implemented in order to use table.to_pandas(split_blocks=True)

### What changes are included in this PR?
Added to_pandas_dtype method to an extension array

### Are these changes tested?
Yes

### Are there any user-facing changes?
The users of Arrow would see the changes, so we would be able to use pandas on the extension arrays


* GitHub Issue: #49907