### PR TITLE
GH-49834: [C++] Avoid building re2 unit tests

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3064,6 +3064,7 @@ function(build_re2)
 
   # Unity build causes some build errors
   set(CMAKE_UNITY_BUILD OFF)
+  set(RE2_BUILD_TESTING OFF)
 
   fetchcontent_makeavailable(re2)
 


### PR DESCRIPTION
### Rationale for this change

We don't need to build unit tests for the bundled RE2 library, and it avoids `ctest` picking those tests when run from the build directory.

### Are these changes tested?

Manually.

### Are there any user-facing changes?

No.

* GitHub Issue: #49834