### PR TITLE
GH-50171: [CI][R] Build libarrow is failing for Linux arm64 

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Build libarrow
         shell: bash
         env:
-          ARCH: {{ "${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64v8' }}" }}
+          ARCH: {{ "${{ matrix.arch == 'x86_64' && 'amd64' || 'arm64/v8' }}" }}
           UBUNTU: {{ '${{ matrix.ubuntu }}' }}
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: |


### PR DESCRIPTION
### Rationale for this change

arm64 builds for libarrow failing after #50125 due to mismatched strings

### What changes are included in this PR?

Update CI job to new config

### Are these changes tested?

Will run archery

### Are there any user-facing changes?

No
* GitHub Issue: #50171