### PR TITLE
GH-50204: [C++] Fix S3FileSystem::MakeUri dropping the bucket on Windows MinGW

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -3053,12 +3053,13 @@ Result<std::string> S3FileSystem::MakeUri(std::string path) const {
     return Status::Invalid("MakeUri requires an absolute, non-root path, got ", path);
   }
   ARROW_ASSIGN_OR_RAISE(auto uri_from_path, util::UriFromAbsolutePath(path));
-  constexpr std::string_view kFileScheme = "file:///";
+  constexpr std::string_view kFileScheme = "file://";
   std::string_view uri_view(uri_from_path);
   if (uri_view.starts_with(kFileScheme)) {
     uri_view.remove_prefix(kFileScheme.size());
-  } else if (uri_view.starts_with("/")) {
-    // MinGW doesn't have `file:///` scheme, we just remove the leading slash
+  }
+  if (uri_view.starts_with("/")) {
+    // Remove leading slash if present
     uri_view.remove_prefix(1);
   }
   std::string uri = "s3://";

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -3052,13 +3052,20 @@ Result<std::string> S3FileSystem::MakeUri(std::string path) const {
   if (path.length() <= 1 || path[0] != '/') {
     return Status::Invalid("MakeUri requires an absolute, non-root path, got ", path);
   }
-  ARROW_ASSIGN_OR_RAISE(auto uri, util::UriFromAbsolutePath(path));
-  if (!options().GetAccessKey().empty()) {
-    uri = "s3://" + options().GetAccessKey() + ":" + options().GetSecretKey() + "@" +
-          uri.substr("file:///"s.size());
-  } else {
-    uri = "s3" + uri.substr("file"s.size());
+  ARROW_ASSIGN_OR_RAISE(auto uri_from_path, util::UriFromAbsolutePath(path));
+  constexpr std::string_view kFileScheme = "file:///";
+  std::string_view uri_view(uri_from_path);
+  if (uri_view.starts_with(kFileScheme)) {
+    uri_view.remove_prefix(kFileScheme.size());
+  } else if (uri_view.starts_with("/")) {
+    // MinGW doesn't have `file:///` scheme, we just remove the leading slash
+    uri_view.remove_prefix(1);
   }
+  std::string uri = "s3://";
+  if (!options().GetAccessKey().empty()) {
+    uri += options().GetAccessKey() + ":" + options().GetSecretKey() + "@";
+  }
+  uri += std::string(uri_view);
   uri += "?";
   uri += "region=" + util::UriEscape(options().region);
   uri += "&";

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -500,6 +500,7 @@ TEST_F(S3FileSystemMakeUri, MakeUriWithCredentials) {
 
 TEST_F(S3FileSystemMakeUri, MakeUriWithoutCredentials) {
   S3Options options;
+  options.ConfigureAnonymousCredentials();
   options.region = "us-east-1";
   ASSERT_OK_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
   ASSERT_OK_AND_ASSIGN(auto uri, fs->MakeUri("/bucket/somedir/subdir/subfile"));

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -482,6 +482,34 @@ TEST_F(S3FileSystemRegionTest, EnvironmentVariable) {
 #endif
 
 ////////////////////////////////////////////////////////////////////////////
+// S3FileSystem make URI test
+
+class S3FileSystemMakeUri : public AwsTestMixin {};
+
+TEST_F(S3FileSystemMakeUri, MakeUriWithCredentials) {
+  S3Options options;
+  options.ConfigureAccessKey("minio", "miniopass");
+  options.region = "us-east-1";
+  ASSERT_OK_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  ASSERT_OK_AND_ASSIGN(auto uri, fs->MakeUri("/bucket/somedir/subdir/subfile"));
+  EXPECT_EQ(uri,
+            "s3://minio:miniopass@bucket/somedir/subdir/subfile"
+            "?region=us-east-1&scheme=https&endpoint_override="
+            "&allow_bucket_creation=0&allow_bucket_deletion=0");
+}
+
+TEST_F(S3FileSystemMakeUri, MakeUriWithoutCredentials) {
+  S3Options options;
+  options.region = "us-east-1";
+  ASSERT_OK_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  ASSERT_OK_AND_ASSIGN(auto uri, fs->MakeUri("/bucket/somedir/subdir/subfile"));
+  EXPECT_EQ(uri,
+            "s3://bucket/somedir/subdir/subfile"
+            "?region=us-east-1&scheme=https&endpoint_override="
+            "&allow_bucket_creation=0&allow_bucket_deletion=0");
+}
+
+////////////////////////////////////////////////////////////////////////////
 // Basic test for the Minio test server.
 
 class TestMinioServer : public S3TestMixin {
@@ -1735,19 +1763,6 @@ TEST(S3GlobalOptions, DefaultsLogLevel) {
     EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "invalid");
     ASSERT_EQ(S3LogLevel::Fatal, arrow::fs::S3GlobalOptions::Defaults().log_level);
   }
-}
-
-//// Minor validation test
-TEST_F(S3OptionsTest, MakeUri) {
-  S3Options options;
-  options.ConfigureAccessKey("minio", "miniopass");
-  options.region = "us-east-1";
-  ASSERT_OK_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
-  ASSERT_OK_AND_ASSIGN(auto uri, fs->MakeUri("/bucket/somedir/subdir/subfile"));
-  EXPECT_EQ(uri,
-            "s3://minio:miniopass@bucket/somedir/subdir/subfile"
-            "?region=us-east-1&scheme=https&endpoint_override="
-            "&allow_bucket_creation=0&allow_bucket_deletion=0");
 }
 
 }  // namespace fs

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1737,5 +1737,18 @@ TEST(S3GlobalOptions, DefaultsLogLevel) {
   }
 }
 
+//// Minor validation test
+TEST_F(S3OptionsTest, MakeUri) {
+  S3Options options;
+  options.ConfigureAccessKey("minio", "miniopass");
+  options.region = "us-east-1";
+  ASSERT_OK_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  ASSERT_OK_AND_ASSIGN(auto uri, fs->MakeUri("/bucket/somedir/subdir/subfile"));
+  EXPECT_EQ(uri,
+            "s3://minio:miniopass@bucket/somedir/subdir/subfile"
+            "?region=us-east-1&scheme=https&endpoint_override="
+            "&allow_bucket_creation=0&allow_bucket_deletion=0");
+}
+
 }  // namespace fs
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

`S3FileSystem::MakeUri` wasn't exercised on CI only on `s3fs-module-test` and on Linux. It currently fails for MinGW.

### What changes are included in this PR?

Properly parse URI on both Linux/Windows MSVC and MinGW environments. Added tests for coverage.

### Are these changes tested?

Yes, new tests have been added.

### Are there any user-facing changes?

No

* GitHub Issue: #50204