### PR TITLE
GH-50129: [C++][Parquet] Enable `ARROW_JSON` automatically with `PARQUET_REQUIRE_ENCRYPTION`

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -593,7 +593,8 @@ takes precedence over ccache if a storage backend is configured" ON)
                 "Build support for encryption. Fail if OpenSSL is not found"
                 OFF
                 DEPENDS
-                ARROW_FILESYSTEM)
+                ARROW_FILESYSTEM
+                ARROW_JSON)
 
   #----------------------------------------------------------------------
   set_option_category("Gandiva")


### PR DESCRIPTION
### Rationale for this change

`PARQUET_REQUIRE_ENCRYPTION` needs `ARROW_JSON`. So `ARROW_JSON` should be enabled automatically when `PARQUET_REQUIRE_ENCRYPTION` is used.

### What changes are included in this PR?

Add missing `ARROW_JSON` dependency to `PARQUET_REQUIRE_ENCRYPTION`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #50129