### PR TITLE
GH-50212: [C++][Parquet] Add PrintTo to fix failure in parquet-internals-test on test-conda-cpp-valgrind

### DIFF
--- a/cpp/src/parquet/bloom_filter_reader_writer_test.cc
+++ b/cpp/src/parquet/bloom_filter_reader_writer_test.cc
@@ -159,6 +159,12 @@ struct BloomFilterBuilderFoldingTestCase {
   int64_t expected_bitset_ndv;
 };
 
+void PrintTo(const BloomFilterBuilderFoldingTestCase& test_case, std::ostream* os) {
+  *os << "{ndv=" << test_case.ndv << ", fold=" << test_case.fold
+      << ", inserted_count=" << test_case.inserted_count
+      << ", expected_bitset_ndv=" << test_case.expected_bitset_ndv << "}";
+}
+
 class BloomFilterBuilderFoldingTest
     : public ::testing::TestWithParam<BloomFilterBuilderFoldingTestCase> {};
 


### PR DESCRIPTION
### Rationale for this change
Fix #50212 
`Test  #89: parquet-internals-test .......................***Failed   14.96 sec`

### What changes are included in this PR?
Add custom `PrintTo` for parameter `BloomFilterBuilderFoldingTestCase` introduced with pr #50008, so gtest prints fields instead of raw bytes (error `Use of uninitialised value`).

Similar to the past solution in commit 1b7e3967 but with additional field names/debug output.

### Are these changes tested?
Yes, by CI.
### Are there any user-facing changes?
No.
* GitHub Issue: #50212