### PR TITLE
MINOR: [C++] Mark all Thrift-generated files generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@ cpp/src/arrow/util/bpacking_*_generated_internal.h linguist-generated=true
 cpp/src/parquet/chunker_*_generated.h linguist-generated=true
 cpp/src/generated/*.cpp linguist-generated=true
 cpp/src/generated/*.h linguist-generated=true
+cpp/src/generated/*.tcc linguist-generated=true
 go/**/*.s linguist-generated=true
 go/arrow/unionmode_string.go linguist-generated=true
 go/arrow/internal/flatbuf/*.go linguist-generated=true


### PR DESCRIPTION
### Rationale for this change

Thrift generates files named `foo.tcc` in addition to `foo.h` and `foo.cc`.

### Are these changes tested?

N/A.

### Are there any user-facing changes?

No.
