### PR TITLE
GH-49644: [Python] Support converting list of multi-dimensional arrays to FixedShapeTensor

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4708,6 +4708,30 @@ cdef class FixedShapeTensorArray(ExtensionArray):
         400
       ]
     ]
+
+    Create an extension array from a list of multi-dimensional NumPy arrays.
+    Each element is flattened in row-major (C) order, and its shape must match
+    the tensor shape.
+
+    >>> import numpy as np
+    >>> pa.array([np.array([[1, 2], [3, 4]], dtype=np.int32),
+    ...           np.array([[10, 20], [30, 40]], dtype=np.int32)],
+    ...          type=tensor_type)
+    <pyarrow.lib.FixedShapeTensorArray object at ...>
+    [
+      [
+        1,
+        2,
+        3,
+        4
+      ],
+      [
+        10,
+        20,
+        30,
+        40
+      ]
+    ]
     """
 
     def to_numpy_ndarray(self):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -266,6 +266,24 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
     if type is not None and type.id == _Type_EXTENSION:
         extension_type = type
         type = type.storage_type
+        # GH-49644: when building a fixed_shape_tensor from a sequence of arrays,
+        # the converter only sees the flat storage type, so validate the
+        # tensor-specific constraints here where the type is still known.
+        if (isinstance(extension_type, FixedShapeTensorType)
+                and isinstance(obj, (list, tuple))):
+            if extension_type.permutation is not None:
+                raise NotImplementedError(
+                    "Converting a sequence of arrays to a fixed_shape_tensor with "
+                    "a permutation is not supported; use "
+                    "FixedShapeTensorArray.from_numpy_ndarray instead")
+            if np is not None:
+                expected_shape = tuple(extension_type.shape)
+                for element in obj:
+                    if (isinstance(element, np.ndarray) and element.ndim >= 2
+                            and tuple(element.shape) != expected_shape):
+                        raise ValueError(
+                            f"Cannot convert array of shape {element.shape} to a "
+                            f"fixed_shape_tensor of shape {expected_shape}")
 
     if from_pandas is None:
         c_from_pandas = False

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -270,7 +270,9 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         # the converter only sees the flat storage type, so validate the
         # tensor-specific constraints here where the type is still known.
         if (isinstance(extension_type, FixedShapeTensorType)
-                and isinstance(obj, (list, tuple))):
+                and isinstance(obj, Sequence)
+                and not _is_array_like(obj)
+                and not isinstance(obj, (str, bytes, bytearray))):
             if extension_type.permutation is not None:
                 raise NotImplementedError(
                     "Converting a sequence of arrays to a fixed_shape_tensor with "

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -270,22 +270,19 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         # the converter only sees the flat storage type, so validate the
         # tensor-specific constraints here where the type is still known.
         if (isinstance(extension_type, FixedShapeTensorType)
-                and isinstance(obj, Sequence)
-                and not _is_array_like(obj)
-                and not isinstance(obj, (str, bytes, bytearray))):
+                and isinstance(obj, (list, tuple))):
             if extension_type.permutation is not None:
                 raise NotImplementedError(
-                    "Converting a sequence of arrays to a fixed_shape_tensor with "
-                    "a permutation is not supported; use "
-                    "FixedShapeTensorArray.from_numpy_ndarray instead")
-            if np is not None:
-                expected_shape = tuple(extension_type.shape)
-                for element in obj:
-                    if (isinstance(element, np.ndarray) and element.ndim >= 2
-                            and tuple(element.shape) != expected_shape):
-                        raise ValueError(
-                            f"Cannot convert array of shape {element.shape} to a "
-                            f"fixed_shape_tensor of shape {expected_shape}")
+                    "Converting a sequence of arrays to a fixed_shape_tensor "
+                    "with a permutation is not supported")
+            expected_shape = tuple(extension_type.shape)
+            for element in obj:
+                shape = getattr(element, "shape", None)
+                if (shape is not None and len(shape) >= 2
+                        and tuple(shape) != expected_shape):
+                    raise ValueError(
+                        f"Cannot convert array of shape {tuple(shape)} to a "
+                        f"fixed_shape_tensor of shape {expected_shape}")
 
     if from_pandas is None:
         c_from_pandas = False

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -908,24 +908,31 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
 
   Status AppendNdarray(PyObject* value) {
     PyArrayObject* ndarray = reinterpret_cast<PyArrayObject*>(value);
-    OwnedRef flattened;
-    if (PyArray_NDIM(ndarray) != 1) {
-      // GH-49644: a fixed-size list (e.g. the storage of a fixed-shape tensor)
-      // can be built from a multi-dimensional array by flattening it in C
-      // order. The total number of elements must still match the list size,
-      // which the builder validates below. 0-dimensional arrays and
-      // variable-sized lists remain restricted to 1-dimensional values.
-      if (PyArray_NDIM(ndarray) < 2 || this->list_type_->id() != Type::FIXED_SIZE_LIST) {
-        return Status::Invalid("Can only convert 1-dimensional array values");
-      }
-      flattened.reset(PyArray_Ravel(ndarray, NPY_CORDER));
-      RETURN_IF_PYERROR();
-      value = flattened.obj();
-      ndarray = reinterpret_cast<PyArrayObject*>(value);
-    }
     if (PyArray_ISBYTESWAPPED(ndarray)) {
       // TODO
       return Status::NotImplemented("Byte-swapped arrays not supported");
+    }
+    OwnedRef flattened;
+    if (PyArray_NDIM(ndarray) != 1) {
+      // GH-49644: a fixed-size list (e.g. fixed-shape-tensor storage) can be
+      // built from a multi-dimensional array, always flattened in C order
+      // regardless of the input's memory layout.
+      if (PyArray_NDIM(ndarray) < 2 || this->list_type_->id() != Type::FIXED_SIZE_LIST) {
+        return Status::Invalid(
+            "Can only convert 1-dimensional array values to a variable-sized list");
+      }
+      // Get an aligned, C-contiguous array (copying only if needed), then view
+      // it as 1-D so its values can be read directly in C order.
+      PyObject* contiguous =
+          PyArray_CheckFromAny(value, nullptr, /*min_depth=*/0, /*max_depth=*/0,
+                               NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_ALIGNED, nullptr);
+      RETURN_IF_PYERROR();
+      flattened.reset(
+          PyArray_Ravel(reinterpret_cast<PyArrayObject*>(contiguous), NPY_CORDER));
+      Py_DECREF(contiguous);
+      RETURN_IF_PYERROR();
+      value = flattened.obj();
+      ndarray = reinterpret_cast<PyArrayObject*>(value);
     }
     const int64_t size = PyArray_SIZE(ndarray);
     RETURN_NOT_OK(AppendTo(this->list_type_, size));

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -914,14 +914,11 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
     }
     OwnedRef flattened;
     if (PyArray_NDIM(ndarray) != 1) {
-      // GH-49644: variable-sized lists only accept 1-dimensional values, and
-      // 0-dimensional arrays are still rejected.
-      if (PyArray_NDIM(ndarray) < 2) {
-        return Status::Invalid("Can only convert 1-dimensional array values");
-      }
+      // GH-49644: a fixed-size list (e.g. fixed-shape-tensor storage) is built
+      // from a multi- or 0-dimensional array by flattening it in C order.
       if (this->list_type_->id() != Type::FIXED_SIZE_LIST) {
-        return Status::Invalid(
-            "Can only convert 1-dimensional array values to a variable-sized list");
+        return Status::Invalid("Can only convert 1-dimensional array values of ",
+                               this->list_type_->ToString(), " to a variable-sized list");
       }
       // Get an aligned, C-contiguous array (copying only if needed).
       PyObject* contiguous =

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -914,15 +914,13 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
     }
     OwnedRef flattened;
     if (PyArray_NDIM(ndarray) != 1) {
-      // GH-49644: a fixed-size list (e.g. fixed-shape-tensor storage) can be
-      // built from a multi-dimensional array, always flattened in C order
-      // regardless of the input's memory layout.
+      // GH-49644: 0-dimensional arrays and variable-sized lists only accept
+      // 1-dimensional values.
       if (PyArray_NDIM(ndarray) < 2 || this->list_type_->id() != Type::FIXED_SIZE_LIST) {
         return Status::Invalid(
             "Can only convert 1-dimensional array values to a variable-sized list");
       }
-      // Get an aligned, C-contiguous array (copying only if needed), then view
-      // it as 1-D so its values can be read directly in C order.
+      // Get an aligned, C-contiguous array (copying only if needed).
       PyObject* contiguous =
           PyArray_CheckFromAny(value, nullptr, /*min_depth=*/0, /*max_depth=*/0,
                                NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_ALIGNED, nullptr);

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -915,8 +915,7 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
       // order. The total number of elements must still match the list size,
       // which the builder validates below. 0-dimensional arrays and
       // variable-sized lists remain restricted to 1-dimensional values.
-      if (PyArray_NDIM(ndarray) < 2 ||
-          this->list_type_->id() != Type::FIXED_SIZE_LIST) {
+      if (PyArray_NDIM(ndarray) < 2 || this->list_type_->id() != Type::FIXED_SIZE_LIST) {
         return Status::Invalid("Can only convert 1-dimensional array values");
       }
       flattened.reset(PyArray_Ravel(ndarray, NPY_CORDER));

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -914,9 +914,12 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
     }
     OwnedRef flattened;
     if (PyArray_NDIM(ndarray) != 1) {
-      // GH-49644: 0-dimensional arrays and variable-sized lists only accept
-      // 1-dimensional values.
-      if (PyArray_NDIM(ndarray) < 2 || this->list_type_->id() != Type::FIXED_SIZE_LIST) {
+      // GH-49644: variable-sized lists only accept 1-dimensional values, and
+      // 0-dimensional arrays are still rejected.
+      if (PyArray_NDIM(ndarray) < 2) {
+        return Status::Invalid("Can only convert 1-dimensional array values");
+      }
+      if (this->list_type_->id() != Type::FIXED_SIZE_LIST) {
         return Status::Invalid(
             "Can only convert 1-dimensional array values to a variable-sized list");
       }

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -913,9 +913,10 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
       // GH-49644: a fixed-size list (e.g. the storage of a fixed-shape tensor)
       // can be built from a multi-dimensional array by flattening it in C
       // order. The total number of elements must still match the list size,
-      // which the builder validates below. Variable-sized lists remain
-      // restricted to 1-dimensional values to avoid ambiguity.
-      if (this->list_type_->id() != Type::FIXED_SIZE_LIST) {
+      // which the builder validates below. 0-dimensional arrays and
+      // variable-sized lists remain restricted to 1-dimensional values.
+      if (PyArray_NDIM(ndarray) < 2 ||
+          this->list_type_->id() != Type::FIXED_SIZE_LIST) {
         return Status::Invalid("Can only convert 1-dimensional array values");
       }
       flattened.reset(PyArray_Ravel(ndarray, NPY_CORDER));

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -908,8 +908,20 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
 
   Status AppendNdarray(PyObject* value) {
     PyArrayObject* ndarray = reinterpret_cast<PyArrayObject*>(value);
+    OwnedRef flattened;
     if (PyArray_NDIM(ndarray) != 1) {
-      return Status::Invalid("Can only convert 1-dimensional array values");
+      // GH-49644: a fixed-size list (e.g. the storage of a fixed-shape tensor)
+      // can be built from a multi-dimensional array by flattening it in C
+      // order. The total number of elements must still match the list size,
+      // which the builder validates below. Variable-sized lists remain
+      // restricted to 1-dimensional values to avoid ambiguity.
+      if (this->list_type_->id() != Type::FIXED_SIZE_LIST) {
+        return Status::Invalid("Can only convert 1-dimensional array values");
+      }
+      flattened.reset(PyArray_Ravel(ndarray, NPY_CORDER));
+      RETURN_IF_PYERROR();
+      value = flattened.obj();
+      ndarray = reinterpret_cast<PyArrayObject*>(value);
     }
     if (PyArray_ISBYTESWAPPED(ndarray)) {
       // TODO

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2949,9 +2949,9 @@ def test_fixed_size_list_from_multidim_ndarray():
         pa.array([np.array([[1, 2, 3]], dtype=np.int64)],
                  type=pa.list_(pa.int64()))
 
-    # 0-dimensional arrays are still rejected (not flattened to length 1)
-    with pytest.raises(pa.lib.ArrowInvalid, match="1-dimensional"):
-        pa.array([np.array(1, dtype=np.int64)], type=pa.list_(pa.int64(), 1))
+    # 0-dimensional arrays are flattened into a length-1 fixed-size list (GH-49644)
+    arr = pa.array([np.array(1, dtype=np.int64)], type=pa.list_(pa.int64(), 1))
+    assert arr.to_pylist() == [[1]]
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2926,30 +2926,24 @@ def test_array_from_invalid_dim_raises():
 
 @pytest.mark.numpy
 def test_fixed_size_list_from_multidim_ndarray():
-    # GH-49644: a fixed-size list can be built from multi-dimensional ndarray
-    # elements by flattening them in C order.
     arr = pa.array([np.array([[1, 2, 3]], dtype=np.int64),
                     np.array([[4, 5, 6]], dtype=np.int64)],
                    type=pa.list_(pa.int64(), 3))
     assert arr.type == pa.list_(pa.int64(), 3)
     assert arr.to_pylist() == [[1, 2, 3], [4, 5, 6]]
 
-    # A non-trivial 2D shape confirms values are flattened in C (row-major) order
     arr = pa.array([np.array([[1, 2], [3, 4]], dtype=np.int64)],
                    type=pa.list_(pa.int64(), 4))
     assert arr.to_pylist() == [[1, 2, 3, 4]]
 
-    # The flattened length must still match the fixed size
     with pytest.raises(pa.lib.ArrowInvalid):
         pa.array([np.array([[1, 2], [3, 4]], dtype=np.int64)],
                  type=pa.list_(pa.int64(), 3))
 
-    # Variable-sized lists still require 1-dimensional values
-    with pytest.raises(pa.lib.ArrowInvalid, match="1-dimensional"):
+    with pytest.raises(pa.lib.ArrowInvalid, match=r"array values of .*int64"):
         pa.array([np.array([[1, 2, 3]], dtype=np.int64)],
                  type=pa.list_(pa.int64()))
 
-    # 0-dimensional arrays are flattened into a length-1 fixed-size list (GH-49644)
     arr = pa.array([np.array(1, dtype=np.int64)], type=pa.list_(pa.int64(), 1))
     assert arr.to_pylist() == [[1]]
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2949,6 +2949,10 @@ def test_fixed_size_list_from_multidim_ndarray():
         pa.array([np.array([[1, 2, 3]], dtype=np.int64)],
                  type=pa.list_(pa.int64()))
 
+    # 0-dimensional arrays are still rejected (not flattened to length 1)
+    with pytest.raises(pa.lib.ArrowInvalid, match="1-dimensional"):
+        pa.array([np.array(1, dtype=np.int64)], type=pa.list_(pa.int64(), 1))
+
 
 @pytest.mark.numpy
 def test_array_from_strided_bool():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2925,6 +2925,24 @@ def test_array_from_invalid_dim_raises():
 
 
 @pytest.mark.numpy
+def test_fixed_size_list_from_multidim_ndarray():
+    # GH-49644: a fixed-size list can be built from multi-dimensional ndarray
+    # elements by flattening them in C order.
+    arr = pa.array([np.array([[1, 2, 3]]), np.array([[4, 5, 6]])],
+                   type=pa.list_(pa.int64(), 3))
+    assert arr.type == pa.list_(pa.int64(), 3)
+    assert arr.to_pylist() == [[1, 2, 3], [4, 5, 6]]
+
+    # The flattened length must still match the fixed size
+    with pytest.raises(pa.lib.ArrowInvalid):
+        pa.array([np.array([[1, 2], [3, 4]])], type=pa.list_(pa.int64(), 3))
+
+    # Variable-sized lists still require 1-dimensional values
+    with pytest.raises(pa.lib.ArrowInvalid, match="1-dimensional"):
+        pa.array([np.array([[1, 2, 3]])], type=pa.list_(pa.int64()))
+
+
+@pytest.mark.numpy
 def test_array_from_strided_bool():
     # ARROW-6325
     arr = np.ones((3, 2), dtype=bool)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2928,18 +2928,26 @@ def test_array_from_invalid_dim_raises():
 def test_fixed_size_list_from_multidim_ndarray():
     # GH-49644: a fixed-size list can be built from multi-dimensional ndarray
     # elements by flattening them in C order.
-    arr = pa.array([np.array([[1, 2, 3]]), np.array([[4, 5, 6]])],
+    arr = pa.array([np.array([[1, 2, 3]], dtype=np.int64),
+                    np.array([[4, 5, 6]], dtype=np.int64)],
                    type=pa.list_(pa.int64(), 3))
     assert arr.type == pa.list_(pa.int64(), 3)
     assert arr.to_pylist() == [[1, 2, 3], [4, 5, 6]]
 
+    # A non-trivial 2D shape confirms values are flattened in C (row-major) order
+    arr = pa.array([np.array([[1, 2], [3, 4]], dtype=np.int64)],
+                   type=pa.list_(pa.int64(), 4))
+    assert arr.to_pylist() == [[1, 2, 3, 4]]
+
     # The flattened length must still match the fixed size
     with pytest.raises(pa.lib.ArrowInvalid):
-        pa.array([np.array([[1, 2], [3, 4]])], type=pa.list_(pa.int64(), 3))
+        pa.array([np.array([[1, 2], [3, 4]], dtype=np.int64)],
+                 type=pa.list_(pa.int64(), 3))
 
     # Variable-sized lists still require 1-dimensional values
     with pytest.raises(pa.lib.ArrowInvalid, match="1-dimensional"):
-        pa.array([np.array([[1, 2, 3]])], type=pa.list_(pa.int64()))
+        pa.array([np.array([[1, 2, 3]], dtype=np.int64)],
+                 type=pa.list_(pa.int64()))
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1778,10 +1778,32 @@ def test_tensor_array_from_list_of_ndarrays(np_type_str):
     with pytest.raises(NotImplementedError, match="permutation"):
         pa.array(elements, type=permuted_type)
 
-    # The validation also applies to non-list sequences (e.g. a deque)
-    from collections import deque
-    with pytest.raises(NotImplementedError, match="permutation"):
-        pa.array(deque(elements), type=permuted_type)
+
+@pytest.mark.numpy
+def test_tensor_array_from_list_mixed_layout():
+    # GH-49644: C- and F-ordered arrays with the same values must produce the
+    # same result, since the values are always flattened in C order.
+    tensor_type = pa.fixed_shape_tensor(pa.int64(), (2, 3))
+    raw = [[1, 2, 3], [4, 5, 6]]
+    c_arr = np.array(raw, order="C")
+    f_arr = np.array(raw, order="F")
+    assert np.array_equal(c_arr, f_arr)
+    assert c_arr.tobytes("A") != f_arr.tobytes("A")
+
+    same = pa.array([c_arr, c_arr], type=tensor_type)
+    mixed = pa.array([c_arr, f_arr], type=tensor_type)
+    assert mixed.equals(same)
+    assert mixed.storage.to_pylist() == [[1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]]
+
+
+@pytest.mark.numpy
+def test_tensor_array_from_list_of_0d_arrays():
+    # GH-49644: a scalar (0-dimensional) tensor can be built from 0-D arrays.
+    tensor_type = pa.fixed_shape_tensor(pa.int64(), ())
+    result = pa.array([np.array(1, dtype=np.int64), np.array(2, dtype=np.int64)],
+                      type=tensor_type)
+    assert result.type == tensor_type
+    assert result.storage.to_pylist() == [[1], [2]]
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1733,8 +1733,7 @@ def test_tensor_array_from_numpy(np_type_str):
 @pytest.mark.numpy
 @pytest.mark.parametrize("np_type_str", ("int8", "int64", "float32"))
 def test_tensor_array_from_list_of_ndarrays(np_type_str):
-    # GH-49644: build a fixed-shape-tensor array from a list of individual
-    # (multi-dimensional) ndarrays, not only from a single stacked ndarray.
+    # GH-49644
     np_dtype = np.dtype(np_type_str)
     tensor_type = pa.fixed_shape_tensor(pa.from_numpy_dtype(np_dtype), (2, 3))
 

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1767,9 +1767,17 @@ def test_tensor_array_from_list_of_ndarrays(np_type_str):
     assert result_with_null.null_count == 1
     assert result_with_null[1].as_py() is None
 
-    # A flattened size that doesn't match the tensor shape is rejected
-    with pytest.raises(pa.lib.ArrowInvalid):
-        pa.array([np.arange(8, dtype=np_dtype).reshape(2, 4)], type=tensor_type)
+    # A multi-dimensional element whose shape doesn't match the tensor shape is
+    # rejected, even when the total number of elements is the same (GH-49644).
+    with pytest.raises(ValueError, match="shape"):
+        pa.array([np.arange(6, dtype=np_dtype).reshape(3, 2)], type=tensor_type)
+
+    # Permuted tensor types can't be built from a sequence (the flatten would
+    # store the wrong layout), so they're rejected for now.
+    permuted_type = pa.fixed_shape_tensor(
+        pa.from_numpy_dtype(np_dtype), (2, 3), permutation=[1, 0])
+    with pytest.raises(NotImplementedError, match="permutation"):
+        pa.array(elements, type=permuted_type)
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1733,7 +1733,6 @@ def test_tensor_array_from_numpy(np_type_str):
 @pytest.mark.numpy
 @pytest.mark.parametrize("np_type_str", ("int8", "int64", "float32"))
 def test_tensor_array_from_list_of_ndarrays(np_type_str):
-    # GH-49644
     np_dtype = np.dtype(np_type_str)
     tensor_type = pa.fixed_shape_tensor(pa.from_numpy_dtype(np_dtype), (2, 3))
 
@@ -1746,33 +1745,25 @@ def test_tensor_array_from_list_of_ndarrays(np_type_str):
     assert result.type == tensor_type
     assert len(result) == 2
 
-    # Must match the existing from_numpy_ndarray path on the same data
     expected = pa.FixedShapeTensorArray.from_numpy_ndarray(np.stack(elements))
     assert result.storage.equals(expected.storage)
 
-    # Each element round-trips back to the original ndarray (with its shape)
     for scalar, original in zip(result, elements):
         np.testing.assert_array_equal(scalar.to_numpy(), original)
 
-    # Higher-dimensional tensors work too
     tensor_3d = pa.fixed_shape_tensor(pa.from_numpy_dtype(np_dtype), (2, 2, 3))
     elements_3d = [np.arange(12, dtype=np_dtype).reshape(2, 2, 3)]
     result_3d = pa.array(elements_3d, type=tensor_3d)
     assert result_3d.type == tensor_3d
     np.testing.assert_array_equal(result_3d[0].to_numpy(), elements_3d[0])
 
-    # None elements are allowed
     result_with_null = pa.array([elements[0], None], type=tensor_type)
     assert result_with_null.null_count == 1
     assert result_with_null[1].as_py() is None
 
-    # A multi-dimensional element whose shape doesn't match the tensor shape is
-    # rejected, even when the total number of elements is the same (GH-49644).
     with pytest.raises(ValueError, match="shape"):
         pa.array([np.arange(6, dtype=np_dtype).reshape(3, 2)], type=tensor_type)
 
-    # Permuted tensor types can't be built from a sequence (the flatten would
-    # store the wrong layout), so they're rejected for now.
     permuted_type = pa.fixed_shape_tensor(
         pa.from_numpy_dtype(np_dtype), (2, 3), permutation=[1, 0])
     with pytest.raises(NotImplementedError, match="permutation"):
@@ -1781,8 +1772,8 @@ def test_tensor_array_from_list_of_ndarrays(np_type_str):
 
 @pytest.mark.numpy
 def test_tensor_array_from_list_mixed_layout():
-    # GH-49644: C- and F-ordered arrays with the same values must produce the
-    # same result, since the values are always flattened in C order.
+    # C- and F-ordered arrays with the same values must produce the same
+    # result, since the values are always flattened in C order.
     tensor_type = pa.fixed_shape_tensor(pa.int64(), (2, 3))
     raw = [[1, 2, 3], [4, 5, 6]]
     c_arr = np.array(raw, order="C")
@@ -1798,7 +1789,6 @@ def test_tensor_array_from_list_mixed_layout():
 
 @pytest.mark.numpy
 def test_tensor_array_from_list_of_0d_arrays():
-    # GH-49644: a scalar (0-dimensional) tensor can be built from 0-D arrays.
     tensor_type = pa.fixed_shape_tensor(pa.int64(), ())
     result = pa.array([np.array(1, dtype=np.int64), np.array(2, dtype=np.int64)],
                       type=tensor_type)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1778,6 +1778,11 @@ def test_tensor_array_from_list_of_ndarrays(np_type_str):
     with pytest.raises(NotImplementedError, match="permutation"):
         pa.array(elements, type=permuted_type)
 
+    # The validation also applies to non-list sequences (e.g. a deque)
+    from collections import deque
+    with pytest.raises(NotImplementedError, match="permutation"):
+        pa.array(deque(elements), type=permuted_type)
+
 
 @pytest.mark.numpy
 @pytest.mark.parametrize("tensor_type", (

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1731,6 +1731,48 @@ def test_tensor_array_from_numpy(np_type_str):
 
 
 @pytest.mark.numpy
+@pytest.mark.parametrize("np_type_str", ("int8", "int64", "float32"))
+def test_tensor_array_from_list_of_ndarrays(np_type_str):
+    # GH-49644: build a fixed-shape-tensor array from a list of individual
+    # (multi-dimensional) ndarrays, not only from a single stacked ndarray.
+    np_dtype = np.dtype(np_type_str)
+    tensor_type = pa.fixed_shape_tensor(pa.from_numpy_dtype(np_dtype), (2, 3))
+
+    elements = [
+        np.arange(6, dtype=np_dtype).reshape(2, 3),
+        np.arange(6, 12, dtype=np_dtype).reshape(2, 3),
+    ]
+    result = pa.array(elements, type=tensor_type)
+    assert isinstance(result, pa.FixedShapeTensorArray)
+    assert result.type == tensor_type
+    assert len(result) == 2
+
+    # Must match the existing from_numpy_ndarray path on the same data
+    expected = pa.FixedShapeTensorArray.from_numpy_ndarray(np.stack(elements))
+    assert result.storage.equals(expected.storage)
+
+    # Each element round-trips back to the original ndarray (with its shape)
+    for scalar, original in zip(result, elements):
+        np.testing.assert_array_equal(scalar.to_numpy(), original)
+
+    # Higher-dimensional tensors work too
+    tensor_3d = pa.fixed_shape_tensor(pa.from_numpy_dtype(np_dtype), (2, 2, 3))
+    elements_3d = [np.arange(12, dtype=np_dtype).reshape(2, 2, 3)]
+    result_3d = pa.array(elements_3d, type=tensor_3d)
+    assert result_3d.type == tensor_3d
+    np.testing.assert_array_equal(result_3d[0].to_numpy(), elements_3d[0])
+
+    # None elements are allowed
+    result_with_null = pa.array([elements[0], None], type=tensor_type)
+    assert result_with_null.null_count == 1
+    assert result_with_null[1].as_py() is None
+
+    # A flattened size that doesn't match the tensor shape is rejected
+    with pytest.raises(pa.lib.ArrowInvalid):
+        pa.array([np.arange(8, dtype=np_dtype).reshape(2, 4)], type=tensor_type)
+
+
+@pytest.mark.numpy
 @pytest.mark.parametrize("tensor_type", (
     pa.fixed_shape_tensor(pa.int8(), [2, 2, 3]),
     pa.fixed_shape_tensor(pa.int8(), [2, 2, 3], permutation=[0, 2, 1]),


### PR DESCRIPTION
### Rationale for this change

Constructing a fixed-shape-tensor array from a list of individual ndarrays only
worked when each element was 1-D; ≥2-D elements failed with
`ArrowInvalid: Can only convert 1-dimensional array values`. The only workaround
was stacking the list into a single ndarray and using
`FixedShapeTensorArray.from_numpy_ndarray`.

### What changes are included in this PR?

The C++ list converter `PyListConverter::AppendNdarray` now accepts
multi-dimensional ndarray elements for **fixed-size lists** (the storage of a
fixed-shape tensor) by flattening them in C order. The fixed-size-list builder
still validates that the flattened length matches the list width, so wrong sizes
error cleanly. Variable-sized lists remain restricted to 1-D values to avoid
ambiguity. As a side benefit, plain `fixed_size_list` also accepts
multi-dimensional ndarray elements now.

### Are these changes tested?

Yes:
- `test_tensor_array_from_list_of_ndarrays` — construction from 2-D and 3-D
  ndarrays, null handling, storage parity with `from_numpy_ndarray`, and the
  size-mismatch error, across `int8`/`int64`/`float32`.
- `test_fixed_size_list_from_multidim_ndarray` — plain `fixed_size_list` from
  multi-dim arrays, plus a check that variable-sized lists still reject 2-D.

### Are there any user-facing changes?

Yes — `pa.array([multi-dim ndarrays], type=fixed_shape_tensor(...))` (and the
same for `fixed_size_list`) now works instead of raising. Existing 1-D behavior
and variable-sized-list behavior are unchanged.

Scoped to construction only; the reverse `to_numpy` shape-preservation also
raised in the issue is intentionally left as a separate follow-up.
* GitHub Issue: #49644