### PR TITLE
GH-50148: [C++] Add Content-Encoding support to S3 filesystem metadata

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1361,6 +1361,7 @@ std::shared_ptr<const KeyValueMetadata> GetObjectMetadata(const ObjectResult& re
 
   md->Append("Content-Length", ToChars(result.GetContentLength()));
   push("Cache-Control", result.GetCacheControl());
+  push("Content-Encoding", result.GetContentEncoding());
   push("Content-Type", result.GetContentType());
   push("Content-Language", result.GetContentLanguage());
   push("ETag", result.GetETag());
@@ -1379,6 +1380,7 @@ struct ObjectMetadataSetter {
   static std::unordered_map<std::string, Setter> GetSetters() {
     return {{"ACL", CannedACLSetter()},
             {"Cache-Control", StringSetter(&ObjectRequest::SetCacheControl)},
+            {"Content-Encoding", ContentEncodingSetter()},
             {"Content-Type", ContentTypeSetter()},
             {"Content-Language", StringSetter(&ObjectRequest::SetContentLanguage)},
             {"Expires", DateTimeSetter(&ObjectRequest::SetExpires)}};
@@ -1415,6 +1417,13 @@ struct ObjectMetadataSetter {
   static Setter ContentTypeSetter() {
     return [](const std::string& str, ObjectRequest* req) {
       req->SetContentType(str);
+      return Status::OK();
+    };
+  }
+
+  static Setter ContentEncodingSetter() {
+    return [](const std::string& str, ObjectRequest* req) {
+      req->SetContentEncoding(str);
       return Status::OK();
     };
   }

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1301,6 +1301,7 @@ std::shared_ptr<const KeyValueMetadata> GetObjectMetadata(const ObjectResult& re
 
   md->Append("Content-Length", ToChars(result.GetContentLength()));
   push("Cache-Control", result.GetCacheControl());
+  push("Content-Encoding", result.GetContentEncoding());
   push("Content-Type", result.GetContentType());
   push("Content-Language", result.GetContentLanguage());
   push("ETag", result.GetETag());
@@ -1319,6 +1320,7 @@ struct ObjectMetadataSetter {
   static std::unordered_map<std::string, Setter> GetSetters() {
     return {{"ACL", CannedACLSetter()},
             {"Cache-Control", StringSetter(&ObjectRequest::SetCacheControl)},
+            {"Content-Encoding", ContentEncodingSetter()},
             {"Content-Type", ContentTypeSetter()},
             {"Content-Language", StringSetter(&ObjectRequest::SetContentLanguage)},
             {"Expires", DateTimeSetter(&ObjectRequest::SetExpires)}};
@@ -1355,6 +1357,13 @@ struct ObjectMetadataSetter {
   static Setter ContentTypeSetter() {
     return [](const std::string& str, ObjectRequest* req) {
       req->SetContentType(str);
+      return Status::OK();
+    };
+  }
+
+  static Setter ContentEncodingSetter() {
+    return [](const std::string& str, ObjectRequest* req) {
+      req->SetContentEncoding(str);
       return Status::OK();
     };
   }

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1655,8 +1655,9 @@ TEST_F(TestS3FS, OpenOutputStreamMetadata) {
                           testing::IsSupersetOf(implicit_metadata->sorted_pairs()));
 
   // Create new file with explicit metadata
-  auto metadata = KeyValueMetadata::Make({"Content-Type", "Expires"},
-                                         {"x-arrow/test6", "2016-02-05T20:08:35Z"});
+  auto metadata = KeyValueMetadata::Make(
+      {"Content-Encoding", "Content-Type", "Expires"},
+      {"gzip", "x-arrow/test6", "2016-02-05T20:08:35Z"});
   AssertMetadataRoundtrip("bucket/mdfile1", metadata,
                           testing::IsSupersetOf(metadata->sorted_pairs()));
 
@@ -1666,8 +1667,9 @@ TEST_F(TestS3FS, OpenOutputStreamMetadata) {
   AssertMetadataRoundtrip("bucket/mdfile2", metadata, testing::_);
 
   // Create new file with default metadata
-  auto default_metadata = KeyValueMetadata::Make({"Content-Type", "Content-Language"},
-                                                 {"image/png", "fr_FR"});
+  auto default_metadata = KeyValueMetadata::Make(
+      {"Content-Encoding", "Content-Type", "Content-Language"},
+      {"br", "image/png", "fr_FR"});
   options_.default_metadata = default_metadata;
   MakeFileSystem();
   // (null, then empty metadata argument)

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1532,8 +1532,9 @@ TEST_F(TestS3FS, OpenOutputStreamMetadata) {
                           testing::IsSupersetOf(implicit_metadata->sorted_pairs()));
 
   // Create new file with explicit metadata
-  auto metadata = KeyValueMetadata::Make({"Content-Type", "Expires"},
-                                         {"x-arrow/test6", "2016-02-05T20:08:35Z"});
+  auto metadata = KeyValueMetadata::Make(
+      {"Content-Encoding", "Content-Type", "Expires"},
+      {"gzip", "x-arrow/test6", "2016-02-05T20:08:35Z"});
   AssertMetadataRoundtrip("bucket/mdfile1", metadata,
                           testing::IsSupersetOf(metadata->sorted_pairs()));
 
@@ -1543,8 +1544,9 @@ TEST_F(TestS3FS, OpenOutputStreamMetadata) {
   AssertMetadataRoundtrip("bucket/mdfile2", metadata, testing::_);
 
   // Create new file with default metadata
-  auto default_metadata = KeyValueMetadata::Make({"Content-Type", "Content-Language"},
-                                                 {"image/png", "fr_FR"});
+  auto default_metadata = KeyValueMetadata::Make(
+      {"Content-Encoding", "Content-Type", "Content-Language"},
+      {"br", "image/png", "fr_FR"});
   options_.default_metadata = default_metadata;
   MakeFileSystem();
   // (null, then empty metadata argument)


### PR DESCRIPTION
### Rationale for this change

The S3 filesystem metadata handling supported headers such as `Content-Type`,
`Content-Language`, `Cache-Control`, and `Expires`, but omitted
`Content-Encoding`.

As a result, `Content-Encoding` was not propagated when writing S3 object
metadata, and it was also not returned when reading metadata back.

### What changes are included in this PR?

- add `Content-Encoding` to S3 object metadata extraction
- add `Content-Encoding` to the S3 metadata setter whitelist
- add a dedicated setter for `Content-Encoding`
- extend the S3 metadata round-trip test to cover explicit and default
  `Content-Encoding` metadata

### Are these changes tested?

Yes.

```text
./cpp/build-s3-system/debug/arrow-s3fs-test --gtest_filter=TestS3FS.OpenOutputStreamMetadata
```

* GitHub Issue: #50148