### PR TITLE
GH-50174: [CI][Python] Fix debug Python job

### DIFF
--- a/ci/docker/conda-python-cpython-debug.dockerfile
+++ b/ci/docker/conda-python-cpython-debug.dockerfile
@@ -22,7 +22,7 @@ FROM ${repo}:${arch}-conda-python-${python}
 
 # (Docker oddity: ARG needs to be repeated after FROM)
 ARG python=3.10
-RUN mamba install -y "conda-forge/label/python_debug::python=${python}[build=*_cpython]" && \
+RUN mamba install -c conda-forge/label/python_debug cpython "python=${python}[build=*_debug_*]" && \
     mamba clean --all --yes
 # Quick check that we do have a debug mode CPython
 RUN python -c "import sys; sys.gettotalrefcount()"

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -508,12 +508,12 @@ tasks:
       image: conda-python
 {% endfor %}
 
-  test-conda-python-3.12-cpython-debug:
+  test-conda-python-3.14-cpython-debug:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        PYTHON: 3.12
+        PYTHON: 3.14
       image: conda-python-cpython-debug
 
   test-conda-python-emscripten:


### PR DESCRIPTION
### Rationale for this change

Use a different Python version (3.14) than the one that's being used by GDB for its own scripting (3.12), otherwise the two can conflict.

### Are these changes tested?

Yes, by existing CI tests.

### Are there any user-facing changes?

No.
* GitHub Issue: #50174