### PR TITLE
GH-46480: [Docs] Add CITATION.cff citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,10 +37,11 @@ keywords:
   - columnar-format
   - in-memory-analytics
   - data-interchange
-  - arrow-ipc
-  - arrow-flight
-  - pyarrow
-  - r
-  - ruby
-  - cpp
+  - columnar-memory-format
+  - record-batch
+  - zero-copy-data-sharing
+  - cross-language-interoperability
+  - arrow-ipc-serialization
+  - arrow-flight-rpc
+  - analytical-data-processing
 license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+cff-version: "1.2.0"
+title: Apache Arrow
+message: >-
+  If you use this software, please cite it using the metadata
+  from this file.
+type: software
+authors:
+  - name: Apache Arrow Contributors
+    email: dev@arrow.apache.org
+repository-code: https://github.com/apache/arrow
+url: https://arrow.apache.org/
+abstract: >-
+  Apache Arrow is a universal columnar format and multi-language toolbox for
+  fast data interchange and in-memory analytics. It contains a set of
+  technologies that enable data systems to efficiently store, process, and
+  move data.
+keywords:
+  - apache-arrow
+  - columnar-format
+  - in-memory-analytics
+  - data-interchange
+  - arrow-ipc
+  - arrow-flight
+  - pyarrow
+  - r
+  - ruby
+  - cpp
+license: Apache-2.0


### PR DESCRIPTION
### Rationale for this change

Adding a top-level `CITATION.cff` lets GitHub and citation tools expose citation metadata for Apache Arrow.

### What changes are included in this PR?

This PR adds `CITATION.cff` with CFF 1.2.0 metadata, including project title, broad author attribution to Apache Arrow Contributors, repository and project URLs, abstract, keywords, and Apache-2.0 license metadata.

### Are these changes tested?

The file was checked by parsing it as YAML.

### Are there any user-facing changes?

Yes. GitHub and compatible citation tools can now surface citation metadata for the project. Otherwise, technically, no changes to the Apache Arrow operational code.

Closes #46480 
* GitHub Issue: #46480