### PR TITLE
GH-50208: [CI][C++][Python] Disable ccache `hash_dir`

### DIFF
--- a/ci/scripts/ccache_setup.sh
+++ b/ci/scripts/ccache_setup.sh
@@ -19,10 +19,12 @@
 
 set -eux
 
+# See similar definitions in compose.yaml under the `x-ccache` key
 {
   echo "ARROW_USE_CCACHE=ON"
   echo "CCACHE_COMPILERCHECK=content"
   echo "CCACHE_COMPRESS=1"
   echo "CCACHE_COMPRESSLEVEL=6"
   echo "CCACHE_MAXSIZE=1G"
+  echo "CCACHE_NOHASHDIR=1"
 } >> "$GITHUB_ENV"

--- a/compose.yaml
+++ b/compose.yaml
@@ -59,6 +59,9 @@ x-ccache: &ccache
   CCACHE_COMPRESSLEVEL: 6
   CCACHE_MAXSIZE: 1G
   CCACHE_DIR: /ccache
+  # Some builds (such as PyArrow) copy their source files in a temporary directory,
+  # avoid hashing the current directory to make ccache useful on those builds.
+  CCACHE_NOHASHDIR: 1
 
 x-common: &common
   GITHUB_ACTIONS:


### PR DESCRIPTION
### Rationale for this change

By default, ccache hashes the path to the current directory in its cache key. However, some builds put their source files in a temporary directory (such as Python builds), which makes caching inefficient as the current directory is different everytime.

### What changes are included in this PR?

Disable the ccache `hash_dir` option on CI, using an environment variable.

### Are these changes tested?

Yes, by existing CI jobs.

I also checked locally using `ccache -s` that this improves the caching of compiled C++ artifacts (from the source files in `python/pyarrow/src`) when building PyArrow.

### Are there any user-facing changes?

No.

* GitHub Issue: #50208