### PR TITLE
GH-48636: [C++][Parquet] Improve parquet reading using multi threads

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -735,10 +735,9 @@ class PARQUET_NO_EXPORT StructReader : public ColumnReaderImpl {
   bool IsOrHasRepeatedChild() const final { return has_repeated_child_; }
 
   Status LoadBatch(int64_t records_to_read) override {
-    for (const std::unique_ptr<ColumnReaderImpl>& reader : children_) {
-      RETURN_NOT_OK(reader->LoadBatch(records_to_read));
-    }
-    return Status::OK();
+    return ::arrow::internal::OptionalParallelFor(
+        ctx_->reader_properties->use_threads(), static_cast<int>(children_.size()),
+        [&](int i) { return children_[i]->LoadBatch(records_to_read); });
   }
   Status BuildArray(int64_t length_upper_bound,
                     std::shared_ptr<ChunkedArray>* out) override;
@@ -825,10 +824,17 @@ Status StructReader::BuildArray(int64_t length_upper_bound,
 
   END_PARQUET_CATCH_EXCEPTIONS
   // Gather children arrays and def levels
-  for (auto& child : children_) {
-    std::shared_ptr<ChunkedArray> field;
-    RETURN_NOT_OK(child->BuildArray(validity_io.values_read, &field));
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ArrayData> array_data, ChunksToSingle(*field));
+  const int num_children = static_cast<int>(children_.size());
+  std::vector<std::shared_ptr<ChunkedArray>> chunked_fields(num_children);
+
+  RETURN_NOT_OK(::arrow::internal::OptionalParallelFor(
+      ctx_->reader_properties->use_threads(), num_children, [&](int i) {
+        return children_[i]->BuildArray(validity_io.values_read, &chunked_fields[i]);
+      }));
+  children_array_data.reserve(num_children);
+  for (int i = 0; i < num_children; ++i) {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ArrayData> array_data,
+                          ChunksToSingle(*chunked_fields[i]));
     children_array_data.push_back(std::move(array_data));
   }
 


### PR DESCRIPTION
### Rationale for this change
Currently the parquet file structs are read sequentially, even when the `use_threads` option is used by the user. This PR aims to bridge this gap by making the struct reading truly parallel.

### What changes are included in this PR?
Changes to the `LoadBatch` and `BuildArray` functions in the `StructReader` in the Parquet reader to enable multi threaded reads of structs in parquet files.

### Are these changes tested?
* Yes I have tested them. Details can be found in this [testing and benchmarking repo](https://github.com/OmBiradar/pyarrow-lincc-fw-openastronomy-gsoc26)
* Weather benchmarks should be added for parallel reads is a question I would ask the reviewer.

### Are there any user-facing changes?

This is purely a performance related PR. No changes to the user or API is needed.
* GitHub Issue: #48636