### PR TITLE
GH-50173: [C++][Gandiva] Install tzdata-legacy to fix failing TestTime.TestCastTimestampWithTZ from gandiva/precompiled/time_test.cc

### DIFF
--- a/ci/docker/conda.dockerfile
+++ b/ci/docker/conda.dockerfile
@@ -26,6 +26,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     gdb \
     libc6-dbg \
     tzdata \
+    tzdata-legacy \
     wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Rationale for this change

issue #50173 - change from Ubuntu:22.04 to 24.04: legacy timezone `Canada/Pacific` is split into separate `tzdata-legacy` package.
```bash
[ RUN      ] TestTime.TestCastTimestampWithTZ
/arrow/cpp/src/gandiva/precompiled/time_test.cc:210: Failure
Expected equality of these values:
  castTIMESTAMP_utf8(context_ptr, "2000-09-23 9:45:30.920 Canada/Pacific", 37)
    Which is: 0
  969727530920
```
`179 - gandiva-precompiled-test (Failed)                 gandiva-tests unittest`

https://documentation.ubuntu.com/release-notes/24.04/#tzdata-package-split : _The tzdata package was split into tzdata, tzdata-icu, and tzdata-legacy. ... Please install tzdata-legacy in case you need the legacy timezones or to restore the previous behavior._

### What changes are included in this PR?
Adding `tzdata-legacy` to `conda.dockerfile`.

### Are these changes tested?
CI jobs pass.

### Are there any user-facing changes?
No.
* GitHub Issue: #50173