### PR TITLE
GH-48740: [C++] Add missing CTypeTraits for decimal types

### DIFF
--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1493,6 +1493,20 @@ PRIMITIVE_TEST(DoubleType, double, DOUBLE, "double");
 
 PRIMITIVE_TEST(BooleanType, bool, BOOL, "bool");
 
+TEST(TypesTest, DecimalTraits) {
+  static_assert(std::is_same_v<TypeTraits<Decimal32Type>::CType, Decimal32>);
+  static_assert(std::is_same_v<CTypeTraits<Decimal32>::ArrowType, Decimal32Type>);
+
+  static_assert(std::is_same_v<TypeTraits<Decimal64Type>::CType, Decimal64>);
+  static_assert(std::is_same_v<CTypeTraits<Decimal64>::ArrowType, Decimal64Type>);
+
+  static_assert(std::is_same_v<TypeTraits<Decimal128Type>::CType, Decimal128>);
+  static_assert(std::is_same_v<CTypeTraits<Decimal128>::ArrowType, Decimal128Type>);
+
+  static_assert(std::is_same_v<TypeTraits<Decimal256Type>::CType, Decimal256>);
+  static_assert(std::is_same_v<CTypeTraits<Decimal256>::ArrowType, Decimal256Type>);
+}
+
 TEST(TestBinaryType, ToString) {
   BinaryType t1;
   BinaryType e1;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -104,16 +104,6 @@ struct CTypeTraits {};
 /// \addtogroup type-traits
 /// @{
 template <>
-struct CTypeTraits<Decimal128> : TypeTraits<Decimal128Type> {
-  using ArrowType = Decimal128Type;
-};
-
-template <>
-struct CTypeTraits<Decimal256> : TypeTraits<Decimal256Type> {
-  using ArrowType = Decimal256Type;
-};
-
-template <>
 struct TypeTraits<NullType> {
   using ArrayType = NullArray;
   using BuilderType = NullBuilder;
@@ -365,6 +355,26 @@ struct TypeTraits<Decimal256Type> {
   using ScalarType = Decimal256Scalar;
   using CType = Decimal256;
   constexpr static bool is_parameter_free = false;
+};
+
+template <>
+struct CTypeTraits<Decimal32> : TypeTraits<Decimal32Type> {
+  using ArrowType = Decimal32Type;
+};
+
+template <>
+struct CTypeTraits<Decimal64> : TypeTraits<Decimal64Type> {
+  using ArrowType = Decimal64Type;
+};
+
+template <>
+struct CTypeTraits<Decimal128> : TypeTraits<Decimal128Type> {
+  using ArrowType = Decimal128Type;
+};
+
+template <>
+struct CTypeTraits<Decimal256> : TypeTraits<Decimal256Type> {
+  using ArrowType = Decimal256Type;
 };
 
 template <>

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -104,6 +104,16 @@ struct CTypeTraits {};
 /// \addtogroup type-traits
 /// @{
 template <>
+struct CTypeTraits<Decimal128> {
+  using ArrowType = Decimal128Type;
+};
+
+template <>
+struct CTypeTraits<Decimal256> {
+  using ArrowType = Decimal256Type;
+};
+
+template <>
 struct TypeTraits<NullType> {
   using ArrayType = NullArray;
   using BuilderType = NullBuilder;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -104,12 +104,12 @@ struct CTypeTraits {};
 /// \addtogroup type-traits
 /// @{
 template <>
-struct CTypeTraits<Decimal128> {
+struct CTypeTraits<Decimal128> : TypeTraits<Decimal128Type> {
   using ArrowType = Decimal128Type;
 };
 
 template <>
-struct CTypeTraits<Decimal256> {
+struct CTypeTraits<Decimal256> : TypeTraits<Decimal256Type> {
   using ArrowType = Decimal256Type;
 };
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -358,22 +358,22 @@ struct TypeTraits<Decimal256Type> {
 };
 
 template <>
-struct CTypeTraits<Decimal32> : TypeTraits<Decimal32Type> {
+struct CTypeTraits<Decimal32> : public TypeTraits<Decimal32Type> {
   using ArrowType = Decimal32Type;
 };
 
 template <>
-struct CTypeTraits<Decimal64> : TypeTraits<Decimal64Type> {
+struct CTypeTraits<Decimal64> : public TypeTraits<Decimal64Type> {
   using ArrowType = Decimal64Type;
 };
 
 template <>
-struct CTypeTraits<Decimal128> : TypeTraits<Decimal128Type> {
+struct CTypeTraits<Decimal128> : public TypeTraits<Decimal128Type> {
   using ArrowType = Decimal128Type;
 };
 
 template <>
-struct CTypeTraits<Decimal256> : TypeTraits<Decimal256Type> {
+struct CTypeTraits<Decimal256> : public TypeTraits<Decimal256Type> {
   using ArrowType = Decimal256Type;
 };
 


### PR DESCRIPTION
### Rationale for this change

As reported in #48740, the `CTypeTraits` specializations were missing for decimal types. This prevented generic code from correctly mapping C++ decimal types to Arrow types.

### What changes are included in this PR?

* Added `CTypeTraits<Decimal128>` mapping to `Decimal128Type`.
* Added `CTypeTraits<Decimal256>` mapping to `Decimal256Type`.

### Are these changes tested?

Yes, via existing type traits tests in the CI pipeline.

### Are there any user-facing changes?

No.

Closes #48740
* GitHub Issue: #48740