### PR TITLE
GH-50191: [CI][Python] Switch caching to apache/infrastructure-actions/stash

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -260,6 +260,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     env:
+      CCACHE_DIR: /ccache
       PYTHON_CMD: "py -3.13"
     steps:
       - name: Disable Crash Dialogs
@@ -292,12 +293,11 @@ jobs:
         id: path-info
         shell: bash
         run: |
-          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
           echo "usr-windows-dir="$(cygpath --absolute --windows /usr)"" >> $GITHUB_OUTPUT
       - name: Restore ccache
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
-          path: ${{ steps.path-info.outputs.cache-dir }}
+          path: ${{ env.CCACHE_DIR }}
           key: python-ccache-windows
       - name: Build Arrow C++ and PyArrow
         shell: cmd
@@ -310,7 +310,7 @@ jobs:
         continue-on-error: true
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
-          path: ${{ steps.path-info.outputs.cache-dir }}
+          path: ${{ env.CCACHE_DIR }}
           key: python-ccache-windows
       - name: Test PyArrow
         shell: cmd

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -72,30 +72,25 @@ jobs:
           - conda-python-3.12-no-numpy
         include:
           - name: conda-python-docs
-            cache: conda-python-3.11
             image: conda-python-docs
             title: AMD64 Conda Python 3.11 Sphinx & Numpydoc
             python: "3.11"
           - name: conda-python-3.11-nopandas
-            cache: conda-python-3.11
             image: conda-python
             title: AMD64 Conda Python 3.11 Without Pandas
             python: "3.11"
           - name: conda-python-3.10-pandas-1.3.4
-            cache: conda-python-3.10
             image: conda-python-pandas
             title: AMD64 Conda Python 3.10 Pandas 1.3.4
             python: "3.10"
             pandas: "1.3.4"
             numpy: "1.21.2"
           - name: conda-python-3.13-pandas-latest
-            cache: conda-python-3.13
             image: conda-python-pandas
             title: AMD64 Conda Python 3.13 Pandas latest
             python: "3.13"
             pandas: latest
           - name: conda-python-3.12-no-numpy
-            cache: conda-python-3.12
             image: conda-python-no-numpy
             title: AMD64 Conda Python 3.12 without NumPy
             python: "3.12"
@@ -111,12 +106,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@v5
+      - name: Restore Docker Volumes
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ${{ matrix.cache }}-${{ hashFiles('cpp/**') }}
-          restore-keys: ${{ matrix.cache }}-
+          key: python-${{ matrix.name }}
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -130,6 +124,14 @@ jobs:
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ${{ matrix.image }}
+      - name: Save Docker Volumes
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: .docker
+          key: python-${{ matrix.name }}
+          include-hidden-files: true
       - name: Docker Push
         if: >-
           success() &&
@@ -216,12 +218,11 @@ jobs:
         id: ccache-info
         shell: bash
         run: echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: python-ccache-macos-${{ matrix.macos-version }}-${{ hashFiles('cpp/**', 'python/**') }}
-          restore-keys: python-ccache-macos-${{ matrix.macos-version }}-
+          key: python-ccache-macos-${{ matrix.macos-version }}
       - name: Build
         shell: bash
         run: |
@@ -242,6 +243,13 @@ jobs:
           python -m pip install wheel
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
           ci/scripts/python_build.sh $(pwd) $(pwd)/build
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: python-ccache-macos-${{ matrix.macos-version }}
       - name: Test
         shell: bash
         run: ci/scripts/python_test.sh $(pwd) $(pwd)/build
@@ -284,23 +292,26 @@ jobs:
         id: path-info
         shell: bash
         run: |
-          echo "CCACHE_DIR=$(ccache --get-config cache_dir)" >> $GITHUB_ENV
+          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
           echo "usr-windows-dir="$(cygpath --absolute --windows /usr)"" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v5
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
-          path: ${{ env.CCACHE_DIR }}
-          key: python-ccache-windows-${{ env.CACHE_VERSION }}-${{ hashFiles('cpp/**') }}
-          restore-keys: python-ccache-windows-${{ env.CACHE_VERSION }}-
-        env:
-          # We can invalidate the current cache by updating this.
-          CACHE_VERSION: "2025-09-16.1"
+          path: ${{ steps.path-info.outputs.cache-dir }}
+          key: python-ccache-windows
       - name: Build Arrow C++ and PyArrow
         shell: cmd
         env:
           USR_WINDOWS_DIR: ${{ steps.path-info.outputs.usr-windows-dir }}
         run: |
           call "ci\scripts\python_build.bat" %cd% "%USR_WINDOWS_DIR%"
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ steps.path-info.outputs.cache-dir }}
+          key: python-ccache-windows
       - name: Test PyArrow
         shell: cmd
         run: |


### PR DESCRIPTION
### Rationale for this change

`apache/infrastructure-actions/stash` benefits from much greater size limits than `actions/cache`, so our compilation cache stands a greater chance of not being evicted by the next time a build runs.

### Are these changes tested?

By the affected CI jobs.

### Are there any user-facing changes?

No.

* GitHub Issue: #50191