### PR TITLE
GH-50176: [Python] Explicitly pass exc_type=ImportError to importorskip pyarrow.*

### DIFF
--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4352,7 +4352,7 @@ def test_swapped_byte_order_fails(numpy_native_dtype):
 
 
 def test_non_cpu_array():
-    cuda = pytest.importorskip("pyarrow.cuda")
+    cuda = pytest.importorskip("pyarrow.cuda", exc_type=ImportError)
     ctx = cuda.Context(0)
 
     data = np.arange(4, dtype=np.int32)

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -32,7 +32,7 @@ except ImportError:
     pytestmark = pytest.mark.numpy
 
 
-cuda = pytest.importorskip("pyarrow.cuda")
+cuda = pytest.importorskip("pyarrow.cuda", exc_type=ImportError)
 
 platform = sysconfig.get_platform()
 # TODO: enable ppc64 when Arrow C++ supports IPC in ppc64 systems:
@@ -858,7 +858,7 @@ def test_copy_to():
 
 
 def test_device_interface_array():
-    cffi = pytest.importorskip("pyarrow.cffi")
+    cffi = pytest.importorskip("pyarrow.cffi", exc_type=ImportError)
     ffi = cffi.ffi
 
     c_schema = ffi.new("struct ArrowSchema*")
@@ -911,7 +911,7 @@ def test_device_interface_array():
 
 
 def test_device_interface_batch_array():
-    cffi = pytest.importorskip("pyarrow.cffi")
+    cffi = pytest.importorskip("pyarrow.cffi", exc_type=ImportError)
     ffi = cffi.ffi
 
     c_schema = ffi.new("struct ArrowSchema*")

--- a/python/pyarrow/tests/test_cuda_numba_interop.py
+++ b/python/pyarrow/tests/test_cuda_numba_interop.py
@@ -23,7 +23,7 @@ except ImportError:
     pytestmark = pytest.mark.numpy
 
 dtypes = ['uint8', 'int16', 'float32']
-cuda = pytest.importorskip("pyarrow.cuda")
+cuda = pytest.importorskip("pyarrow.cuda", exc_type=ImportError)
 nb_cuda = pytest.importorskip("numba.cuda")
 
 from numba.cuda.cudadrv.devicearray import DeviceNDArray  # noqa: E402

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5617,7 +5617,7 @@ def test_write_dataset_with_scanner_use_projected_schema(tempdir):
 @pytest.mark.parametrize("format", ("ipc", "parquet"))
 def test_read_table_nested_columns(tempdir, format):
     if format == "parquet":
-        pytest.importorskip("pyarrow.parquet")
+        pytest.importorskip("pyarrow.parquet", exc_type=ImportError)
 
     table = pa.table({"user_id": ["abc123", "qrs456"],
                       "a.dotted.field": [1, 2],

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -154,7 +154,7 @@ def test_dlpack_not_supported():
 
 
 def test_dlpack_cuda_not_supported():
-    cuda = pytest.importorskip("pyarrow.cuda")
+    cuda = pytest.importorskip("pyarrow.cuda", exc_type=ImportError)
 
     schema = pa.schema([pa.field('f0', pa.int16())])
     a0 = pa.array([1, 2, 3], type=pa.int16())

--- a/python/pyarrow/tests/test_flight_async.py
+++ b/python/pyarrow/tests/test_flight_async.py
@@ -21,7 +21,7 @@ import pytest
 
 import pyarrow
 
-flight = pytest.importorskip("pyarrow.flight")
+flight = pytest.importorskip("pyarrow.flight", exc_type=ImportError)
 pytestmark = pytest.mark.flight
 
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -682,7 +682,7 @@ def test_allocate_buffer_resizable():
 
 @pytest.mark.numpy
 def test_non_cpu_buffer(pickle_module):
-    cuda = pytest.importorskip("pyarrow.cuda")
+    cuda = pytest.importorskip("pyarrow.cuda", exc_type=ImportError)
     ctx = cuda.Context(0)
 
     data = np.array([b'testing'])

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -3516,7 +3516,7 @@ def test_invalid_non_join_column():
 
 @pytest.fixture
 def cuda_context():
-    cuda = pytest.importorskip("pyarrow.cuda")
+    cuda = pytest.importorskip("pyarrow.cuda", exc_type=ImportError)
     return cuda.Context(0)
 
 


### PR DESCRIPTION
### Rationale for this change

Some of our CI jobs are failing due to a breaking change on pytest 9.1:
https://github.com/pytest-dev/pytest/pull/14293

### What changes are included in this PR?

Add `exc_type=ImportError` to the `pytest.importorskip("pyarrow.*)` calls

### Are these changes tested?

Via CI

### Are there any user-facing changes?

No

* GitHub Issue: #50176