### PR TITLE
GH-49907: [Python] Implement FixedShapeTensorType.to_pandas_dtype

### DIFF
--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1787,6 +1787,55 @@ def test_tensor_type_cast():
 
 
 @pytest.mark.pandas
+@pytest.mark.parametrize("value_type", [pa.int8(), pa.float32(), pa.float64()])
+@pytest.mark.parametrize("shape,permutation", [
+    ([2, 2], None),
+    ([2, 3], None),
+    ([2, 2, 3], [0, 2, 1]),
+])
+def test_tensor_type_to_pandas(value_type, shape, permutation):
+    # GH-49907: to_pandas_dtype should return a pandas dtype instead of
+    # raising NotImplementedError, and enable Table.to_pandas(split_blocks=True)
+    import pandas as pd
+
+    if Version(pd.__version__) < Version("2.1.0"):
+        # pd.ArrowDtype extension blocks are only reliable from 2.1.0,
+        # see GH-35821
+        pytest.skip("requires pandas >= 2.1.0")
+
+    tensor_type = pa.fixed_shape_tensor(
+        value_type, shape, permutation=permutation)
+
+    # The type maps to a pandas ArrowDtype wrapping the extension type
+    dtype = tensor_type.to_pandas_dtype()
+    assert isinstance(dtype, pd.ArrowDtype)
+    assert dtype.pyarrow_dtype == tensor_type
+
+    # Build an extension array of a few tensors via the storage type so the
+    # explicit permutation is preserved exactly
+    size = 3
+    n = int(np.prod(shape))
+    storage = pa.array(
+        [list(range(i * n, (i + 1) * n)) for i in range(size)],
+        pa.list_(value_type, n))
+    arr = pa.ExtensionArray.from_storage(tensor_type, storage)
+
+    # Array.to_pandas uses the ArrowDtype
+    series = arr.to_pandas()
+    assert isinstance(series.dtype, pd.ArrowDtype)
+    assert series.dtype.pyarrow_dtype == tensor_type
+    assert len(series) == size
+
+    # Table.to_pandas, including the split_blocks=True path from GH-49907
+    table = pa.table({"tensor": arr})
+    for split_blocks in [False, True]:
+        result = table.to_pandas(split_blocks=split_blocks)
+        assert isinstance(result["tensor"].dtype, pd.ArrowDtype)
+        assert result["tensor"].dtype.pyarrow_dtype == tensor_type
+        assert len(result) == size
+
+
+@pytest.mark.pandas
 def test_extension_to_pandas_storage_type(registered_period_type):
     period_type, _ = registered_period_type
     np_arr = np.array([1, 2, 3, 4], dtype='i8')

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2049,6 +2049,30 @@ cdef class FixedShapeTensorType(BaseExtensionType):
         else:
             return None
 
+    def to_pandas_dtype(self):
+        """
+        Return the equivalent pandas dtype, an instance of
+        :class:`pandas.ArrowDtype` wrapping this extension type.
+
+        Each value of the resulting pandas column is a tensor with this
+        type's ``shape``. Returning a pandas extension dtype (rather than a
+        NumPy dtype) is what lets ``Table.to_pandas(split_blocks=True)``
+        build an extension block for this type.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.fixed_shape_tensor(pa.int32(), [2, 2]).to_pandas_dtype()
+        extension<arrow.fixed_shape_tensor[value_type=int32, shape=[2,2]]>[pyarrow]
+        """
+        import pandas as pd
+        if not hasattr(pd, "ArrowDtype"):
+            # pandas < 1.5 has no ArrowDtype able to hold tensors, so keep the
+            # documented fallback. Conversion code catches this and produces an
+            # object-dtype column instead.
+            raise NotImplementedError(str(self))
+        return pd.ArrowDtype(self)
+
     def __arrow_ext_class__(self):
         return FixedShapeTensorArray
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2059,18 +2059,24 @@ cdef class FixedShapeTensorType(BaseExtensionType):
         NumPy dtype) is what lets ``Table.to_pandas(split_blocks=True)``
         build an extension block for this type.
 
+        This requires pandas >= 2.1.0, the first version with reliable
+        ``ArrowDtype`` extension blocks (see GH-35821). On older pandas it
+        raises ``NotImplementedError`` and conversion falls back to the
+        object dtype.
+
         Examples
         --------
         >>> import pyarrow as pa
         >>> pa.fixed_shape_tensor(pa.int32(), [2, 2]).to_pandas_dtype()
         extension<arrow.fixed_shape_tensor[value_type=int32, shape=[2,2]]>[pyarrow]
         """
+        if not _pandas_api.is_ge_v21():
+            # pandas.ArrowDtype extension blocks are only reliable from 2.1.0
+            # (GH-35821); on older pandas keep the documented fallback so the
+            # conversion code produces an object-dtype column instead.
+            raise NotImplementedError(
+                f"{self} requires pandas >= 2.1.0 to map to pandas.ArrowDtype")
         import pandas as pd
-        if not hasattr(pd, "ArrowDtype"):
-            # pandas < 1.5 has no ArrowDtype able to hold tensors, so keep the
-            # documented fallback. Conversion code catches this and produces an
-            # object-dtype column instead.
-            raise NotImplementedError(str(self))
         return pd.ArrowDtype(self)
 
     def __arrow_ext_class__(self):


### PR DESCRIPTION
### Rationale for this change

`FixedShapeTensorType.to_pandas_dtype()` inherited the base `DataType`
implementation, which raises `NotImplementedError` for every extension type.
This contradicted the documented public API, and it also blocked
`Table.to_pandas(split_blocks=True)` for fixed-shape-tensor columns: with no
pandas dtype available, the split-blocks path emitted an extension (`py_array`)
block with no matching dtype and crashed with `KeyError` in
`_reconstruct_block`.

(See the discussion in #49907 and the related #33134 on how extension arrays
should convert to pandas in general.)

### What changes are included in this PR?

Implement `to_pandas_dtype()` on `FixedShapeTensorType` to return
`pandas.ArrowDtype(self)`. `ArrowDtype` is a pandas `ExtensionDtype` that
implements `__from_arrow__`, which is exactly what the `pandas_compat`
extension-block path requires to build the column — so no conversion code
needed to change.

On pandas `< 1.5` (no `ArrowDtype`), the method falls back to raising
`NotImplementedError`, leaving behavior on older pandas unchanged.

### Are these changes tested?

Yes. `test_tensor_type_to_pandas` in
`python/pyarrow/tests/test_extension_type.py` asserts that:
- `to_pandas_dtype()` returns a `pd.ArrowDtype` wrapping the type,
- `Array.to_pandas()` produces an ArrowDtype-backed column,
- `Table.to_pandas()` with both `split_blocks=False` and `split_blocks=True`
  (the case from #49907) round-trips correctly,

parametrized over value types (`int8`, `float32`, `float64`) and shapes
including a permutation. It is gated to pandas `>= 2.1.0`, matching the
existing `pd.ArrowDtype` extension-block tests (GH-35821).

### Are there any user-facing changes?

Yes:
- `FixedShapeTensorType.to_pandas_dtype()` now returns `pandas.ArrowDtype(...)`
  instead of raising `NotImplementedError` (pandas `>= 1.5`).
- Consequently, `Array.to_pandas()` / `Table.to_pandas()` on a
  fixed-shape-tensor column now yield an `ArrowDtype`-backed column instead of
  an `object`-dtype column of flattened ndarrays (pandas `>= 2.1`). Code
  relying on the previous `object` dtype will observe this change.
* GitHub Issue: #49907