### PR TITLE
GH-50216: [C++][Parquet] Add RleBitPackedToBitmapDecoder

### DIFF
--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -99,6 +99,7 @@ add_arrow_test(bit-utility-test
                bit_util_test.cc
                bitmap_test.cc
                bpacking_test.cc
+               rle_bitmap_test.cc
                rle_encoding_test.cc
                test_common.cc)
 

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -183,8 +183,8 @@ template <typename Uint>
 struct CopyBitsParams {
   Uint src = {};
   Uint dst = {};
-  Uint start = {};
-  Uint end = {};
+  int start = {};
+  int end = {};
 };
 
 /// Copy a contiguous span of bits from src into dst.
@@ -195,19 +195,20 @@ struct CopyBitsParams {
 /// guarantee that the range of bits to copy does not cover the whole range.
 template <typename Uint, bool kAllowFullCopy = true>
 [[nodiscard]] constexpr Uint CopyBitsInInteger(const CopyBitsParams<Uint>& params) {
-  constexpr auto kUintSizeBits = static_cast<Uint>(sizeof(Uint) * 8);
+  constexpr auto kUintSizeBits = static_cast<int>(sizeof(Uint) * 8);
   assert(params.start <= params.end);
   assert(params.start < kUintSizeBits);
   assert(params.end <= kUintSizeBits);
 
-  const auto length = static_cast<Uint>(params.end - params.start);
+  const int length = params.end - params.start;
   if constexpr (kAllowFullCopy) {
     if (length == kUintSizeBits) {
       return params.src;
     }
   }
   assert(length < kUintSizeBits);
-  const Uint mask = LeastSignificantBitMask<Uint, false>(length) << params.start;
+  const Uint mask =
+      static_cast<Uint>(LeastSignificantBitMask<Uint, false>(length) << params.start);
   return (~mask & params.dst) | (mask & params.src);
 }
 

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -20,8 +20,10 @@
 #include <bit>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <type_traits>
 
+#include "arrow/util/endian.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
@@ -175,6 +177,22 @@ static constexpr bool GetBit(const uint8_t* bits, uint64_t i) {
 // Gets the i-th bit from a byte. Should only be used with i <= 7.
 static constexpr bool GetBitFromByte(uint8_t byte, uint8_t i) {
   return byte & kBitmask[i];
+}
+
+/// Read 32 bits starting at bit `offset` into a uint32.
+///
+/// The return value in in-memory byte layout matches the source bit-stream
+/// identically on little- and big-endian platforms.
+///
+/// The caller must guarantee that many bytes are readable.
+static inline uint32_t Get32Bits(const uint8_t* bits, uint64_t offset) {
+  uint64_t buffer = {};
+  std::memcpy(&buffer, bits + (offset / 8), BytesForBits(offset % 8 + 32));
+  // Interpret the loaded bytes as little-endian, drop the low `offset % 8` bits
+  // to align LSB-first, then store back in little-endian byte order so the
+  // result's memory representation matches the bit-stream.
+  buffer = FromLittleEndian(buffer);
+  return ToLittleEndian(static_cast<uint32_t>(buffer >> (offset % 8)));
 }
 
 template <typename Uint>

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -179,22 +179,6 @@ static constexpr bool GetBitFromByte(uint8_t byte, uint8_t i) {
   return byte & kBitmask[i];
 }
 
-/// Read 32 bits starting at bit `offset` into a uint32.
-///
-/// The return value in in-memory byte layout matches the source bit-stream
-/// identically on little- and big-endian platforms.
-///
-/// The caller must guarantee that many bytes are readable.
-static inline uint32_t Get32Bits(const uint8_t* bits, uint64_t offset) {
-  uint64_t buffer = {};
-  std::memcpy(&buffer, bits + (offset / 8), BytesForBits(offset % 8 + 32));
-  // Interpret the loaded bytes as little-endian, drop the low `offset % 8` bits
-  // to align LSB-first, then store back in little-endian byte order so the
-  // result's memory representation matches the bit-stream.
-  buffer = FromLittleEndian(buffer);
-  return ToLittleEndian(static_cast<uint32_t>(buffer >> (offset % 8)));
-}
-
 template <typename Uint>
 struct CopyBitsParams {
   Uint src = {};

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -194,7 +194,7 @@ struct CopyBitsParams {
 /// Setting ``kAllowFullCopy`` to false is an optimization when the caller can
 /// guarantee that the range of bits to copy does not cover the whole range.
 template <typename Uint, bool kAllowFullCopy = true>
-[[nodiscard]] constexpr Uint CopyBits(const CopyBitsParams<Uint>& params) {
+[[nodiscard]] constexpr Uint CopyBitsInInteger(const CopyBitsParams<Uint>& params) {
   constexpr auto kUintSizeBits = static_cast<Uint>(sizeof(Uint) * 8);
   assert(params.start <= params.end);
   assert(params.start < kUintSizeBits);

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <bit>
+#include <cassert>
 #include <cstdint>
 #include <type_traits>
 
@@ -174,6 +175,38 @@ static constexpr bool GetBit(const uint8_t* bits, uint64_t i) {
 // Gets the i-th bit from a byte. Should only be used with i <= 7.
 static constexpr bool GetBitFromByte(uint8_t byte, uint8_t i) {
   return byte & kBitmask[i];
+}
+
+template <typename Uint>
+struct CopyBitsParams {
+  Uint src = {};
+  Uint dst = {};
+  Uint start = {};
+  Uint end = {};
+};
+
+/// Copy a contiguous span of bits from src into dst.
+///
+/// Copy bits [start, end[ from src into the position [start, end[ in dst
+/// and return the result (inputs are unmodified).
+/// Setting ``kAllowFullCopy`` to false is an optimization when the caller can
+/// guarantee that the range of bits to copy does not cover the whole range.
+template <typename Uint, bool kAllowFullCopy = true>
+[[nodiscard]] constexpr Uint CopyBits(const CopyBitsParams<Uint>& params) {
+  constexpr auto kUintSizeBits = static_cast<Uint>(sizeof(Uint) * 8);
+  assert(params.start <= params.end);
+  assert(params.start < kUintSizeBits);
+  assert(params.end <= kUintSizeBits);
+
+  const auto length = static_cast<Uint>(params.end - params.start);
+  if constexpr (kAllowFullCopy) {
+    if (length == kUintSizeBits) {
+      return params.src;
+    }
+  }
+  assert(length < kUintSizeBits);
+  const Uint mask = LeastSignificantBitMask<Uint, false>(length) << params.start;
+  return (~mask & params.dst) | (mask & params.src);
 }
 
 static inline void ClearBit(uint8_t* bits, int64_t i) {

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1067,35 +1067,35 @@ TEST(SpliceWord, SpliceWord) {
 
 TEST(BitUtil, CopyBits) {
   // Copy bits [start, end[ from src into dst, keeping dst's other bits.
-  using bit_util::CopyBits;
+  using bit_util::CopyBitsInInteger;
 
   // Empty range: result equals dst.
-  ASSERT_EQ(
-      CopyBits<uint8_t>({.src = 0b11111111, .dst = 0b00010010, .start = 3, .end = 3}),
-      0b00010010);
+  ASSERT_EQ(CopyBitsInInteger<uint8_t>(
+                {.src = 0b11111111, .dst = 0b00010010, .start = 3, .end = 3}),
+            0b00010010);
   // dst = 0101 0101, src = 1010 1010  ->  0101 1010
-  ASSERT_EQ(
-      CopyBits<uint8_t>({.src = 0b10101010, .dst = 0b01010101, .start = 0, .end = 4}),
-      0b01011010);
+  ASSERT_EQ(CopyBitsInInteger<uint8_t>(
+                {.src = 0b10101010, .dst = 0b01010101, .start = 0, .end = 4}),
+            0b01011010);
   // Copy a middle span [2, 5[ of all-ones into an all-zeros dst.
-  ASSERT_EQ(
-      CopyBits<uint8_t>({.src = 0b11111111, .dst = 0b00000000, .start = 2, .end = 5}),
-      0b00011100);
+  ASSERT_EQ(CopyBitsInInteger<uint8_t>(
+                {.src = 0b11111111, .dst = 0b00000000, .start = 2, .end = 5}),
+            0b00011100);
   // Copy a middle span [2, 5[ of all-zeros into an all-ones dst.
-  ASSERT_EQ(
-      CopyBits<uint8_t>({.src = 0b00000000, .dst = 0b11111111, .start = 2, .end = 5}),
-      0b11100011);
+  ASSERT_EQ(CopyBitsInInteger<uint8_t>(
+                {.src = 0b00000000, .dst = 0b11111111, .start = 2, .end = 5}),
+            0b11100011);
   // Full-word copy returns src unchanged.
-  ASSERT_EQ(
-      CopyBits<uint8_t>({.src = 0b10101011, .dst = 0b00010010, .start = 0, .end = 8}),
-      0b10101011);
+  ASSERT_EQ(CopyBitsInInteger<uint8_t>(
+                {.src = 0b10101011, .dst = 0b00010010, .start = 0, .end = 8}),
+            0b10101011);
   // uint16_t partial range [4, 12[: dst keeps its bits outside, src fills inside.
   ASSERT_EQ(
-      CopyBits<uint16_t>(
+      CopyBitsInInteger<uint16_t>(
           {.src = 0b1010101010101010, .dst = 0b0101010101010101, .start = 4, .end = 12}),
       0b0101101010100101);
   // uint64_t
-  ASSERT_EQ(CopyBits<uint64_t>({
+  ASSERT_EQ(CopyBitsInInteger<uint64_t>({
                 .src = 0x0123456789abcdef,
                 .dst = 0xfedcba9876543210,
                 .start = 0,
@@ -1103,9 +1103,9 @@ TEST(BitUtil, CopyBits) {
             }),
             0x0123456789abcdef);
   // constexpr-evaluable.
-  static_assert(
-      CopyBits<uint8_t>({.src = 0b10101010, .dst = 0b01010101, .start = 0, .end = 4}) ==
-      0b01011010);
+  static_assert(CopyBitsInInteger<uint8_t>(
+                    {.src = 0b10101010, .dst = 0b01010101, .start = 0, .end = 4}) ==
+                0b01011010);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -726,23 +726,6 @@ TEST(BitUtil, ByteSwap) {
   EXPECT_EQ(bit_util::ByteSwap(srcd64), expectedd64);
 }
 
-TEST(BitUtil, Get32Bits) {
-  const std::array<uint8_t, 12> src = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
-                                       0xde, 0xf0, 0x11, 0x22, 0x33, 0x44};
-
-  // The result's in-memory bytes must reproduce the source bit-stream slice
-  // so each result bit must match the corresponding source bit.
-  for (uint64_t offset = 0; offset <= 24; ++offset) {
-    ARROW_SCOPED_TRACE("offset = ", offset);
-    const uint32_t result = bit_util::Get32Bits(src.data(), offset);
-    for (uint64_t i = 0; i < 32; ++i) {
-      EXPECT_EQ(bit_util::GetBit(reinterpret_cast<const uint8_t*>(&result), i),
-                bit_util::GetBit(src.data(), offset + i))
-          << "bit " << i;
-    }
-  }
-}
-
 TEST(BitUtil, Log2) {
   EXPECT_EQ(bit_util::Log2(1), 0);
   EXPECT_EQ(bit_util::Log2(2), 1);

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -726,6 +726,23 @@ TEST(BitUtil, ByteSwap) {
   EXPECT_EQ(bit_util::ByteSwap(srcd64), expectedd64);
 }
 
+TEST(BitUtil, Get32Bits) {
+  const std::array<uint8_t, 12> src = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+                                       0xde, 0xf0, 0x11, 0x22, 0x33, 0x44};
+
+  // The result's in-memory bytes must reproduce the source bit-stream slice
+  // so each result bit must match the corresponding source bit.
+  for (uint64_t offset = 0; offset <= 24; ++offset) {
+    ARROW_SCOPED_TRACE("offset = ", offset);
+    const uint32_t result = bit_util::Get32Bits(src.data(), offset);
+    for (uint64_t i = 0; i < 32; ++i) {
+      EXPECT_EQ(bit_util::GetBit(reinterpret_cast<const uint8_t*>(&result), i),
+                bit_util::GetBit(src.data(), offset + i))
+          << "bit " << i;
+    }
+  }
+}
+
 TEST(BitUtil, Log2) {
   EXPECT_EQ(bit_util::Log2(1), 0);
   EXPECT_EQ(bit_util::Log2(2), 1);

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1065,4 +1065,47 @@ TEST(SpliceWord, SpliceWord) {
             0xfedc456789abcdef);
 }
 
+TEST(BitUtil, CopyBits) {
+  // Copy bits [start, end[ from src into dst, keeping dst's other bits.
+  using bit_util::CopyBits;
+
+  // Empty range: result equals dst.
+  ASSERT_EQ(
+      CopyBits<uint8_t>({.src = 0b11111111, .dst = 0b00010010, .start = 3, .end = 3}),
+      0b00010010);
+  // dst = 0101 0101, src = 1010 1010  ->  0101 1010
+  ASSERT_EQ(
+      CopyBits<uint8_t>({.src = 0b10101010, .dst = 0b01010101, .start = 0, .end = 4}),
+      0b01011010);
+  // Copy a middle span [2, 5[ of all-ones into an all-zeros dst.
+  ASSERT_EQ(
+      CopyBits<uint8_t>({.src = 0b11111111, .dst = 0b00000000, .start = 2, .end = 5}),
+      0b00011100);
+  // Copy a middle span [2, 5[ of all-zeros into an all-ones dst.
+  ASSERT_EQ(
+      CopyBits<uint8_t>({.src = 0b00000000, .dst = 0b11111111, .start = 2, .end = 5}),
+      0b11100011);
+  // Full-word copy returns src unchanged.
+  ASSERT_EQ(
+      CopyBits<uint8_t>({.src = 0b10101011, .dst = 0b00010010, .start = 0, .end = 8}),
+      0b10101011);
+  // uint16_t partial range [4, 12[: dst keeps its bits outside, src fills inside.
+  ASSERT_EQ(
+      CopyBits<uint16_t>(
+          {.src = 0b1010101010101010, .dst = 0b0101010101010101, .start = 4, .end = 12}),
+      0b0101101010100101);
+  // uint64_t
+  ASSERT_EQ(CopyBits<uint64_t>({
+                .src = 0x0123456789abcdef,
+                .dst = 0xfedcba9876543210,
+                .start = 0,
+                .end = 64,
+            }),
+            0x0123456789abcdef);
+  // constexpr-evaluable.
+  static_assert(
+      CopyBits<uint8_t>({.src = 0b10101010, .dst = 0b01010101, .start = 0, .end = 4}) ==
+      0b01011010);
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -110,9 +110,8 @@ class RunToBitMapDecoderMixin {
     const auto n_vals = derived()->GetBatchFast(out, batch_size);
 
     // TRAILER: Writing inside the last byte if caller asked for non multiple of 8 values
-    const auto n_last_vals = batch_size - n_vals;
-    if (ARROW_PREDICT_FALSE(derived()->remaining() > 0 && n_last_vals > 0)) {
-      ARROW_DCHECK_GT(n_last_vals, 0);
+    const auto n_last_vals = std::min(batch_size - n_vals, derived()->remaining());
+    if (ARROW_PREDICT_FALSE(n_last_vals > 0)) {
       ARROW_DCHECK_LT(n_last_vals, 8);
       out = out.NewStartingAt(n_vals);
       return n_vals + derived()->GetBatchFirstByte(out, n_last_vals);
@@ -322,5 +321,110 @@ class BitPackedRunToBitMapDecoder
     return to_read;
   }
 };
+
+/// A specialized decoder class to extract RLE+bitpacked booleans.
+///
+/// In some cases, such as when reading definition levels for nullable values (with
+/// no repetition and no nesting), we know values to be decoded will end up in an
+/// Arrow validity bitmap. In such cases, decoding values to a ``int16`` before
+/// encoding them again in overly wasteful.
+class RleBitPackedToBitMapDecoder {
+ public:
+  RleBitPackedToBitMapDecoder() noexcept = default;
+
+  /// Create a decoder object.
+  ///
+  /// data and data_size are the raw bytes to decode.
+  RleBitPackedToBitMapDecoder(const uint8_t* data, rle_size_t data_size) noexcept {
+    Reset(data, data_size);
+  }
+
+  void Reset(const uint8_t* data, rle_size_t data_size) noexcept {
+    parser_.Reset(data, data_size, /* value_bit_width= */ 1);
+    decoder_ = {};
+  }
+
+  /// Whether there is still runs to iterate over.
+  bool exhausted() const { return (run_remaining() == 0) && parser_.exhausted(); }
+
+  /// Get a batch of values return the number of decoded elements.
+  /// May write fewer elements to the output than requested if there are not enough
+  /// values left or if an error occurred.
+  [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size);
+
+ private:
+  /// Utility to map a run type to the associate decoder.
+  template <typename Run>
+  struct get_decoder;
+  template <>
+  struct get_decoder<RleRun> {
+    using type = RleRunToBitMapDecoder;
+  };
+  template <>
+  struct get_decoder<BitPackedRun> {
+    using type = BitPackedRunToBitMapDecoder;
+  };
+  template <typename Run>
+  using get_decoder_t = get_decoder<Run>::type;
+
+  RleBitPackedParser parser_ = {};
+  std::variant<RleRunToBitMapDecoder, BitPackedRunToBitMapDecoder> decoder_ = {};
+
+  /// Return the number of values that are remaining in the current run.
+  rle_size_t run_remaining() const {
+    return std::visit([](const auto& dec) { return dec.remaining(); }, decoder_);
+  }
+
+  /// Get a batch of values from the current run and return the number elements read.
+  [[nodiscard]] rle_size_t RunGetBatch(BitmapSpanMut out, rle_size_t batch_size) {
+    return std::visit([&](auto& dec) { return dec.GetBatch(out, batch_size); }, decoder_);
+  }
+};
+
+/************************************************
+ *  RleBitPackedToBitMapDecoder implementation  *
+ ************************************************/
+
+inline auto RleBitPackedToBitMapDecoder::GetBatch(BitmapSpanMut out,
+                                                  rle_size_t batch_size) -> rle_size_t {
+  using ControlFlow = RleBitPackedParser::ControlFlow;
+
+  rle_size_t values_read = 0;
+
+  // Remaining from a previous call that would have left some unread data from a run.
+  if (ARROW_PREDICT_FALSE(run_remaining() > 0)) {
+    const auto read = RunGetBatch(out, batch_size);
+    values_read += read;
+
+    // Either we fulfilled all the batch to be read or we finished remaining run.
+    if (ARROW_PREDICT_FALSE(values_read == batch_size)) {
+      return values_read;
+    }
+    ARROW_DCHECK(run_remaining() == 0);
+  }
+
+  parser_.ParseWithCallable([&](auto run) {
+    using RunDecoder = get_decoder_t<decltype(run)>;
+
+    ARROW_DCHECK_LT(values_read, batch_size);
+    RunDecoder decoder(run);
+    // The output span carries its own bit offset, so advancing it past the values
+    // already written keeps successive runs correctly aligned in the bitmap.
+    const auto read =
+        decoder.GetBatch(out.NewStartingAt(values_read), batch_size - values_read);
+    ARROW_DCHECK_LE(read, batch_size - values_read);
+    values_read += read;
+
+    // Stop reading and store remaining decoder
+    if (ARROW_PREDICT_FALSE(values_read == batch_size || read == 0)) {
+      decoder_ = std::move(decoder);
+      return ControlFlow::Break;
+    }
+
+    return ControlFlow::Continue;
+  });
+
+  return values_read;
+}
 
 }  // namespace arrow::util

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -217,6 +217,12 @@ class BitPackedRunToBitMapDecoder
     data_ = run.raw_data_ptr();
     values_count_ = run.values_count();
     values_read_ = 0;
+    // This decoder bounds all of its reads by `values_count_` alone and does not
+    // carry `max_read_bytes`. Its memory safety therefore relies on the producer
+    // having sized the run to fit the backing buffer. Check that contract here,
+    // at the point it is relied upon (a negative max means "unbounded").
+    ARROW_DCHECK(run.raw_data_max_size() < 0 ||
+                 bit_util::BytesForBits(values_count_) <= run.raw_data_max_size());
   }
 
   /// Return the number of values that can be advanced.

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -113,7 +113,7 @@ class RleRunToBitmapDecoder {
   }
 
   /// Get the next value and return false if there are no more.
-  [[nodiscard]] constexpr bool Get(BitmapSpanMut out) { return GetBatch(out, 1) == 1; }
+  [[nodiscard]] bool Get(BitmapSpanMut out) { return GetBatch(out, 1) == 1; }
 
   /// Get a batch of values return the number of decoded elements.
   ///
@@ -230,7 +230,7 @@ class BitPackedRunToBitmapDecoder {
   }
 
   /// Get the next value and return false if there are no more.
-  [[nodiscard]] constexpr bool Get(BitmapSpanMut out) { return GetBatch(out, 1) == 1; }
+  [[nodiscard]] bool Get(BitmapSpanMut out) { return GetBatch(out, 1) == 1; }
 
   /// Get a batch of values return the number of decoded elements.
   /// May write fewer elements to the output than requested if there are not enough values

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -395,6 +395,10 @@ inline auto RleBitPackedToBitmapDecoder::GetBatch(BitmapSpanMut out,
                                                   rle_size_t batch_size) -> rle_size_t {
   using ControlFlow = RleBitPackedParser::ControlFlow;
 
+  if (ARROW_PREDICT_FALSE(batch_size == 0 || exhausted())) {
+    return 0;
+  }
+
   rle_size_t values_read = 0;
 
   // Remaining from a previous call that would have left some unread data from a run.

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -27,6 +27,7 @@
 
 namespace arrow::util {
 
+/// A lightweight view over a bitmap.
 template <typename B = uint8_t>
 class BitmapSpan {
  public:
@@ -38,10 +39,13 @@ class BitmapSpan {
     Normalize();
   }
 
+  /// Pointer to the byte where the first value is stored.
   constexpr byte_type* data() const noexcept { return data_; }
 
+  /// Bit offset of the first value in the first byte.
   constexpr size_type bit_start() const noexcept { return bit_start_; }
 
+  /// Return a new span starting at the given position.
   constexpr BitmapSpan NewStartingAt(size_type bit_start) const noexcept {
     auto out = *this;
     out.bit_start_ += bit_start;
@@ -217,10 +221,6 @@ class BitPackedRunToBitMapDecoder
     data_ = run.raw_data_ptr();
     values_count_ = run.values_count();
     values_read_ = 0;
-    // This decoder bounds all of its reads by `values_count_` alone and does not
-    // carry `max_read_bytes`. Its memory safety therefore relies on the producer
-    // having sized the run to fit the backing buffer. Check that contract here,
-    // at the point it is relied upon (a negative max means "unbounded").
     ARROW_DCHECK(run.raw_data_max_size() < 0 ||
                  bit_util::BytesForBits(values_count_) <= run.raw_data_max_size());
   }

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -72,7 +72,7 @@ using BitmapSpanConst = BitmapSpan<const uint8_t>;
 
 namespace internal_rle {
 template <typename CRTP>
-class RunToBitMapDecoderMixin {
+class RunToBitmapDecoderMixin {
  public:
   /// Advance by as many values as provided or until exhaustion of the decoder.
   /// Return the number of values skipped.
@@ -156,15 +156,15 @@ class RunToBitMapDecoderMixin {
 };
 }  // namespace internal_rle
 
-class RleRunToBitMapDecoder
-    : public internal_rle::RunToBitMapDecoderMixin<RleRunToBitMapDecoder> {
+class RleRunToBitmapDecoder
+    : public internal_rle::RunToBitmapDecoderMixin<RleRunToBitmapDecoder> {
  public:
   /// The type of run that can be decoded.
   using RunType = RleRun;
 
-  constexpr RleRunToBitMapDecoder() noexcept = default;
+  constexpr RleRunToBitmapDecoder() noexcept = default;
 
-  explicit RleRunToBitMapDecoder(const RunType& run) noexcept { Reset(run); }
+  explicit RleRunToBitmapDecoder(const RunType& run) noexcept { Reset(run); }
 
   void Reset(const RunType& run) noexcept {
     values_left_ = run.values_count();
@@ -182,7 +182,7 @@ class RleRunToBitMapDecoder
   constexpr bool value() const { return value_pattern_ != 0; }
 
  private:
-  friend class internal_rle::RunToBitMapDecoderMixin<RleRunToBitMapDecoder>;
+  friend class internal_rle::RunToBitmapDecoderMixin<RleRunToBitmapDecoder>;
 
   /// The byte pattern for 8 values (full ones or full zeros).
   uint8_t value_pattern_ = {};
@@ -207,15 +207,15 @@ class RleRunToBitMapDecoder
   }
 };
 
-class BitPackedRunToBitMapDecoder
-    : public internal_rle::RunToBitMapDecoderMixin<BitPackedRunToBitMapDecoder> {
+class BitPackedRunToBitmapDecoder
+    : public internal_rle::RunToBitmapDecoderMixin<BitPackedRunToBitmapDecoder> {
  public:
   /// The type of run that can be decoded.
   using RunType = BitPackedRun;
 
-  constexpr BitPackedRunToBitMapDecoder() noexcept = default;
+  constexpr BitPackedRunToBitmapDecoder() noexcept = default;
 
-  explicit BitPackedRunToBitMapDecoder(const RunType& run) noexcept { Reset(run); }
+  explicit BitPackedRunToBitmapDecoder(const RunType& run) noexcept { Reset(run); }
 
   void Reset(const RunType& run) noexcept {
     data_ = run.raw_data_ptr();
@@ -241,8 +241,8 @@ class BitPackedRunToBitMapDecoder
   }
 
  private:
-  using Base = internal_rle::RunToBitMapDecoderMixin<BitPackedRunToBitMapDecoder>;
-  friend class internal_rle::RunToBitMapDecoderMixin<BitPackedRunToBitMapDecoder>;
+  using Base = internal_rle::RunToBitmapDecoderMixin<BitPackedRunToBitmapDecoder>;
+  friend class internal_rle::RunToBitmapDecoderMixin<BitPackedRunToBitmapDecoder>;
 
   /// The pointer to the beginning of the run
   const uint8_t* data_ = nullptr;
@@ -334,14 +334,14 @@ class BitPackedRunToBitMapDecoder
 /// no repetition and no nesting), we know values to be decoded will end up in an
 /// Arrow validity bitmap. In such cases, decoding values to a ``int16`` before
 /// encoding them again in overly wasteful.
-class RleBitPackedToBitMapDecoder {
+class RleBitPackedToBitmapDecoder {
  public:
-  RleBitPackedToBitMapDecoder() noexcept = default;
+  RleBitPackedToBitmapDecoder() noexcept = default;
 
   /// Create a decoder object.
   ///
   /// data and data_size are the raw bytes to decode.
-  RleBitPackedToBitMapDecoder(const uint8_t* data, rle_size_t data_size) noexcept {
+  RleBitPackedToBitmapDecoder(const uint8_t* data, rle_size_t data_size) noexcept {
     Reset(data, data_size);
   }
 
@@ -364,17 +364,17 @@ class RleBitPackedToBitMapDecoder {
   struct get_decoder;
   template <>
   struct get_decoder<RleRun> {
-    using type = RleRunToBitMapDecoder;
+    using type = RleRunToBitmapDecoder;
   };
   template <>
   struct get_decoder<BitPackedRun> {
-    using type = BitPackedRunToBitMapDecoder;
+    using type = BitPackedRunToBitmapDecoder;
   };
   template <typename Run>
   using get_decoder_t = get_decoder<Run>::type;
 
   RleBitPackedParser parser_ = {};
-  std::variant<RleRunToBitMapDecoder, BitPackedRunToBitMapDecoder> decoder_ = {};
+  std::variant<RleRunToBitmapDecoder, BitPackedRunToBitmapDecoder> decoder_ = {};
 
   /// Return the number of values that are remaining in the current run.
   rle_size_t run_remaining() const {
@@ -388,10 +388,10 @@ class RleBitPackedToBitMapDecoder {
 };
 
 /************************************************
- *  RleBitPackedToBitMapDecoder implementation  *
+ *  RleBitPackedToBitmapDecoder implementation  *
  ************************************************/
 
-inline auto RleBitPackedToBitMapDecoder::GetBatch(BitmapSpanMut out,
+inline auto RleBitPackedToBitmapDecoder::GetBatch(BitmapSpanMut out,
                                                   rle_size_t batch_size) -> rle_size_t {
   using ControlFlow = RleBitPackedParser::ControlFlow;
 

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -359,20 +359,6 @@ class RleBitPackedToBitmapDecoder {
   [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size);
 
  private:
-  /// Utility to map a run type to the associate decoder.
-  template <typename Run>
-  struct get_decoder;
-  template <>
-  struct get_decoder<RleRun> {
-    using type = RleRunToBitmapDecoder;
-  };
-  template <>
-  struct get_decoder<BitPackedRun> {
-    using type = BitPackedRunToBitmapDecoder;
-  };
-  template <typename Run>
-  using get_decoder_t = get_decoder<Run>::type;
-
   RleBitPackedParser parser_ = {};
   std::variant<RleRunToBitmapDecoder, BitPackedRunToBitmapDecoder> decoder_ = {};
 
@@ -390,6 +376,20 @@ class RleBitPackedToBitmapDecoder {
 /************************************************
  *  RleBitPackedToBitmapDecoder implementation  *
  ************************************************/
+
+/// Utility to map a run type to the associate decoder.
+template <typename Run>
+struct RleBitPackedToBitmapDecoderGetDecoder;
+
+template <>
+struct RleBitPackedToBitmapDecoderGetDecoder<RleRun> {
+  using type = RleRunToBitmapDecoder;
+};
+
+template <>
+struct RleBitPackedToBitmapDecoderGetDecoder<BitPackedRun> {
+  using type = BitPackedRunToBitmapDecoder;
+};
 
 inline auto RleBitPackedToBitmapDecoder::GetBatch(BitmapSpanMut out,
                                                   rle_size_t batch_size) -> rle_size_t {
@@ -410,7 +410,7 @@ inline auto RleBitPackedToBitmapDecoder::GetBatch(BitmapSpanMut out,
   }
 
   parser_.ParseWithCallable([&](auto run) {
-    using RunDecoder = get_decoder_t<decltype(run)>;
+    using RunDecoder = RleBitPackedToBitmapDecoderGetDecoder<decltype(run)>::type;
 
     ARROW_DCHECK_LT(values_read, batch_size);
     RunDecoder decoder(run);

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -98,7 +98,7 @@ class RleRunToBitmapDecoder {
   /// Return how much the decoder would advance if asked to.
   ///
   /// Does not modify input.
-  rle_size_t AdvanceCapacity(rle_size_t batch_size) const noexcept {
+  rle_size_t GetAdvanceCapacity(rle_size_t batch_size) const noexcept {
     const auto n_vals = std::min(batch_size, remaining());
     return n_vals;
   }
@@ -106,16 +106,16 @@ class RleRunToBitmapDecoder {
   /// Advance by as many values as provided or until exhaustion of the decoder.
   /// Return the number of values skipped.
   [[nodiscard]] rle_size_t Advance(rle_size_t batch_size) {
-    const auto n_vals = AdvanceCapacity(batch_size);
+    const auto n_vals = GetAdvanceCapacity(batch_size);
     values_left_ -= n_vals;
     ARROW_DCHECK_GE(remaining(), 0);
     return n_vals;
   }
 
-  /// Get the next value and return false if there are no more.
+  /// Read the next value into `out` and return false if there are no more.
   [[nodiscard]] bool Get(BitmapSpanMut out) { return GetBatch(out, 1) == 1; }
 
-  /// Get a batch of values return the number of decoded elements.
+  /// Get a batch of values into `out` and return the number of decoded elements.
   ///
   /// May write fewer elements to the output than requested if there are not
   /// enough values left.
@@ -140,7 +140,7 @@ class RleRunToBitmapDecoder {
 
     // TRAILER: Writing inside the last byte if caller asked for non multiple of 8 values
     const auto n_last_vals = std::min(batch_size - n_vals, remaining());
-    if (ARROW_PREDICT_FALSE(n_last_vals > 0)) {
+    if (n_last_vals > 0) {
       ARROW_DCHECK_LT(n_last_vals, 8);
       n_vals += GetBatchInByte(out.NewStartingAt(n_vals), n_last_vals);
     }
@@ -215,7 +215,7 @@ class BitPackedRunToBitmapDecoder {
   /// Return how much the decoder would advance if asked to.
   ///
   /// Does not modify input.
-  rle_size_t AdvanceCapacity(rle_size_t batch_size) const noexcept {
+  rle_size_t GetAdvanceCapacity(rle_size_t batch_size) const noexcept {
     const auto n_vals = std::min(batch_size, remaining());
     return n_vals;
   }
@@ -223,7 +223,7 @@ class BitPackedRunToBitmapDecoder {
   /// Advance by as many values as provided or until exhaustion of the decoder.
   /// Return the number of values skipped.
   [[nodiscard]] rle_size_t Advance(rle_size_t batch_size) {
-    const auto n_vals = AdvanceCapacity(batch_size);
+    const auto n_vals = GetAdvanceCapacity(batch_size);
     values_read_ += n_vals;
     ARROW_DCHECK_GE(remaining(), 0);
     return n_vals;
@@ -236,7 +236,7 @@ class BitPackedRunToBitmapDecoder {
   /// May write fewer elements to the output than requested if there are not enough values
   /// left.
   [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size) {
-    auto n_vals = AdvanceCapacity(batch_size);
+    auto n_vals = GetAdvanceCapacity(batch_size);
     arrow::internal::CopyBitmap(unread_values_ptr(), unread_values_bit_offset(), n_vals,
                                 out.data(), out.bit_start());
     return Advance(n_vals);

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -183,8 +183,8 @@ class RleRunToBitmapDecoder {
 
   /// Get batch in full bytes using memset.
   [[nodiscard]] rle_size_t GetBatchFullBytes(BitmapSpanMut out, rle_size_t batch_size) {
-    ARROW_DCHECK(out.bit_start() == 0 || batch_size == 0);
     const auto n_bytes = std::min(batch_size, remaining()) / 8;
+    ARROW_DCHECK(out.bit_start() == 0 || n_bytes == 0);
     std::memset(out.data(), value_pattern_, n_bytes);
     const auto n_vals = 8 * n_bytes;
     AdvanceUnsafe(n_vals);

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -168,7 +168,7 @@ class RleRunToBitmapDecoder
 
   void Reset(const RunType& run) noexcept {
     values_left_ = run.values_count();
-    if (run.value() == 0) {
+    if (run.value_little_endian() == 0) {
       value_pattern_ = uint8_t{0};
     } else {
       value_pattern_ = uint8_t{0xFF};

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -101,24 +101,22 @@ class RunToBitmapDecoderMixin {
       return 0;
     }
 
+    rle_size_t n_vals = 0;
+
     // HEADER: Writing inside the first byte if caller gives a non-aligned input
-    if (ARROW_PREDICT_FALSE(out_bit_offset != 0)) {
-      const auto n_vals = derived()->GetBatchFirstByte(out, batch_size);
-      // If we exhausted the values in this decoder, or we filled what was required,
-      // then the following recursive call will return 0.
-      // If in the opposite case, then we will continue on a byte-aligned boundary.
-      return n_vals + GetBatch(out.NewStartingAt(n_vals), batch_size - n_vals);
+    if (out_bit_offset != 0) {
+      n_vals = derived()->GetBatchFirstByte(out, batch_size);
     }
 
     // Writing full bytes
-    const auto n_vals = derived()->GetBatchFast(out, batch_size);
+    n_vals +=
+        derived()->GetBatchFullBytes(out.NewStartingAt(n_vals), batch_size - n_vals);
 
     // TRAILER: Writing inside the last byte if caller asked for non multiple of 8 values
     const auto n_last_vals = std::min(batch_size - n_vals, derived()->remaining());
     if (ARROW_PREDICT_FALSE(n_last_vals > 0)) {
       ARROW_DCHECK_LT(n_last_vals, 8);
-      out = out.NewStartingAt(n_vals);
-      return n_vals + derived()->GetBatchFirstByte(out, n_last_vals);
+      n_vals += derived()->GetBatchFirstByte(out.NewStartingAt(n_vals), n_last_vals);
     }
 
     return n_vals;
@@ -197,8 +195,8 @@ class RleRunToBitmapDecoder
   }
 
   /// Get batch in full bytes using memset.
-  [[nodiscard]] rle_size_t GetBatchFast(BitmapSpanMut out, rle_size_t batch_size) {
-    ARROW_DCHECK_EQ(out.bit_start(), 0);
+  [[nodiscard]] rle_size_t GetBatchFullBytes(BitmapSpanMut out, rle_size_t batch_size) {
+    ARROW_DCHECK(out.bit_start() == 0 || batch_size == 0);
     const auto n_bytes = std::min(batch_size, remaining()) / 8;
     std::memset(out.data(), value_pattern_, n_bytes);
     const auto n_vals = 8 * n_bytes;
@@ -265,8 +263,9 @@ class BitPackedRunToBitmapDecoder
   }
 
   /// Get batch in full bytes using memcpy.
-  [[nodiscard]] rle_size_t GetBatchFast(BitmapSpanMut out, rle_size_t batch_size) {
-    ARROW_DCHECK_EQ(out.bit_start(), 0);
+  [[nodiscard]] rle_size_t GetBatchFullBytes(BitmapSpanMut out, rle_size_t batch_size) {
+    ARROW_DCHECK(out.bit_start() == 0 || batch_size == 0);
+    ARROW_DCHECK(unread_values_bit_offset() == 0 || batch_size == 0);
     const auto n_bytes = std::min(batch_size, remaining()) / 8;
     std::memcpy(out.data(), unread_values_ptr(), n_bytes);
     const auto n_vals = 8 * n_bytes;
@@ -297,7 +296,7 @@ class BitPackedRunToBitmapDecoder
     const rle_size_t to_read = std::min(batch_size, remaining());
     rle_size_t read = 0;
 
-    // HEADER: copy bits one by one unit the output is byte-aligned
+    // HEADER: copy bits one by one until the output is byte-aligned
     const rle_size_t to_read_until_aligned = (8 - out_bit_offset) % 8;
     const rle_size_t to_read_header = std::min(to_read, to_read_until_aligned);
     const auto read_header = GetBatchSlow(out, to_read_header);

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -171,7 +171,7 @@ class RleRunToBitmapDecoder {
     // Try to advance, and get number of bits we had remaining
     const auto n_bits = Advance(desired_bits);
     // Copy relevant bits from the value pattern to the output.
-    *out.data() = bit_util::CopyBits<uint8_t, /* kAllowFullCopy= */ false>({
+    *out.data() = bit_util::CopyBitsInInteger<uint8_t, /* kAllowFullCopy= */ false>({
         .src = value_pattern_,
         .dst = *out.data(),
         .start = static_cast<uint8_t>(out_bit_offset),

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -1,0 +1,326 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+
+#include "arrow/util/bit_util.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
+#include "arrow/util/rle_encoding_internal.h"
+
+namespace arrow::util {
+
+template <typename B = uint8_t>
+class BitmapSpan {
+ public:
+  using size_type = rle_size_t;
+  using byte_type = B;
+
+  explicit constexpr BitmapSpan(byte_type* data, size_type bit_start = 0) noexcept
+      : data_{data}, bit_start_{bit_start} {
+    Normalize();
+  }
+
+  constexpr byte_type* data() const noexcept { return data_; }
+
+  constexpr size_type bit_start() const noexcept { return bit_start_; }
+
+  constexpr BitmapSpan NewStartingAt(size_type bit_start) const noexcept {
+    auto out = *this;
+    out.bit_start_ += bit_start;
+    out.Normalize();
+    return out;
+  }
+
+ private:
+  byte_type* data_;
+  size_type bit_start_ = 0;
+
+  /// Ensure `bit_start` always ends up in [0, 8[, even when it starts negative.
+  constexpr void Normalize() {
+    // On two's-complement targets an arithmetic right shift floors, and the AND mask
+    // yields the non-negative remainder (e.g. -1 -> byte -1, offset 7), unlike `/` and
+    // `%` which truncate toward zero.
+    data_ += bit_start_ >> 3;
+    bit_start_ &= 0b0111;
+  }
+};
+
+using BitmapSpanMut = BitmapSpan<uint8_t>;
+using BitmapSpanConst = BitmapSpan<const uint8_t>;
+
+namespace internal_rle {
+template <typename CRTP>
+class RunToBitMapDecoderMixin {
+ public:
+  /// Advance by as many values as provided or until exhaustion of the decoder.
+  /// Return the number of values skipped.
+  [[nodiscard]] rle_size_t Advance(rle_size_t batch_size) {
+    const auto steps = std::min(batch_size, derived()->remaining());
+    derived()->AdvanceUnsafe(steps);
+    ARROW_DCHECK_GE(derived()->remaining(), 0);
+    return steps;
+  }
+
+  /// Get the next value and return false if there are no more.
+  [[nodiscard]] constexpr bool Get(BitmapSpanMut out) {
+    return derived()->GetBatch(out, 1) == 1;
+  }
+
+  /// Get a batch of values return the number of decoded elements.
+  ///
+  /// May write fewer elements to the output than requested if there are not
+  /// enough values left.
+  [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size) {
+    const auto out_bit_offset = out.bit_start();
+    ARROW_DCHECK_GE(out_bit_offset, 0);
+    ARROW_DCHECK_LT(out_bit_offset, 8);
+
+    if (ARROW_PREDICT_FALSE(derived()->remaining() == 0 || batch_size == 0)) {
+      return 0;
+    }
+
+    // HEADER: Writing inside the first byte if caller gives a non-aligned input
+    if (ARROW_PREDICT_FALSE(out_bit_offset != 0)) {
+      const auto n_vals = derived()->GetBatchFirstByte(out, batch_size);
+      // If we exhausted the values in this decoder, or we filled what was required,
+      // then the following recursive call will return 0.
+      // If in the opposite case, then we will continue on a byte-aligned boundary.
+      return n_vals + GetBatch(out.NewStartingAt(n_vals), batch_size - n_vals);
+    }
+
+    // Writing full bytes
+    const auto n_vals = derived()->GetBatchFast(out, batch_size);
+
+    // TRAILER: Writing inside the last byte if caller asked for non multiple of 8 values
+    const auto n_last_vals = batch_size - n_vals;
+    if (ARROW_PREDICT_FALSE(derived()->remaining() > 0 && n_last_vals > 0)) {
+      ARROW_DCHECK_GT(n_last_vals, 0);
+      ARROW_DCHECK_LT(n_last_vals, 8);
+      out = out.NewStartingAt(n_vals);
+      return n_vals + derived()->GetBatchFirstByte(out, n_last_vals);
+    }
+
+    return n_vals;
+  }
+
+ protected:
+  [[nodiscard]] rle_size_t GetBatchFromByte(BitmapSpanMut out, rle_size_t batch_size,
+                                            uint8_t src) {
+    const auto out_bit_offset = out.bit_start();
+    ARROW_DCHECK_GE(out_bit_offset, 0);
+    ARROW_DCHECK_LT(out_bit_offset, 8);
+    ARROW_DCHECK_GT(derived()->remaining(), 0);
+    ARROW_DCHECK_GE(batch_size, 0);
+
+    // Empty bits in first byte that we can fill
+    const auto empty_bits = rle_size_t{8} - out_bit_offset;
+    // Number of bits in first byte that we want to fill
+    const auto desired_bits = std::min(empty_bits, batch_size);
+    // Try to advance, and get number of bits we had remaining
+    const auto n_bits = Advance(desired_bits);
+    // Copy relevant bits from the value pattern to the output.
+    *out.data() = bit_util::CopyBits<uint8_t, /* kAllowFullCopy= */ false>({
+        .src = src,
+        .dst = *out.data(),
+        .start = static_cast<uint8_t>(out_bit_offset),
+        .end = static_cast<uint8_t>(out_bit_offset + n_bits),
+    });
+
+    return n_bits;
+  }
+
+ private:
+  CRTP* derived() { return static_cast<CRTP*>(this); }
+  CRTP const* derived() const { return static_cast<CRTP const*>(this); }
+};
+}  // namespace internal_rle
+
+class RleRunToBitMapDecoder
+    : public internal_rle::RunToBitMapDecoderMixin<RleRunToBitMapDecoder> {
+ public:
+  /// The type of run that can be decoded.
+  using RunType = RleRun;
+
+  constexpr RleRunToBitMapDecoder() noexcept = default;
+
+  explicit RleRunToBitMapDecoder(const RunType& run) noexcept { Reset(run); }
+
+  void Reset(const RunType& run) noexcept {
+    values_left_ = run.values_count();
+    if (run.value() == 0) {
+      value_pattern_ = uint8_t{0};
+    } else {
+      value_pattern_ = uint8_t{0xFF};
+    }
+  }
+
+  /// Return the number of values that can be advanced.
+  rle_size_t remaining() const { return values_left_; }
+
+  /// Return the repeated value of this decoder.
+  constexpr bool value() const { return value_pattern_ != 0; }
+
+ private:
+  friend class internal_rle::RunToBitMapDecoderMixin<RleRunToBitMapDecoder>;
+
+  /// The byte pattern for 8 values (full ones or full zeros).
+  uint8_t value_pattern_ = {};
+  /// Number of values left to decode.
+  rle_size_t values_left_ = 0;
+
+  void AdvanceUnsafe(rle_size_t batch_size) { values_left_ -= batch_size; }
+
+  /// Get batch values to fill the first incomplete byte of the output.
+  [[nodiscard]] rle_size_t GetBatchFirstByte(BitmapSpanMut out, rle_size_t batch_size) {
+    return GetBatchFromByte(out, batch_size, value_pattern_);
+  }
+
+  /// Get batch in full bytes using memset.
+  [[nodiscard]] rle_size_t GetBatchFast(BitmapSpanMut out, rle_size_t batch_size) {
+    ARROW_DCHECK_EQ(out.bit_start(), 0);
+    const auto n_bytes = std::min(batch_size, remaining()) / 8;
+    std::memset(out.data(), value_pattern_, n_bytes);
+    const auto n_vals = 8 * n_bytes;
+    AdvanceUnsafe(n_vals);
+    return n_vals;
+  }
+};
+
+class BitPackedRunToBitMapDecoder
+    : public internal_rle::RunToBitMapDecoderMixin<BitPackedRunToBitMapDecoder> {
+ public:
+  /// The type of run that can be decoded.
+  using RunType = BitPackedRun;
+
+  constexpr BitPackedRunToBitMapDecoder() noexcept = default;
+
+  explicit BitPackedRunToBitMapDecoder(const RunType& run) noexcept { Reset(run); }
+
+  void Reset(const RunType& run) noexcept {
+    data_ = run.raw_data_ptr();
+    values_count_ = run.values_count();
+    values_read_ = 0;
+  }
+
+  /// Return the number of values that can be advanced.
+  constexpr rle_size_t remaining() const { return values_count_ - values_read_; }
+
+  /// Get a batch of values return the number of decoded elements.
+  /// May write fewer elements to the output than requested if there are not enough values
+  /// left.
+  [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size) {
+    // WARN: Slow case where bit offsets of input and output are not aligned.
+    // We loose the ability to do memcpy
+    if (ARROW_PREDICT_FALSE(out.bit_start() != unread_values_bit_offset())) {
+      return GetBatchMisaligned(out, batch_size);
+    }
+    return Base::GetBatch(out, batch_size);
+  }
+
+ private:
+  using Base = internal_rle::RunToBitMapDecoderMixin<BitPackedRunToBitMapDecoder>;
+  friend class internal_rle::RunToBitMapDecoderMixin<BitPackedRunToBitMapDecoder>;
+
+  /// The pointer to the beginning of the run
+  const uint8_t* data_ = nullptr;
+  /// The total number of values in the run
+  rle_size_t values_count_ = 0;
+  /// The number of values read by the decoder
+  rle_size_t values_read_ = 0;
+
+  /// Start pointer of the unread values (may contain values already read).
+  const uint8_t* unread_values_ptr() const noexcept { return data_ + (values_read_ / 8); }
+
+  /// Bit in @ref unread_values_ptr where the unread values start.
+  rle_size_t unread_values_bit_offset() const noexcept { return values_read_ % 8; }
+
+  void AdvanceUnsafe(rle_size_t batch_size) { values_read_ += batch_size; }
+
+  /// Get batch values to fill the first incomplete byte of the output.
+  [[nodiscard]] rle_size_t GetBatchFirstByte(BitmapSpanMut out, rle_size_t batch_size) {
+    return GetBatchFromByte(out, batch_size, *unread_values_ptr());
+  }
+
+  /// Get batch in full bytes using memcpy.
+  [[nodiscard]] rle_size_t GetBatchFast(BitmapSpanMut out, rle_size_t batch_size) {
+    ARROW_DCHECK_EQ(out.bit_start(), 0);
+    const auto n_bytes = std::min(batch_size, remaining()) / 8;
+    std::memcpy(out.data(), unread_values_ptr(), n_bytes);
+    const auto n_vals = 8 * n_bytes;
+    AdvanceUnsafe(n_vals);
+    return n_vals;
+  }
+
+  /// Correct and slow function for reading a batch one bit at a time.
+  [[nodiscard]] rle_size_t GetBatchSlow(BitmapSpanMut out, rle_size_t batch_size) {
+    const rle_size_t to_read = std::min(batch_size, remaining());
+    for (rle_size_t i = 0; i < to_read; ++i) {
+      const bool bit = bit_util::GetBit(data_, values_read_ + i);
+      bit_util::SetBitTo(out.data(), out.bit_start() + i, bit);
+    }
+    AdvanceUnsafe(to_read);
+    return to_read;
+  }
+
+  [[nodiscard]] rle_size_t GetBatchMisaligned(BitmapSpanMut out, rle_size_t batch_size) {
+    const auto out_bit_offset = out.bit_start();
+    ARROW_DCHECK_LT(out_bit_offset, 8);
+    ARROW_DCHECK_GE(out_bit_offset, 0);
+
+    if (ARROW_PREDICT_FALSE(remaining() == 0 || batch_size == 0)) {
+      return 0;
+    }
+
+    const rle_size_t to_read = std::min(batch_size, remaining());
+    rle_size_t read = 0;
+
+    // HEADER: copy bits one by one unit the output is byte-aligned
+    const rle_size_t to_read_until_aligned = (8 - out_bit_offset) % 8;
+    const rle_size_t to_read_header = std::min(to_read, to_read_until_aligned);
+    const auto read_header = GetBatchSlow(out, to_read_header);
+    // We ensured there was enough capacity
+    ARROW_DCHECK_EQ(read_header, to_read_header);
+    read += read_header;
+    out = out.NewStartingAt(read_header);
+    // Either we are done or we have aligned the output values on a byte.
+    ARROW_DCHECK(read == to_read || read == to_read_until_aligned);
+
+    // Main loop, copy 32 bits at the time
+    const rle_size_t n_batches = (to_read - read) / 32;
+    for (rle_size_t i = 0; i < n_batches; ++i) {
+      const auto bits = bit_util::Get32Bits(data_, values_read_ + 32 * i);
+      std::memcpy(out.data(), &bits, sizeof(bits));
+      out = out.NewStartingAt(8 * sizeof(bits));
+    }
+    const rle_size_t read_main = n_batches * 32;
+    AdvanceUnsafe(read_main);
+    read += read_main;
+
+    // TRAILER: copy remaining bits one by one
+    const auto read_trailer = GetBatchSlow(out, to_read - read);
+    read += read_trailer;
+    ARROW_DCHECK_EQ(read, to_read);
+
+    return to_read;
+  }
+};
+
+}  // namespace arrow::util

--- a/cpp/src/arrow/util/rle_bitmap_internal.h
+++ b/cpp/src/arrow/util/rle_bitmap_internal.h
@@ -21,6 +21,7 @@
 #include <cstring>
 
 #include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_ops.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/rle_encoding_internal.h"
@@ -70,92 +71,7 @@ class BitmapSpan {
 using BitmapSpanMut = BitmapSpan<uint8_t>;
 using BitmapSpanConst = BitmapSpan<const uint8_t>;
 
-namespace internal_rle {
-template <typename CRTP>
-class RunToBitmapDecoderMixin {
- public:
-  /// Advance by as many values as provided or until exhaustion of the decoder.
-  /// Return the number of values skipped.
-  [[nodiscard]] rle_size_t Advance(rle_size_t batch_size) {
-    const auto steps = std::min(batch_size, derived()->remaining());
-    derived()->AdvanceUnsafe(steps);
-    ARROW_DCHECK_GE(derived()->remaining(), 0);
-    return steps;
-  }
-
-  /// Get the next value and return false if there are no more.
-  [[nodiscard]] constexpr bool Get(BitmapSpanMut out) {
-    return derived()->GetBatch(out, 1) == 1;
-  }
-
-  /// Get a batch of values return the number of decoded elements.
-  ///
-  /// May write fewer elements to the output than requested if there are not
-  /// enough values left.
-  [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size) {
-    const auto out_bit_offset = out.bit_start();
-    ARROW_DCHECK_GE(out_bit_offset, 0);
-    ARROW_DCHECK_LT(out_bit_offset, 8);
-
-    if (ARROW_PREDICT_FALSE(derived()->remaining() == 0 || batch_size == 0)) {
-      return 0;
-    }
-
-    rle_size_t n_vals = 0;
-
-    // HEADER: Writing inside the first byte if caller gives a non-aligned input
-    if (out_bit_offset != 0) {
-      n_vals = derived()->GetBatchFirstByte(out, batch_size);
-    }
-
-    // Writing full bytes
-    n_vals +=
-        derived()->GetBatchFullBytes(out.NewStartingAt(n_vals), batch_size - n_vals);
-
-    // TRAILER: Writing inside the last byte if caller asked for non multiple of 8 values
-    const auto n_last_vals = std::min(batch_size - n_vals, derived()->remaining());
-    if (ARROW_PREDICT_FALSE(n_last_vals > 0)) {
-      ARROW_DCHECK_LT(n_last_vals, 8);
-      n_vals += derived()->GetBatchFirstByte(out.NewStartingAt(n_vals), n_last_vals);
-    }
-
-    return n_vals;
-  }
-
- protected:
-  [[nodiscard]] rle_size_t GetBatchFromByte(BitmapSpanMut out, rle_size_t batch_size,
-                                            uint8_t src) {
-    const auto out_bit_offset = out.bit_start();
-    ARROW_DCHECK_GE(out_bit_offset, 0);
-    ARROW_DCHECK_LT(out_bit_offset, 8);
-    ARROW_DCHECK_GT(derived()->remaining(), 0);
-    ARROW_DCHECK_GE(batch_size, 0);
-
-    // Empty bits in first byte that we can fill
-    const auto empty_bits = rle_size_t{8} - out_bit_offset;
-    // Number of bits in first byte that we want to fill
-    const auto desired_bits = std::min(empty_bits, batch_size);
-    // Try to advance, and get number of bits we had remaining
-    const auto n_bits = Advance(desired_bits);
-    // Copy relevant bits from the value pattern to the output.
-    *out.data() = bit_util::CopyBits<uint8_t, /* kAllowFullCopy= */ false>({
-        .src = src,
-        .dst = *out.data(),
-        .start = static_cast<uint8_t>(out_bit_offset),
-        .end = static_cast<uint8_t>(out_bit_offset + n_bits),
-    });
-
-    return n_bits;
-  }
-
- private:
-  CRTP* derived() { return static_cast<CRTP*>(this); }
-  CRTP const* derived() const { return static_cast<CRTP const*>(this); }
-};
-}  // namespace internal_rle
-
-class RleRunToBitmapDecoder
-    : public internal_rle::RunToBitmapDecoderMixin<RleRunToBitmapDecoder> {
+class RleRunToBitmapDecoder {
  public:
   /// The type of run that can be decoded.
   using RunType = RleRun;
@@ -179,9 +95,60 @@ class RleRunToBitmapDecoder
   /// Return the repeated value of this decoder.
   constexpr bool value() const { return value_pattern_ != 0; }
 
- private:
-  friend class internal_rle::RunToBitmapDecoderMixin<RleRunToBitmapDecoder>;
+  /// Return how much the decoder would advance if asked to.
+  ///
+  /// Does not modify input.
+  rle_size_t AdvanceCapacity(rle_size_t batch_size) const noexcept {
+    const auto n_vals = std::min(batch_size, remaining());
+    return n_vals;
+  }
 
+  /// Advance by as many values as provided or until exhaustion of the decoder.
+  /// Return the number of values skipped.
+  [[nodiscard]] rle_size_t Advance(rle_size_t batch_size) {
+    const auto n_vals = AdvanceCapacity(batch_size);
+    values_left_ -= n_vals;
+    ARROW_DCHECK_GE(remaining(), 0);
+    return n_vals;
+  }
+
+  /// Get the next value and return false if there are no more.
+  [[nodiscard]] constexpr bool Get(BitmapSpanMut out) { return GetBatch(out, 1) == 1; }
+
+  /// Get a batch of values return the number of decoded elements.
+  ///
+  /// May write fewer elements to the output than requested if there are not
+  /// enough values left.
+  [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size) {
+    const auto out_bit_offset = out.bit_start();
+    ARROW_DCHECK_GE(out_bit_offset, 0);
+    ARROW_DCHECK_LT(out_bit_offset, 8);
+
+    if (ARROW_PREDICT_FALSE(remaining() == 0 || batch_size == 0)) {
+      return 0;
+    }
+
+    rle_size_t n_vals = 0;
+
+    // HEADER: Writing inside the first byte if caller gives a non-aligned input
+    if (out_bit_offset != 0) {
+      n_vals = GetBatchInByte(out, batch_size);
+    }
+
+    // Writing full bytes
+    n_vals += GetBatchFullBytes(out.NewStartingAt(n_vals), batch_size - n_vals);
+
+    // TRAILER: Writing inside the last byte if caller asked for non multiple of 8 values
+    const auto n_last_vals = std::min(batch_size - n_vals, remaining());
+    if (ARROW_PREDICT_FALSE(n_last_vals > 0)) {
+      ARROW_DCHECK_LT(n_last_vals, 8);
+      n_vals += GetBatchInByte(out.NewStartingAt(n_vals), n_last_vals);
+    }
+
+    return n_vals;
+  }
+
+ private:
   /// The byte pattern for 8 values (full ones or full zeros).
   uint8_t value_pattern_ = {};
   /// Number of values left to decode.
@@ -190,8 +157,28 @@ class RleRunToBitmapDecoder
   void AdvanceUnsafe(rle_size_t batch_size) { values_left_ -= batch_size; }
 
   /// Get batch values to fill the first incomplete byte of the output.
-  [[nodiscard]] rle_size_t GetBatchFirstByte(BitmapSpanMut out, rle_size_t batch_size) {
-    return GetBatchFromByte(out, batch_size, value_pattern_);
+  [[nodiscard]] rle_size_t GetBatchInByte(BitmapSpanMut out, rle_size_t batch_size) {
+    const auto out_bit_offset = out.bit_start();
+    ARROW_DCHECK_GE(out_bit_offset, 0);
+    ARROW_DCHECK_LT(out_bit_offset, 8);
+    ARROW_DCHECK_GT(remaining(), 0);
+    ARROW_DCHECK_GE(batch_size, 0);
+
+    // Empty bits in first byte that we can fill
+    const auto empty_bits = rle_size_t{8} - out_bit_offset;
+    // Number of bits in first byte that we want to fill
+    const auto desired_bits = std::min(empty_bits, batch_size);
+    // Try to advance, and get number of bits we had remaining
+    const auto n_bits = Advance(desired_bits);
+    // Copy relevant bits from the value pattern to the output.
+    *out.data() = bit_util::CopyBits<uint8_t, /* kAllowFullCopy= */ false>({
+        .src = value_pattern_,
+        .dst = *out.data(),
+        .start = static_cast<uint8_t>(out_bit_offset),
+        .end = static_cast<uint8_t>(out_bit_offset + n_bits),
+    });
+
+    return n_bits;
   }
 
   /// Get batch in full bytes using memset.
@@ -205,8 +192,7 @@ class RleRunToBitmapDecoder
   }
 };
 
-class BitPackedRunToBitmapDecoder
-    : public internal_rle::RunToBitmapDecoderMixin<BitPackedRunToBitmapDecoder> {
+class BitPackedRunToBitmapDecoder {
  public:
   /// The type of run that can be decoded.
   using RunType = BitPackedRun;
@@ -226,22 +212,37 @@ class BitPackedRunToBitmapDecoder
   /// Return the number of values that can be advanced.
   constexpr rle_size_t remaining() const { return values_count_ - values_read_; }
 
+  /// Return how much the decoder would advance if asked to.
+  ///
+  /// Does not modify input.
+  rle_size_t AdvanceCapacity(rle_size_t batch_size) const noexcept {
+    const auto n_vals = std::min(batch_size, remaining());
+    return n_vals;
+  }
+
+  /// Advance by as many values as provided or until exhaustion of the decoder.
+  /// Return the number of values skipped.
+  [[nodiscard]] rle_size_t Advance(rle_size_t batch_size) {
+    const auto n_vals = AdvanceCapacity(batch_size);
+    values_read_ += n_vals;
+    ARROW_DCHECK_GE(remaining(), 0);
+    return n_vals;
+  }
+
+  /// Get the next value and return false if there are no more.
+  [[nodiscard]] constexpr bool Get(BitmapSpanMut out) { return GetBatch(out, 1) == 1; }
+
   /// Get a batch of values return the number of decoded elements.
   /// May write fewer elements to the output than requested if there are not enough values
   /// left.
   [[nodiscard]] rle_size_t GetBatch(BitmapSpanMut out, rle_size_t batch_size) {
-    // WARN: Slow case where bit offsets of input and output are not aligned.
-    // We loose the ability to do memcpy
-    if (ARROW_PREDICT_FALSE(out.bit_start() != unread_values_bit_offset())) {
-      return GetBatchMisaligned(out, batch_size);
-    }
-    return Base::GetBatch(out, batch_size);
+    auto n_vals = AdvanceCapacity(batch_size);
+    arrow::internal::CopyBitmap(unread_values_ptr(), unread_values_bit_offset(), n_vals,
+                                out.data(), out.bit_start());
+    return Advance(n_vals);
   }
 
  private:
-  using Base = internal_rle::RunToBitmapDecoderMixin<BitPackedRunToBitmapDecoder>;
-  friend class internal_rle::RunToBitmapDecoderMixin<BitPackedRunToBitmapDecoder>;
-
   /// The pointer to the beginning of the run
   const uint8_t* data_ = nullptr;
   /// The total number of values in the run
@@ -254,77 +255,6 @@ class BitPackedRunToBitmapDecoder
 
   /// Bit in @ref unread_values_ptr where the unread values start.
   rle_size_t unread_values_bit_offset() const noexcept { return values_read_ % 8; }
-
-  void AdvanceUnsafe(rle_size_t batch_size) { values_read_ += batch_size; }
-
-  /// Get batch values to fill the first incomplete byte of the output.
-  [[nodiscard]] rle_size_t GetBatchFirstByte(BitmapSpanMut out, rle_size_t batch_size) {
-    return GetBatchFromByte(out, batch_size, *unread_values_ptr());
-  }
-
-  /// Get batch in full bytes using memcpy.
-  [[nodiscard]] rle_size_t GetBatchFullBytes(BitmapSpanMut out, rle_size_t batch_size) {
-    ARROW_DCHECK(out.bit_start() == 0 || batch_size == 0);
-    ARROW_DCHECK(unread_values_bit_offset() == 0 || batch_size == 0);
-    const auto n_bytes = std::min(batch_size, remaining()) / 8;
-    std::memcpy(out.data(), unread_values_ptr(), n_bytes);
-    const auto n_vals = 8 * n_bytes;
-    AdvanceUnsafe(n_vals);
-    return n_vals;
-  }
-
-  /// Correct and slow function for reading a batch one bit at a time.
-  [[nodiscard]] rle_size_t GetBatchSlow(BitmapSpanMut out, rle_size_t batch_size) {
-    const rle_size_t to_read = std::min(batch_size, remaining());
-    for (rle_size_t i = 0; i < to_read; ++i) {
-      const bool bit = bit_util::GetBit(data_, values_read_ + i);
-      bit_util::SetBitTo(out.data(), out.bit_start() + i, bit);
-    }
-    AdvanceUnsafe(to_read);
-    return to_read;
-  }
-
-  [[nodiscard]] rle_size_t GetBatchMisaligned(BitmapSpanMut out, rle_size_t batch_size) {
-    const auto out_bit_offset = out.bit_start();
-    ARROW_DCHECK_LT(out_bit_offset, 8);
-    ARROW_DCHECK_GE(out_bit_offset, 0);
-
-    if (ARROW_PREDICT_FALSE(remaining() == 0 || batch_size == 0)) {
-      return 0;
-    }
-
-    const rle_size_t to_read = std::min(batch_size, remaining());
-    rle_size_t read = 0;
-
-    // HEADER: copy bits one by one until the output is byte-aligned
-    const rle_size_t to_read_until_aligned = (8 - out_bit_offset) % 8;
-    const rle_size_t to_read_header = std::min(to_read, to_read_until_aligned);
-    const auto read_header = GetBatchSlow(out, to_read_header);
-    // We ensured there was enough capacity
-    ARROW_DCHECK_EQ(read_header, to_read_header);
-    read += read_header;
-    out = out.NewStartingAt(read_header);
-    // Either we are done or we have aligned the output values on a byte.
-    ARROW_DCHECK(read == to_read || read == to_read_until_aligned);
-
-    // Main loop, copy 32 bits at the time
-    const rle_size_t n_batches = (to_read - read) / 32;
-    for (rle_size_t i = 0; i < n_batches; ++i) {
-      const auto bits = bit_util::Get32Bits(data_, values_read_ + 32 * i);
-      std::memcpy(out.data(), &bits, sizeof(bits));
-      out = out.NewStartingAt(8 * sizeof(bits));
-    }
-    const rle_size_t read_main = n_batches * 32;
-    AdvanceUnsafe(read_main);
-    read += read_main;
-
-    // TRAILER: copy remaining bits one by one
-    const auto read_trailer = GetBatchSlow(out, to_read - read);
-    read += read_trailer;
-    ARROW_DCHECK_EQ(read, to_read);
-
-    return to_read;
-  }
 };
 
 /// A specialized decoder class to extract RLE+bitpacked booleans.

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <cstdint>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,17 @@ namespace arrow::util {
 
 namespace {
 
+/// Make a vector of `size` pseudo-random bytes, deterministic for a given `seed`.
+std::vector<uint8_t> MakeRandomBytes(size_t size, uint32_t seed = 56) {
+  std::vector<uint8_t> bytes(size);
+  std::minstd_rand gen(seed);
+  std::uniform_int_distribution<uint8_t> dist(0, 255);
+  for (auto& byte : bytes) {
+    byte = dist(gen);
+  }
+  return bytes;
+}
+
 /// Read the first `count` bits of `bytes` (LSB first) into a vector of booleans.
 std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t count) {
   std::vector<bool> bits(count);
@@ -40,20 +52,41 @@ std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t co
   return bits;
 }
 
+struct CheckDecodedBitsParams {
+  const std::vector<uint8_t>& actual;
+  const std::vector<bool>& expected;
+  rle_size_t count;
+  rle_size_t actual_start_bit = 0;
+  rle_size_t expected_start_idx = 0;
+};
+
 /// Check the decoded output in `out` against `expected`.
-/// Bits `out[out_offset..out_offset + count]` must equal
-/// `expected[expected_skip..expected_skip + count]`. The `out_offset` bits before them
-/// must still be zero.
-void CheckDecodedBits(const std::vector<uint8_t>& out, const std::vector<bool>& expected,
-                      rle_size_t count, rle_size_t out_offset = 0,
-                      rle_size_t expected_skip = 0) {
-  ARROW_SCOPED_TRACE("out_offset = ", out_offset, ", expected_skip = ", expected_skip);
-  for (rle_size_t i = 0; i < out_offset; ++i) {
-    EXPECT_FALSE(bit_util::GetBit(out.data(), i)) << "clobbered bit " << i;
+void CheckDecodedBits(const CheckDecodedBitsParams& params) {
+  ARROW_SCOPED_TRACE("out_start_bit = ", params.actual_start_bit,
+                     ", expected_start_idx = ", params.expected_start_idx);
+  for (rle_size_t i = 0; i < params.count; ++i) {
+    ASSERT_EQ(bit_util::GetBit(params.actual.data(), params.actual_start_bit + i),
+              params.expected[params.expected_start_idx + i])
+        << "first difference at bit " << i;
   }
-  for (rle_size_t i = 0; i < count; ++i) {
-    EXPECT_EQ(bit_util::GetBit(out.data(), out_offset + i), expected[expected_skip + i])
-        << "at bit " << i;
+}
+
+struct CheckBitsEqualParams {
+  const std::vector<uint8_t>& actual;
+  const std::vector<uint8_t>& expected;
+  rle_size_t count;
+  rle_size_t actual_start_bit = 0;
+  rle_size_t expected_start_bit = 0;
+};
+
+/// Check that two bit ranges, stored in `actual` and `expected`, are equal.
+void CheckBitsEqual(const CheckBitsEqualParams& params) {
+  ARROW_SCOPED_TRACE("actual_start_bit = ", params.actual_start_bit,
+                     ", expected_start_bit = ", params.expected_start_bit);
+  for (rle_size_t i = 0; i < params.count; ++i) {
+    ASSERT_EQ(bit_util::GetBit(params.actual.data(), params.actual_start_bit + i),
+              bit_util::GetBit(params.expected.data(), params.expected_start_bit + i))
+        << "first difference at bit " << i;
   }
 }
 
@@ -68,37 +101,103 @@ void CheckDecodedBits(const std::vector<uint8_t>& out, const std::vector<bool>& 
 /// read path of BitPackedRunToBitmapDecoder. With `expected_skip == 0` they stay in sync
 /// and only the aligned path runs.
 template <typename Decoder>
-void CheckChunkedDecode(const typename Decoder::RunType& run,
-                        const std::vector<bool>& expected, rle_size_t chunk_size = 1,
-                        rle_size_t expected_skip = 0) {
+void CheckDecoderValuesChunked(const typename Decoder::RunType& run,
+                               const std::vector<bool>& expected,
+                               rle_size_t chunk_size = 1, rle_size_t expected_skip = 0) {
   ARROW_SCOPED_TRACE("chunk_size = ", chunk_size, ", expected_skip = ", expected_skip);
+
   const auto n_vals = static_cast<rle_size_t>(expected.size());
   ASSERT_LE(expected_skip, n_vals);
 
   Decoder decoder(run);
   const auto advanced = decoder.Advance(expected_skip);
   ASSERT_EQ(advanced, expected_skip);
-  const auto rest = n_vals - expected_skip;
+  const auto n_vals_to_decode = n_vals - expected_skip;
 
-  // Output buffer with one guard byte to catch out-of-bounds writes.
-  std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(rest)) + 1, 0);
-  const uint8_t guard = 0xA5;
-  out.back() = guard;
+  // Output buffer
+  const auto n_bytes = static_cast<size_t>(bit_util::BytesForBits(n_vals_to_decode));
+  std::vector<uint8_t> out(n_bytes, 0);
 
-  rle_size_t read = 0;
-  while (read < rest) {
-    const auto want = std::min(chunk_size, rest - read);
+  rle_size_t n_val_read = 0;
+  while (n_val_read < n_vals_to_decode) {
+    const auto want = std::min(chunk_size, n_vals_to_decode - n_val_read);
     const auto got =
-        decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/read), want);
-    EXPECT_EQ(got, want) << "at pos " << read;
-    ASSERT_GT(got, 0) << "at pos " << read;  // break on failure
-    read += got;
-    EXPECT_EQ(decoder.remaining(), rest - read);
+        decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/n_val_read), want);
+    EXPECT_EQ(got, want) << "at pos " << n_val_read;
+    ASSERT_GT(got, 0) << "at pos " << n_val_read;  // break on failure
+    n_val_read += got;
+    EXPECT_EQ(decoder.remaining(), n_vals_to_decode - n_val_read);
   }
 
   EXPECT_EQ(decoder.remaining(), 0);
-  EXPECT_EQ(out.back(), guard) << "decoder wrote past the end of the output";
-  CheckDecodedBits(out, expected, /*count=*/rest, /*out_offset=*/0, expected_skip);
+  CheckDecodedBits({
+      .actual = out,
+      .expected = expected,
+      .count = n_vals_to_decode,
+      .actual_start_bit = 0,
+      .expected_start_idx = expected_skip,
+  });
+}
+
+/// Decode a chunk of data into a known output to check for out of bounds write.
+///
+/// @see CheckDecoderValuesChunked
+template <typename Decoder>
+void CheckDecoderClobber(const typename Decoder::RunType& run,
+                         const std::vector<bool>& expected, rle_size_t chunk_size = 1,
+                         rle_size_t expected_skip = 0) {
+  ARROW_SCOPED_TRACE("chunk_size = ", chunk_size, ", expected_skip = ", expected_skip);
+
+  const auto n_vals = static_cast<rle_size_t>(expected.size());
+  ASSERT_LE(expected_skip, n_vals);
+
+  Decoder decoder(run);
+  const auto advanced = decoder.Advance(expected_skip);
+  ASSERT_EQ(advanced, expected_skip);
+  const auto n_vals_to_decode = n_vals - expected_skip;
+
+  // Output buffer with enough capacity to store a full chunk plus extra bytes as
+  // clobbers/guard to check for out of bounds write.
+  const auto n_bytes = static_cast<size_t>(bit_util::BytesForBits(chunk_size) +
+                                           bit_util::CeilDiv(n_vals, chunk_size) + 2);
+  // This seed is arbitrary and of little importance. We are simply trying to avoid an
+  // unlikely case where guards have the same pattern in all invocations.
+  const auto out_pattern =
+      MakeRandomBytes(n_bytes, /* seed= */ (chunk_size << 16) ^ expected_skip);
+  auto out = out_pattern;
+
+  rle_size_t n_val_read = 0;
+  rle_size_t out_bit_start = 0;
+  while (n_val_read < n_vals_to_decode) {
+    // Clean output buffer
+    out = out_pattern;
+    const auto want = std::min(chunk_size, n_vals_to_decode - n_val_read);
+    const auto got = decoder.GetBatch(BitmapSpanMut(out.data(), out_bit_start), want);
+    ASSERT_GT(got, 0) << "at pos " << n_val_read;  // break on failure
+    EXPECT_EQ(got, want) << "at pos " << n_val_read;
+    // Check that the leading bits have not been modified
+    CheckBitsEqual({.actual = out, .expected = out_pattern, .count = out_bit_start});
+    // Check that the trailing bits have not been modified
+    CheckBitsEqual({
+        .actual = out,
+        .expected = out_pattern,
+        .count = static_cast<rle_size_t>(8 * n_bytes) - (out_bit_start + want),
+        .actual_start_bit = out_bit_start + want,
+        .expected_start_bit = out_bit_start + want,
+    });
+    // Check decoded bits are also correct
+    CheckDecodedBits({
+        .actual = out,
+        .expected = expected,
+        .count = want,
+        .actual_start_bit = out_bit_start,
+        .expected_start_idx = expected_skip + n_val_read,
+    });
+
+    n_val_read += got;
+    ++out_bit_start;
+    EXPECT_EQ(decoder.remaining(), n_vals_to_decode - n_val_read);
+  }
 }
 
 /// All the checks shared by both decoder types.
@@ -127,7 +226,7 @@ void CheckBitmapDecoder(const typename Decoder::RunType& run,
   // Decode the whole run in several chunks.
   for (const rle_size_t chunk_size : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
                                       rle_size_t{8}, rle_size_t{9}, n_vals, n_vals + 1}) {
-    CheckChunkedDecode<Decoder>(run, expected, chunk_size);
+    CheckDecoderValuesChunked<Decoder>(run, expected, chunk_size);
   }
 
   // Decode the whole run in several chunks, after an initial Advance that shifts
@@ -136,7 +235,10 @@ void CheckBitmapDecoder(const typename Decoder::RunType& run,
                                       rle_size_t{8}, rle_size_t{9}, n_vals, n_vals + 1}) {
     for (rle_size_t expected_skip = 1; expected_skip < 8 && expected_skip < n_vals;
          ++expected_skip) {
-      CheckChunkedDecode<Decoder>(run, expected, chunk_size, expected_skip);
+      // Check the decoding happens as expected
+      CheckDecoderValuesChunked<Decoder>(run, expected, chunk_size, expected_skip);
+      // Check the decoding does not write out of bounds
+      CheckDecoderClobber<Decoder>(run, expected, chunk_size, expected_skip);
     }
   }
 
@@ -155,7 +257,7 @@ void CheckBitmapDecoder(const typename Decoder::RunType& run,
     const auto advanced = decoder.Advance(1);
     EXPECT_EQ(advanced, 0);
     EXPECT_EQ(decoder.remaining(), 0);
-    CheckDecodedBits(out, expected, /*count=*/n_vals);
+    CheckDecodedBits({.actual = out, .expected = expected, .count = n_vals});
   }
 
   // Advancing more than available stops at the run boundary.
@@ -179,7 +281,7 @@ void CheckBitmapDecoder(const typename Decoder::RunType& run,
     std::vector<uint8_t> out_2(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
     const auto got = decoder.GetBatch(BitmapSpanMut(out_2.data()), n_vals);
     EXPECT_EQ(got, n_vals);
-    CheckDecodedBits(out_2, expected, /*count=*/n_vals);
+    CheckDecodedBits({.actual = out_2, .expected = expected, .count = n_vals});
   }
 }
 
@@ -337,7 +439,12 @@ void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
   EXPECT_TRUE(decoder.exhausted());
 
   EXPECT_EQ(out.back(), guard) << "decoder wrote past the end of the output";
-  CheckDecodedBits(out, expected, /*count=*/n_vals, out_offset);
+  CheckDecodedBits({
+      .actual = out,
+      .expected = expected,
+      .count = n_vals,
+      .actual_start_bit = out_offset,
+  });
 }
 
 /// Run the decode check over a battery of chunk sizes and output offsets.
@@ -438,7 +545,7 @@ TEST(RleBitPackedToBitmapDecoder, ReadPastEnd) {
   EXPECT_TRUE(decoder.exhausted());
   got = decoder.GetBatch(BitmapSpanMut(out.data()), 10);
   EXPECT_EQ(got, 0);
-  CheckDecodedBits(out, expected, /*count=*/n_vals);
+  CheckDecodedBits({.actual = out, .expected = expected, .count = n_vals});
 }
 
 TEST(RleBitPackedToBitmapDecoder, Reset) {
@@ -463,7 +570,7 @@ TEST(RleBitPackedToBitmapDecoder, Reset) {
   const auto got_2 = decoder.GetBatch(BitmapSpanMut(out_2.data()), n_vals);
   EXPECT_EQ(got_2, n_vals);
   EXPECT_TRUE(decoder.exhausted());
-  CheckDecodedBits(out_2, expected, /*count=*/n_vals);
+  CheckDecodedBits({.actual = out_2, .expected = expected, .count = n_vals});
 }
 
 TEST(RleBitPackedToBitmapDecoder, Truncated) {
@@ -485,7 +592,7 @@ TEST(RleBitPackedToBitmapDecoder, Truncated) {
   const auto got = decoder.GetBatch(BitmapSpanMut(out.data()), 1000);
   EXPECT_EQ(got, 10);
   EXPECT_FALSE(decoder.exhausted());
-  CheckDecodedBits(out, expected, /*count=*/10);
+  CheckDecodedBits({.actual = out, .expected = expected, .count = 10});
 }
 
 }  // namespace arrow::util

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -30,8 +31,7 @@ namespace arrow::util {
 
 namespace {
 
-/// Expand a list of bytes into the bit-packed (LSB-first) sequence of booleans
-/// they encode, keeping only the first `count` bits.
+/// Read the first `count` bits of `bytes` (LSB first) into a vector of booleans.
 std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t count) {
   std::vector<bool> bits(count);
   for (rle_size_t i = 0; i < count; ++i) {
@@ -40,28 +40,42 @@ std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t co
   return bits;
 }
 
+/// Check the decoded output in `out` against `expected`.
+/// Bits `out[out_offset..out_offset + count]` must equal `expected[skip..skip + count]`.
+/// The `out_offset` bits before them must still be zero.
+void CheckDecodedBits(const std::vector<uint8_t>& out, const std::vector<bool>& expected,
+                      rle_size_t count, rle_size_t out_offset = 0, rle_size_t skip = 0) {
+  ARROW_SCOPED_TRACE("out_offset = ", out_offset, ", skip = ", skip);
+  for (rle_size_t i = 0; i < out_offset; ++i) {
+    EXPECT_FALSE(bit_util::GetBit(out.data(), i)) << "clobbered bit " << i;
+  }
+  for (rle_size_t i = 0; i < count; ++i) {
+    EXPECT_EQ(bit_util::GetBit(out.data(), out_offset + i), expected[skip + i])
+        << "at bit " << i;
+  }
+}
+
 /// Skip the first `skip` values with Advance(), then decode the rest of the run
-/// into a contiguous output bitmap, in successive calls of at most `chunk` values
-/// each, and compare the result against `expected`.
+/// into one output bitmap, `chunk` values at a time. Compare against `expected`.
 ///
-/// This drives both decoder types through their byte-aligned and bit-unaligned
-/// code paths depending on `chunk`: as soon as `chunk` is not a multiple of 8,
-/// later calls land on a non-zero output bit offset.
+/// `chunk` controls output bit alignment. When `chunk` is not a multiple of 8,
+/// later calls start at a non-zero output bit offset.
 ///
-/// A non-zero `skip` additionally desynchronizes the decoder's read offset from
-/// the (byte-aligned) output offset, which exercises the bit-unaligned
-/// (GetBatchMisaligned) path of BitPackedRunToBitMapDecoder. With `skip == 0` the
-/// read and output offsets stay in lockstep and only the aligned path is used.
+/// `skip` shifts the decoder's read offset relative to the output offset.
+/// A non-zero `skip` makes the two differ, which exercises the bit-unaligned read
+/// path of BitPackedRunToBitMapDecoder. With `skip == 0` they stay in sync and
+/// only the aligned path runs.
 template <typename Decoder>
 void CheckChunkedDecode(const typename Decoder::RunType& run,
-                        const std::vector<bool>& expected, rle_size_t chunk,
+                        const std::vector<bool>& expected, rle_size_t chunk = 1,
                         rle_size_t skip = 0) {
   ARROW_SCOPED_TRACE("chunk = ", chunk, ", skip = ", skip);
   const auto n_vals = static_cast<rle_size_t>(expected.size());
   ASSERT_LE(skip, n_vals);
 
   Decoder decoder(run);
-  ASSERT_EQ(decoder.Advance(skip), skip);
+  const auto advanced = decoder.Advance(skip);
+  ASSERT_EQ(advanced, skip);
   const auto rest = n_vals - skip;
 
   // Output buffer with one guard byte to catch out-of-bounds writes.
@@ -82,20 +96,16 @@ void CheckChunkedDecode(const typename Decoder::RunType& run,
 
   EXPECT_EQ(decoder.remaining(), 0);
   EXPECT_EQ(out.back(), guard) << "decoder wrote past the end of the output";
-  for (rle_size_t i = 0; i < rest; ++i) {
-    EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[skip + i]) << "at bit " << i;
-  }
+  CheckDecodedBits(out, expected, /*count=*/rest, /*out_offset=*/0, skip);
 }
 
-/// The full battery of checks shared by both decoder types. `expected` is the
-/// full sequence of booleans the run is supposed to decode to.
+/// All the checks shared by both decoder types.
+///
+/// `expected` is the full sequence of booleans the run should decode to.
 template <typename Decoder>
 void CheckBitMapDecoder(const typename Decoder::RunType& run,
                         const std::vector<bool>& expected) {
   const auto n_vals = static_cast<rle_size_t>(expected.size());
-  // The sub-checks below (Advance, single Get, several chunk sizes) assume a
-  // run with a handful of values to exercise.
-  ASSERT_GE(n_vals, 9);
 
   // remaining() reflects the run size before any value is read.
   {
@@ -107,18 +117,21 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
   {
     Decoder decoder(run);
     uint8_t out = 0;
-    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&out), /*batch_size=*/0), 0);
+    const auto got = decoder.GetBatch(BitmapSpanMut(&out), /*batch_size=*/0);
+    EXPECT_EQ(got, 0);
     EXPECT_EQ(decoder.remaining(), n_vals);
   }
 
-  // Decode the whole run with various chunk sizes: aligned (8), unaligned
-  // (1, 3, 7, 9) and all-at-once.
+  // Decode the whole run in several chunks.
   for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
                                  rle_size_t{8}, rle_size_t{9}, n_vals}) {
     CheckChunkedDecode<Decoder>(run, expected, chunk);
-    // Same, but skipping the first 1..7 values first so the decoder's read
-    // offset no longer matches the byte-aligned output (driving the
-    // bit-unaligned path for decoders that have one).
+  }
+
+  // Decode the whole run in several chunks, after an initial Advance that shifts
+  // the run and output bit alignment.
+  for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
+                                 rle_size_t{8}, rle_size_t{9}, n_vals}) {
     for (rle_size_t skip = 1; skip < 8 && skip < n_vals; ++skip) {
       CheckChunkedDecode<Decoder>(run, expected, chunk, skip);
     }
@@ -129,65 +142,41 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
     Decoder decoder(run);
     std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)) + 1, 0);
     for (rle_size_t i = 0; i < n_vals; ++i) {
-      EXPECT_TRUE(decoder.Get(BitmapSpanMut(out.data(), /*bit_start=*/i)));
+      const bool ok = decoder.Get(BitmapSpanMut(out.data(), /*bit_start=*/i));
+      EXPECT_TRUE(ok);
       EXPECT_EQ(decoder.remaining(), n_vals - i - 1);
     }
     // Exhausted: nothing more can be read or advanced.
-    EXPECT_FALSE(decoder.Get(BitmapSpanMut(out.data())));
-    EXPECT_EQ(decoder.Advance(1), 0);
+    const bool ok = decoder.Get(BitmapSpanMut(out.data()));
+    EXPECT_FALSE(ok);
+    const auto advanced = decoder.Advance(1);
+    EXPECT_EQ(advanced, 0);
     EXPECT_EQ(decoder.remaining(), 0);
-    for (rle_size_t i = 0; i < n_vals; ++i) {
-      EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
-    }
-  }
-
-  // Advance() skips values; the remainder still decodes correctly and
-  // contiguously from the skipped position.
-  {
-    Decoder decoder(run);
-    const rle_size_t skip = 5;
-    EXPECT_EQ(decoder.Advance(skip), skip);
-    EXPECT_EQ(decoder.remaining(), n_vals - skip);
-
-    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)) + 1, 0);
-    rle_size_t read = skip;
-    while (read < n_vals) {
-      const auto got =
-          decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/read), n_vals - read);
-      ASSERT_GT(got, 0);  // break on failure
-      read += got;
-    }
-    EXPECT_EQ(decoder.remaining(), 0);
-    // Bits before the skipped position must be left untouched (still zero).
-    for (rle_size_t i = 0; i < skip; ++i) {
-      EXPECT_FALSE(bit_util::GetBit(out.data(), i)) << "clobbered bit " << i;
-    }
-    for (rle_size_t i = skip; i < n_vals; ++i) {
-      EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
-    }
+    CheckDecodedBits(out, expected, /*count=*/n_vals);
   }
 
   // Advancing more than available stops at the run boundary.
   {
     Decoder decoder(run);
-    EXPECT_EQ(decoder.Advance(n_vals + 100), n_vals);
+    const auto advanced = decoder.Advance(n_vals + 100);
+    EXPECT_EQ(advanced, n_vals);
     EXPECT_EQ(decoder.remaining(), 0);
   }
 
   // Reset() rewinds the decoder so the run can be decoded again.
   {
     Decoder decoder(run);
-    std::vector<uint8_t> scratch(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
-    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(scratch.data()), n_vals), n_vals);
+    std::vector<uint8_t> out_1(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
+    const auto scratch_got = decoder.GetBatch(BitmapSpanMut(out_1.data()), n_vals);
+    EXPECT_EQ(scratch_got, n_vals);
     EXPECT_EQ(decoder.remaining(), 0);
 
     decoder.Reset(run);
     EXPECT_EQ(decoder.remaining(), n_vals);
-    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
-    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n_vals), n_vals);
-    for (rle_size_t i = 0; i < n_vals; ++i) {
-      EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
-    }
+    std::vector<uint8_t> out_2(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
+    const auto got = decoder.GetBatch(BitmapSpanMut(out_2.data()), n_vals);
+    EXPECT_EQ(got, n_vals);
+    CheckDecodedBits(out_2, expected, /*count=*/n_vals);
   }
 }
 
@@ -223,20 +212,26 @@ TEST_P(RleRunToBitMapDecoderTest, Decode) {
   CheckBitMapDecoder<RleRunToBitMapDecoder>(run, expected);
 }
 
-INSTANTIATE_TEST_SUITE_P(RleBitmap, RleRunToBitMapDecoderTest,
-                         ::testing::Values(RleBitMapCase{/*value=*/false, /*count=*/9},
-                                           RleBitMapCase{/*value=*/true, /*count=*/9},
-                                           RleBitMapCase{/*value=*/false, /*count=*/13},
-                                           RleBitMapCase{/*value=*/true, /*count=*/13},
-                                           RleBitMapCase{/*value=*/false, /*count=*/64},
-                                           RleBitMapCase{/*value=*/true, /*count=*/64},
-                                           RleBitMapCase{/*value=*/false, /*count=*/100},
-                                           RleBitMapCase{/*value=*/true, /*count=*/100},
-                                           RleBitMapCase{/*value=*/true, /*count=*/1000}),
-                         [](const ::testing::TestParamInfo<RleBitMapCase>& info) {
-                           return std::string(info.param.value ? "true_" : "false_") +
-                                  std::to_string(info.param.count);
-                         });
+INSTANTIATE_TEST_SUITE_P(  //
+    RleBitmap, RleRunToBitMapDecoderTest,
+    ::testing::Values(  //
+        RleBitMapCase{.value = false, .count = 0},
+        RleBitMapCase{.value = true, .count = 1},
+        RleBitMapCase{.value = false, .count = 3},
+        RleBitMapCase{.value = true, .count = 8},
+        RleBitMapCase{.value = false, .count = 9},
+        RleBitMapCase{.value = true, .count = 9},
+        RleBitMapCase{.value = false, .count = 13},
+        RleBitMapCase{.value = true, .count = 13},
+        RleBitMapCase{.value = false, .count = 64},
+        RleBitMapCase{.value = true, .count = 64},
+        RleBitMapCase{.value = false, .count = 100},
+        RleBitMapCase{.value = true, .count = 100},
+        RleBitMapCase{.value = true, .count = 1000}),
+    [](const ::testing::TestParamInfo<RleBitMapCase>& info) {
+      return std::string(info.param.value ? "true_" : "false_") +
+             std::to_string(info.param.count);
+    });
 
 /*********************************
  *  BitPackedRunToBitMapDecoder  *
@@ -264,26 +259,26 @@ TEST_P(BitPackedRunToBitMapDecoderTest, Decode) {
   CheckBitMapDecoder<BitPackedRunToBitMapDecoder>(run, expected);
 }
 
-INSTANTIATE_TEST_SUITE_P(
+INSTANTIATE_TEST_SUITE_P(  //
     RleBitmap, BitPackedRunToBitMapDecoderTest,
-    ::testing::Values(BitPackedBitMapCase{/*name=*/"alternating",
-                                          /*bytes=*/{0b10101010, 0b10101010},
-                                          /*count=*/13},
-                      BitPackedBitMapCase{/*name=*/"all_zeros",
-                                          /*bytes=*/{0x00, 0x00},
-                                          /*count=*/16},
-                      BitPackedBitMapCase{/*name=*/"all_ones",
-                                          /*bytes=*/{0xFF, 0xFF},
-                                          /*count=*/16},
-                      BitPackedBitMapCase{/*name=*/"mixed",
-                                          /*bytes=*/{0b11001010, 0b00001111, 0b10110001},
-                                          /*count=*/24},
-                      BitPackedBitMapCase{/*name=*/"unaligned_count",
-                                          /*bytes=*/{0b00110101, 0b11100100},
-                                          /*count=*/11},
-                      BitPackedBitMapCase{/*name=*/"large",
-                                          /*bytes=*/std::vector<uint8_t>(16, 0b01101001),
-                                          /*count=*/128}),
+    ::testing::Values(  //
+        BitPackedBitMapCase{.name = "empty", .bytes = {0b10110010}, .count = 0},
+        BitPackedBitMapCase{.name = "single", .bytes = {0b00000001}, .count = 1},
+        BitPackedBitMapCase{.name = "three", .bytes = {0b00000101}, .count = 3},
+        BitPackedBitMapCase{.name = "eight", .bytes = {0b11010010}, .count = 8},
+        BitPackedBitMapCase{
+            .name = "alternating", .bytes = {0b10101010, 0b10101010}, .count = 13},
+        BitPackedBitMapCase{.name = "all_zeros", .bytes = {0x00, 0x00}, .count = 16},
+        BitPackedBitMapCase{.name = "all_ones", .bytes = {0xFF, 0xFF}, .count = 16},
+        BitPackedBitMapCase{
+            .name = "mixed", .bytes = {0b11001010, 0b00001111, 0b10110001}, .count = 24},
+        BitPackedBitMapCase{
+            .name = "unaligned_count", .bytes = {0b00110101, 0b11100100}, .count = 11},
+        BitPackedBitMapCase{
+            .name = "large",
+            .bytes = std::vector<uint8_t>(16, 0b01101001),
+            .count = 128,
+        }),
     [](const ::testing::TestParamInfo<BitPackedBitMapCase>& info) {
       return info.param.name;
     });
@@ -296,15 +291,13 @@ namespace {
 
 /// Append the LEB128 (unsigned, little-endian base-128) encoding of `value`.
 void AppendLeb128(std::vector<uint8_t>& out, uint32_t value) {
-  uint8_t buf[bit_util::kMaxLEB128ByteLenFor<uint32_t>];
-  const auto n_vals =
-      bit_util::WriteLEB128(value, buf, static_cast<int32_t>(sizeof(buf)));
-  ASSERT_GT(n_vals, 0);
-  out.insert(out.end(), buf, buf + n_vals);
+  std::array<uint8_t, bit_util::kMaxLEB128ByteLenFor<uint32_t>> buf;
+  const auto n_bytes =
+      bit_util::WriteLEB128(value, buf.data(), static_cast<int32_t>(buf.size()));
+  ASSERT_GT(n_bytes, 0);
+  out.insert(out.end(), buf.data(), buf.data() + n_bytes);
 }
 
-/// Append an RLE run of `count` copies of `value` (1-bit values) to the encoded
-/// `bytes` stream and to the `expected` decoded sequence.
 void AppendRleRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected, bool value,
                   rle_size_t count) {
   AppendLeb128(bytes, static_cast<uint32_t>(count) << 1);  // low bit 0 => RLE
@@ -312,8 +305,6 @@ void AppendRleRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected, bool
   expected.insert(expected.end(), count, value);
 }
 
-/// Append a bit-packed run holding `packed.size()` groups of 8 (1-bit) values,
-/// LSB first, to the encoded `bytes` stream and to the `expected` sequence.
 void AppendBitPackedRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected,
                         const std::vector<uint8_t>& packed) {
   const auto groups = static_cast<rle_size_t>(packed.size());
@@ -324,13 +315,11 @@ void AppendBitPackedRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected
   }
 }
 
-/// Decode the whole `bytes` stream into a bitmap starting at bit offset
-/// `out_offset`, in successive GetBatch calls of at most `chunk` values, and
-/// compare against `expected`.
+/// Decode the whole `bytes` into a bitmap and check it against `expected`.
 ///
-/// Decoding in small, byte-unaligned chunks and (with a non-zero `out_offset`)
-/// at a non-aligned output position exercises how the decoder threads its output
-/// bit offset across runs that do not end on a byte boundary.
+/// Decode `chunk` values per GetBatch call to check the decoder state between
+/// calls. The output starts at bit offset `out_offset`. A non-zero offset makes
+/// the output and the encoded `bytes` use different bit alignment.
 void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
                              const std::vector<bool>& expected, rle_size_t chunk,
                              rle_size_t out_offset = 0) {
@@ -361,27 +350,21 @@ void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
   EXPECT_TRUE(decoder.exhausted());
   // Reading past the end yields nothing and leaves the decoder exhausted.
   uint8_t scratch = 0;
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&scratch), 8), 0);
+  const auto past_end = decoder.GetBatch(BitmapSpanMut(&scratch), 8);
+  EXPECT_EQ(past_end, 0);
   EXPECT_TRUE(decoder.exhausted());
 
   EXPECT_EQ(out.back(), guard) << "decoder wrote past the end of the output";
-  // Bits before the output offset must be left untouched (still zero).
-  for (rle_size_t i = 0; i < out_offset; ++i) {
-    EXPECT_FALSE(bit_util::GetBit(out.data(), i)) << "clobbered bit " << i;
-  }
-  for (rle_size_t i = 0; i < n_vals; ++i) {
-    EXPECT_EQ(bit_util::GetBit(out.data(), out_offset + i), expected[i])
-        << "at bit " << i;
-  }
+  CheckDecodedBits(out, expected, /*count=*/n_vals, out_offset);
 }
 
 /// Run the decode check over a battery of chunk sizes and output offsets.
 void CheckRleBitPackedToBitMap(const std::vector<uint8_t>& bytes,
                                const std::vector<bool>& expected) {
-  const auto n = static_cast<rle_size_t>(expected.size());
-  ASSERT_GT(n, 0);
+  const auto n_vals = static_cast<rle_size_t>(expected.size());
+  ASSERT_GT(n_vals, 0);
   for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
-                                 rle_size_t{8}, rle_size_t{9}, rle_size_t{33}, n}) {
+                                 rle_size_t{8}, rle_size_t{9}, rle_size_t{33}, n_vals}) {
     CheckRleBitPackedDecode(bytes, expected, chunk);
     // A non-zero output offset forces the first run to start at a non-byte
     // aligned output position.
@@ -398,12 +381,14 @@ TEST(RleBitPackedToBitMapDecoder, Empty) {
   RleBitPackedToBitMapDecoder decoder;
   EXPECT_TRUE(decoder.exhausted());
   uint8_t out = 0;
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&out), 8), 0);
+  auto got = decoder.GetBatch(BitmapSpanMut(&out), 8);
+  EXPECT_EQ(got, 0);
 
   // So is one reset on an empty buffer.
   decoder.Reset(nullptr, 0);
   EXPECT_TRUE(decoder.exhausted());
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&out), 8), 0);
+  got = decoder.GetBatch(BitmapSpanMut(&out), 8);
+  EXPECT_EQ(got, 0);
 }
 
 TEST(RleBitPackedToBitMapDecoder, SingleRleZeros) {
@@ -459,18 +444,18 @@ TEST(RleBitPackedToBitMapDecoder, ReadPastEnd) {
   std::vector<bool> expected;
   AppendRleRun(bytes, expected, /*value=*/true, /*count=*/10);
   AppendBitPackedRun(bytes, expected, {0b10110010});
-  const auto n = static_cast<rle_size_t>(expected.size());
+  const auto n_vals = static_cast<rle_size_t>(expected.size());
 
   RleBitPackedToBitMapDecoder decoder(bytes.data(),
                                       static_cast<rle_size_t>(bytes.size()));
-  std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)) + 1, 0);
+  std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)) + 1, 0);
   // Requesting more values than available produces only the available ones.
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n + 100), n);
+  auto got = decoder.GetBatch(BitmapSpanMut(out.data()), n_vals + 100);
+  EXPECT_EQ(got, n_vals);
   EXPECT_TRUE(decoder.exhausted());
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), 10), 0);
-  for (rle_size_t i = 0; i < n; ++i) {
-    EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
-  }
+  got = decoder.GetBatch(BitmapSpanMut(out.data()), 10);
+  EXPECT_EQ(got, 0);
+  CheckDecodedBits(out, expected, /*count=*/n_vals);
 }
 
 TEST(RleBitPackedToBitMapDecoder, Reset) {
@@ -479,32 +464,34 @@ TEST(RleBitPackedToBitMapDecoder, Reset) {
   AppendRleRun(bytes, expected, /*value=*/true, /*count=*/13);
   AppendBitPackedRun(bytes, expected, {0b01101001, 0b10010110});
   AppendRleRun(bytes, expected, /*value=*/false, /*count=*/20);
-  const auto n = static_cast<rle_size_t>(expected.size());
-  const auto size = static_cast<rle_size_t>(bytes.size());
+  const auto n_vals = static_cast<rle_size_t>(expected.size());
+  const auto data_size = static_cast<rle_size_t>(bytes.size());
 
-  RleBitPackedToBitMapDecoder decoder(bytes.data(), size);
-  std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n), n);
+  RleBitPackedToBitMapDecoder decoder(bytes.data(), data_size);
+  std::vector<uint8_t> out_1(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
+  const auto got_1 = decoder.GetBatch(BitmapSpanMut(out_1.data()), n_vals);
+  EXPECT_EQ(got_1, n_vals);
   EXPECT_TRUE(decoder.exhausted());
 
   // Reset rewinds the decoder so the same buffer decodes again.
-  decoder.Reset(bytes.data(), size);
+  decoder.Reset(bytes.data(), data_size);
   EXPECT_FALSE(decoder.exhausted());
-  std::vector<uint8_t> out2(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out2.data()), n), n);
+  std::vector<uint8_t> out_2(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
+  const auto got_2 = decoder.GetBatch(BitmapSpanMut(out_2.data()), n_vals);
+  EXPECT_EQ(got_2, n_vals);
   EXPECT_TRUE(decoder.exhausted());
-  for (rle_size_t i = 0; i < n; ++i) {
-    EXPECT_EQ(bit_util::GetBit(out2.data(), i), expected[i]) << "at bit " << i;
-  }
+  CheckDecodedBits(out_2, expected, /*count=*/n_vals);
 }
 
 TEST(RleBitPackedToBitMapDecoder, Truncated) {
-  // GH-style malformed input: a bit-packed run declares more groups than the
-  // buffer holds. The decoder yields what it can and is not exhausted.
+  // Malformed input: a bit-packed run declares more values than the buffer
+  // holds. The decoder should return the values it can read and report that it
+  // is not exhausted, rather than crash or read out of bounds.
   std::vector<uint8_t> bytes;
   std::vector<bool> expected;
   AppendRleRun(bytes, expected, /*value=*/true, /*count=*/10);
-  // Declare 4 groups (32 values) of bit-packed data but provide only 1 byte.
+  // The header declares 4 bytes (4 * 8 = 32 values) of bit-packed data, but only
+  // 1 byte follows.
   AppendLeb128(bytes, (4u << 1) | 1);
   bytes.push_back(0b10101010);
 
@@ -512,11 +499,10 @@ TEST(RleBitPackedToBitMapDecoder, Truncated) {
                                       static_cast<rle_size_t>(bytes.size()));
   std::vector<uint8_t> out(16, 0);
   // The RLE run decodes fully; the truncated bit-packed run cannot be parsed.
-  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), 1000), 10);
+  const auto got = decoder.GetBatch(BitmapSpanMut(out.data()), 1000);
+  EXPECT_EQ(got, 10);
   EXPECT_FALSE(decoder.exhausted());
-  for (rle_size_t i = 0; i < 10; ++i) {
-    EXPECT_EQ(bit_util::GetBit(out.data(), i), true) << "at bit " << i;
-  }
+  CheckDecodedBits(out, expected, /*count=*/10);
 }
 
 }  // namespace arrow::util

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -30,8 +30,8 @@ namespace arrow::util {
 
 namespace {
 
-// Expand a list of bytes into the bit-packed (LSB-first) sequence of booleans
-// they encode, keeping only the first `count` bits.
+/// Expand a list of bytes into the bit-packed (LSB-first) sequence of booleans
+/// they encode, keeping only the first `count` bits.
 std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t count) {
   std::vector<bool> bits(count);
   for (rle_size_t i = 0; i < count; ++i) {
@@ -40,18 +40,18 @@ std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t co
   return bits;
 }
 
-// Skip the first `skip` values with Advance(), then decode the rest of the run
-// into a contiguous output bitmap, in successive calls of at most `chunk` values
-// each, and compare the result against `expected`.
-//
-// This drives both decoder types through their byte-aligned and bit-unaligned
-// code paths depending on `chunk`: as soon as `chunk` is not a multiple of 8,
-// later calls land on a non-zero output bit offset.
-//
-// A non-zero `skip` additionally desynchronizes the decoder's read offset from
-// the (byte-aligned) output offset, which exercises the bit-unaligned
-// (GetBatchMisaligned) path of BitPackedRunToBitMapDecoder. With `skip == 0` the
-// read and output offsets stay in lockstep and only the aligned path is used.
+/// Skip the first `skip` values with Advance(), then decode the rest of the run
+/// into a contiguous output bitmap, in successive calls of at most `chunk` values
+/// each, and compare the result against `expected`.
+///
+/// This drives both decoder types through their byte-aligned and bit-unaligned
+/// code paths depending on `chunk`: as soon as `chunk` is not a multiple of 8,
+/// later calls land on a non-zero output bit offset.
+///
+/// A non-zero `skip` additionally desynchronizes the decoder's read offset from
+/// the (byte-aligned) output offset, which exercises the bit-unaligned
+/// (GetBatchMisaligned) path of BitPackedRunToBitMapDecoder. With `skip == 0` the
+/// read and output offsets stay in lockstep and only the aligned path is used.
 template <typename Decoder>
 void CheckChunkedDecode(const typename Decoder::RunType& run,
                         const std::vector<bool>& expected, rle_size_t chunk,
@@ -87,8 +87,8 @@ void CheckChunkedDecode(const typename Decoder::RunType& run,
   }
 }
 
-// The full battery of checks shared by both decoder types. `expected` is the
-// full sequence of booleans the run is supposed to decode to.
+/// The full battery of checks shared by both decoder types. `expected` is the
+/// full sequence of booleans the run is supposed to decode to.
 template <typename Decoder>
 void CheckBitMapDecoder(const typename Decoder::RunType& run,
                         const std::vector<bool>& expected) {
@@ -294,7 +294,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 namespace {
 
-// Append the LEB128 (unsigned, little-endian base-128) encoding of `value`.
+/// Append the LEB128 (unsigned, little-endian base-128) encoding of `value`.
 void AppendLeb128(std::vector<uint8_t>& out, uint32_t value) {
   uint8_t buf[bit_util::kMaxLEB128ByteLenFor<uint32_t>];
   const auto n_vals =
@@ -303,8 +303,8 @@ void AppendLeb128(std::vector<uint8_t>& out, uint32_t value) {
   out.insert(out.end(), buf, buf + n_vals);
 }
 
-// Append an RLE run of `count` copies of `value` (1-bit values) to the encoded
-// `bytes` stream and to the `expected` decoded sequence.
+/// Append an RLE run of `count` copies of `value` (1-bit values) to the encoded
+/// `bytes` stream and to the `expected` decoded sequence.
 void AppendRleRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected, bool value,
                   rle_size_t count) {
   AppendLeb128(bytes, static_cast<uint32_t>(count) << 1);  // low bit 0 => RLE
@@ -312,8 +312,8 @@ void AppendRleRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected, bool
   expected.insert(expected.end(), count, value);
 }
 
-// Append a bit-packed run holding `packed.size()` groups of 8 (1-bit) values,
-// LSB first, to the encoded `bytes` stream and to the `expected` sequence.
+/// Append a bit-packed run holding `packed.size()` groups of 8 (1-bit) values,
+/// LSB first, to the encoded `bytes` stream and to the `expected` sequence.
 void AppendBitPackedRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected,
                         const std::vector<uint8_t>& packed) {
   const auto groups = static_cast<rle_size_t>(packed.size());
@@ -324,13 +324,13 @@ void AppendBitPackedRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected
   }
 }
 
-// Decode the whole `bytes` stream into a bitmap starting at bit offset
-// `out_offset`, in successive GetBatch calls of at most `chunk` values, and
-// compare against `expected`.
-//
-// Decoding in small, byte-unaligned chunks and (with a non-zero `out_offset`)
-// at a non-aligned output position exercises how the decoder threads its output
-// bit offset across runs that do not end on a byte boundary.
+/// Decode the whole `bytes` stream into a bitmap starting at bit offset
+/// `out_offset`, in successive GetBatch calls of at most `chunk` values, and
+/// compare against `expected`.
+///
+/// Decoding in small, byte-unaligned chunks and (with a non-zero `out_offset`)
+/// at a non-aligned output position exercises how the decoder threads its output
+/// bit offset across runs that do not end on a byte boundary.
 void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
                              const std::vector<bool>& expected, rle_size_t chunk,
                              rle_size_t out_offset = 0) {
@@ -375,7 +375,7 @@ void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
   }
 }
 
-// Run the decode check over a battery of chunk sizes and output offsets.
+/// Run the decode check over a battery of chunk sizes and output offsets.
 void CheckRleBitPackedToBitMap(const std::vector<uint8_t>& bytes,
                                const std::vector<bool>& expected) {
   const auto n = static_cast<rle_size_t>(expected.size());

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -329,6 +329,10 @@ struct BitPackedBitmapCase {
   rle_size_t count;
 };
 
+// Gtest representation without which, gtest falls back to dumping
+// the raw object bytes, which reads uninitialised padding and trips valgrind.
+void PrintTo(const BitPackedBitmapCase& param, std::ostream* os) { *os << param.name; }
+
 class BitPackedRunToBitmapDecoderTest
     : public ::testing::TestWithParam<BitPackedBitmapCase> {};
 

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -375,7 +375,7 @@ namespace {
 
 /// Append the LEB128 (unsigned, little-endian base-128) encoding of `value`.
 void AppendLeb128(std::vector<uint8_t>& out, uint32_t value) {
-  std::array<uint8_t, bit_util::kMaxLEB128ByteLenFor<uint32_t>> buf;
+  std::array<uint8_t, bit_util::kMaxLEB128ByteLenFor<uint32_t>> buf = {};
   const auto n_bytes =
       bit_util::WriteLEB128(value, buf.data(), static_cast<int32_t>(buf.size()));
   ASSERT_GT(n_bytes, 0);

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -36,9 +36,9 @@ namespace {
 std::vector<uint8_t> MakeRandomBytes(size_t size, uint32_t seed = 56) {
   std::vector<uint8_t> bytes(size);
   std::minstd_rand gen(seed);
-  std::uniform_int_distribution<uint8_t> dist(0, 255);
+  std::uniform_int_distribution<int> dist(0, 255);  // no standard support for uint8_t
   for (auto& byte : bytes) {
-    byte = dist(gen);
+    byte = static_cast<uint8_t>(dist(gen));
   }
   return bytes;
 }

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -315,7 +315,7 @@ TEST_P(RleRunToBitmapDecoderTest, Decode) {
 
 INSTANTIATE_TEST_SUITE_P(  //
     RleBitmap, RleRunToBitmapDecoderTest,
-    ::testing::Values(0, 1, 3, 8, 9, 13, 64, 100, 100, 1000));
+    ::testing::Values(0, 1, 3, 8, 9, 13, 64, 100, 177));
 
 /*********************************
  *  BitPackedRunToBitmapDecoder  *
@@ -454,7 +454,7 @@ void CheckRleBitPackedToBitmap(const std::vector<uint8_t>& bytes,
   ASSERT_GT(n_vals, 0);
   for (const rle_size_t chunk_size :
        {rle_size_t{1}, rle_size_t{3}, rle_size_t{7}, rle_size_t{8}, rle_size_t{9},
-        rle_size_t{33}, n_vals}) {
+        rle_size_t{33}, n_vals, n_vals + 1}) {
     CheckRleBitPackedDecode(bytes, expected, chunk_size);
     // A non-zero output offset forces the first run to start at a non-byte
     // aligned output position.

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -57,25 +57,27 @@ void CheckChunkedDecode(const typename Decoder::RunType& run,
                         const std::vector<bool>& expected, rle_size_t chunk,
                         rle_size_t skip = 0) {
   ARROW_SCOPED_TRACE("chunk = ", chunk, ", skip = ", skip);
-  const auto n = static_cast<rle_size_t>(expected.size());
-  ASSERT_LE(skip, n);
+  const auto n_vals = static_cast<rle_size_t>(expected.size());
+  ASSERT_LE(skip, n_vals);
 
   Decoder decoder(run);
   ASSERT_EQ(decoder.Advance(skip), skip);
-  const auto rest = n - skip;
+  const auto rest = n_vals - skip;
 
   // Output buffer with one guard byte to catch out-of-bounds writes.
   std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(rest)) + 1, 0);
   const uint8_t guard = 0xA5;
   out.back() = guard;
 
-  rle_size_t pos = 0;
-  while (pos < rest) {
-    const auto want = std::min(chunk, rest - pos);
-    const auto got = decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/pos), want);
-    EXPECT_EQ(got, want) << "at pos " << pos;
-    pos += got;
-    EXPECT_EQ(decoder.remaining(), rest - pos);
+  rle_size_t read = 0;
+  while (read < rest) {
+    const auto want = std::min(chunk, rest - read);
+    const auto got =
+        decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/read), want);
+    EXPECT_EQ(got, want) << "at pos " << read;
+    ASSERT_GT(got, 0) << "at pos " << read;  // break on failure
+    read += got;
+    EXPECT_EQ(decoder.remaining(), rest - read);
   }
 
   EXPECT_EQ(decoder.remaining(), 0);
@@ -90,15 +92,15 @@ void CheckChunkedDecode(const typename Decoder::RunType& run,
 template <typename Decoder>
 void CheckBitMapDecoder(const typename Decoder::RunType& run,
                         const std::vector<bool>& expected) {
-  const auto n = static_cast<rle_size_t>(expected.size());
+  const auto n_vals = static_cast<rle_size_t>(expected.size());
   // The sub-checks below (Advance, single Get, several chunk sizes) assume a
   // run with a handful of values to exercise.
-  ASSERT_GE(n, 9);
+  ASSERT_GE(n_vals, 9);
 
   // remaining() reflects the run size before any value is read.
   {
     Decoder decoder(run);
-    EXPECT_EQ(decoder.remaining(), n);
+    EXPECT_EQ(decoder.remaining(), n_vals);
   }
 
   // Empty requests are a no-op.
@@ -106,18 +108,18 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
     Decoder decoder(run);
     uint8_t out = 0;
     EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&out), /*batch_size=*/0), 0);
-    EXPECT_EQ(decoder.remaining(), n);
+    EXPECT_EQ(decoder.remaining(), n_vals);
   }
 
   // Decode the whole run with various chunk sizes: aligned (8), unaligned
   // (1, 3, 7, 9) and all-at-once.
-  for (const rle_size_t chunk :
-       {rle_size_t{1}, rle_size_t{3}, rle_size_t{7}, rle_size_t{8}, rle_size_t{9}, n}) {
+  for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
+                                 rle_size_t{8}, rle_size_t{9}, n_vals}) {
     CheckChunkedDecode<Decoder>(run, expected, chunk);
     // Same, but skipping the first 1..7 values first so the decoder's read
     // offset no longer matches the byte-aligned output (driving the
     // bit-unaligned path for decoders that have one).
-    for (rle_size_t skip = 1; skip < 8 && skip < n; ++skip) {
+    for (rle_size_t skip = 1; skip < 8 && skip < n_vals; ++skip) {
       CheckChunkedDecode<Decoder>(run, expected, chunk, skip);
     }
   }
@@ -125,16 +127,16 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
   // Get() one value at a time, then read past the end.
   {
     Decoder decoder(run);
-    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)) + 1, 0);
-    for (rle_size_t i = 0; i < n; ++i) {
+    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)) + 1, 0);
+    for (rle_size_t i = 0; i < n_vals; ++i) {
       EXPECT_TRUE(decoder.Get(BitmapSpanMut(out.data(), /*bit_start=*/i)));
-      EXPECT_EQ(decoder.remaining(), n - i - 1);
+      EXPECT_EQ(decoder.remaining(), n_vals - i - 1);
     }
     // Exhausted: nothing more can be read or advanced.
     EXPECT_FALSE(decoder.Get(BitmapSpanMut(out.data())));
     EXPECT_EQ(decoder.Advance(1), 0);
     EXPECT_EQ(decoder.remaining(), 0);
-    for (rle_size_t i = 0; i < n; ++i) {
+    for (rle_size_t i = 0; i < n_vals; ++i) {
       EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
     }
   }
@@ -145,18 +147,22 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
     Decoder decoder(run);
     const rle_size_t skip = 5;
     EXPECT_EQ(decoder.Advance(skip), skip);
-    EXPECT_EQ(decoder.remaining(), n - skip);
+    EXPECT_EQ(decoder.remaining(), n_vals - skip);
 
-    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)) + 1, 0);
-    rle_size_t pos = skip;
-    while (pos < n) {
+    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)) + 1, 0);
+    rle_size_t read = skip;
+    while (read < n_vals) {
       const auto got =
-          decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/pos), n - pos);
-      EXPECT_GT(got, 0);
-      pos += got;
+          decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/read), n_vals - read);
+      ASSERT_GT(got, 0);  // break on failure
+      read += got;
     }
     EXPECT_EQ(decoder.remaining(), 0);
-    for (rle_size_t i = skip; i < n; ++i) {
+    // Bits before the skipped position must be left untouched (still zero).
+    for (rle_size_t i = 0; i < skip; ++i) {
+      EXPECT_FALSE(bit_util::GetBit(out.data(), i)) << "clobbered bit " << i;
+    }
+    for (rle_size_t i = skip; i < n_vals; ++i) {
       EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
     }
   }
@@ -164,22 +170,22 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
   // Advancing more than available stops at the run boundary.
   {
     Decoder decoder(run);
-    EXPECT_EQ(decoder.Advance(n + 100), n);
+    EXPECT_EQ(decoder.Advance(n_vals + 100), n_vals);
     EXPECT_EQ(decoder.remaining(), 0);
   }
 
   // Reset() rewinds the decoder so the run can be decoded again.
   {
     Decoder decoder(run);
-    std::vector<uint8_t> scratch(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
-    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(scratch.data()), n), n);
+    std::vector<uint8_t> scratch(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
+    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(scratch.data()), n_vals), n_vals);
     EXPECT_EQ(decoder.remaining(), 0);
 
     decoder.Reset(run);
-    EXPECT_EQ(decoder.remaining(), n);
-    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
-    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n), n);
-    for (rle_size_t i = 0; i < n; ++i) {
+    EXPECT_EQ(decoder.remaining(), n_vals);
+    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
+    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n_vals), n_vals);
+    for (rle_size_t i = 0; i < n_vals; ++i) {
       EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
     }
   }
@@ -187,9 +193,9 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
 
 }  // namespace
 
-// ---------------------------------------------------------------------------
-// RleRunToBitMapDecoder
-// ---------------------------------------------------------------------------
+/***************************
+ *  RleRunToBitMapDecoder  *
+ ***************************/
 
 struct RleBitMapCase {
   // The repeated boolean value of the run.
@@ -232,9 +238,9 @@ INSTANTIATE_TEST_SUITE_P(RleBitmap, RleRunToBitMapDecoderTest,
                                   std::to_string(info.param.count);
                          });
 
-// ---------------------------------------------------------------------------
-// BitPackedRunToBitMapDecoder
-// ---------------------------------------------------------------------------
+/*********************************
+ *  BitPackedRunToBitMapDecoder  *
+ *********************************/
 
 struct BitPackedBitMapCase {
   std::string name;
@@ -281,5 +287,236 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<BitPackedBitMapCase>& info) {
       return info.param.name;
     });
+
+/*********************************
+ *  RleBitPackedToBitMapDecoder  *
+ *********************************/
+
+namespace {
+
+// Append the LEB128 (unsigned, little-endian base-128) encoding of `value`.
+void AppendLeb128(std::vector<uint8_t>& out, uint32_t value) {
+  uint8_t buf[bit_util::kMaxLEB128ByteLenFor<uint32_t>];
+  const auto n_vals =
+      bit_util::WriteLEB128(value, buf, static_cast<int32_t>(sizeof(buf)));
+  ASSERT_GT(n_vals, 0);
+  out.insert(out.end(), buf, buf + n_vals);
+}
+
+// Append an RLE run of `count` copies of `value` (1-bit values) to the encoded
+// `bytes` stream and to the `expected` decoded sequence.
+void AppendRleRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected, bool value,
+                  rle_size_t count) {
+  AppendLeb128(bytes, static_cast<uint32_t>(count) << 1);  // low bit 0 => RLE
+  bytes.push_back(value ? 1 : 0);
+  expected.insert(expected.end(), count, value);
+}
+
+// Append a bit-packed run holding `packed.size()` groups of 8 (1-bit) values,
+// LSB first, to the encoded `bytes` stream and to the `expected` sequence.
+void AppendBitPackedRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected,
+                        const std::vector<uint8_t>& packed) {
+  const auto groups = static_cast<rle_size_t>(packed.size());
+  AppendLeb128(bytes, (static_cast<uint32_t>(groups) << 1) | 1);  // low bit 1 => packed
+  bytes.insert(bytes.end(), packed.begin(), packed.end());
+  for (rle_size_t i = 0; i < groups * 8; ++i) {
+    expected.push_back(bit_util::GetBit(packed.data(), i));
+  }
+}
+
+// Decode the whole `bytes` stream into a bitmap starting at bit offset
+// `out_offset`, in successive GetBatch calls of at most `chunk` values, and
+// compare against `expected`.
+//
+// Decoding in small, byte-unaligned chunks and (with a non-zero `out_offset`)
+// at a non-aligned output position exercises how the decoder threads its output
+// bit offset across runs that do not end on a byte boundary.
+void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
+                             const std::vector<bool>& expected, rle_size_t chunk,
+                             rle_size_t out_offset = 0) {
+  ARROW_SCOPED_TRACE("chunk = ", chunk, ", out_offset = ", out_offset);
+  const auto n_vals = static_cast<rle_size_t>(expected.size());
+
+  RleBitPackedToBitMapDecoder decoder(bytes.data(),
+                                      static_cast<rle_size_t>(bytes.size()));
+  EXPECT_EQ(decoder.exhausted(), n_vals == 0);
+
+  // Output buffer with one guard byte to catch out-of-bounds writes.
+  std::vector<uint8_t> out(
+      static_cast<size_t>(bit_util::BytesForBits(out_offset + n_vals)) + 1, 0);
+  const uint8_t guard = 0xA5;
+  out.back() = guard;
+
+  rle_size_t read = 0;
+  while (read < n_vals) {
+    const auto want = std::min(chunk, n_vals - read);
+    const auto got = decoder.GetBatch(
+        BitmapSpanMut(out.data(), /*bit_start=*/out_offset + read), want);
+    EXPECT_EQ(got, want) << "at pos " << read;
+    ASSERT_GT(got, 0) << "at pos " << read;  // break on failure
+    read += got;
+  }
+
+  EXPECT_EQ(read, n_vals);
+  EXPECT_TRUE(decoder.exhausted());
+  // Reading past the end yields nothing and leaves the decoder exhausted.
+  uint8_t scratch = 0;
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&scratch), 8), 0);
+  EXPECT_TRUE(decoder.exhausted());
+
+  EXPECT_EQ(out.back(), guard) << "decoder wrote past the end of the output";
+  // Bits before the output offset must be left untouched (still zero).
+  for (rle_size_t i = 0; i < out_offset; ++i) {
+    EXPECT_FALSE(bit_util::GetBit(out.data(), i)) << "clobbered bit " << i;
+  }
+  for (rle_size_t i = 0; i < n_vals; ++i) {
+    EXPECT_EQ(bit_util::GetBit(out.data(), out_offset + i), expected[i])
+        << "at bit " << i;
+  }
+}
+
+// Run the decode check over a battery of chunk sizes and output offsets.
+void CheckRleBitPackedToBitMap(const std::vector<uint8_t>& bytes,
+                               const std::vector<bool>& expected) {
+  const auto n = static_cast<rle_size_t>(expected.size());
+  ASSERT_GT(n, 0);
+  for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
+                                 rle_size_t{8}, rle_size_t{9}, rle_size_t{33}, n}) {
+    CheckRleBitPackedDecode(bytes, expected, chunk);
+    // A non-zero output offset forces the first run to start at a non-byte
+    // aligned output position.
+    for (rle_size_t out_offset = 1; out_offset < 8; ++out_offset) {
+      CheckRleBitPackedDecode(bytes, expected, chunk, out_offset);
+    }
+  }
+}
+
+}  // namespace
+
+TEST(RleBitPackedToBitMapDecoder, Empty) {
+  // A default-constructed decoder is already exhausted.
+  RleBitPackedToBitMapDecoder decoder;
+  EXPECT_TRUE(decoder.exhausted());
+  uint8_t out = 0;
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&out), 8), 0);
+
+  // So is one reset on an empty buffer.
+  decoder.Reset(nullptr, 0);
+  EXPECT_TRUE(decoder.exhausted());
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&out), 8), 0);
+}
+
+TEST(RleBitPackedToBitMapDecoder, SingleRleZeros) {
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendRleRun(bytes, expected, /*value=*/false, /*count=*/100);
+  CheckRleBitPackedToBitMap(bytes, expected);
+}
+
+TEST(RleBitPackedToBitMapDecoder, SingleRleOnes) {
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendRleRun(bytes, expected, /*value=*/true, /*count=*/100);
+  CheckRleBitPackedToBitMap(bytes, expected);
+}
+
+TEST(RleBitPackedToBitMapDecoder, SingleBitPacked) {
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendBitPackedRun(bytes, expected, {0b10101010, 0b11001100, 0b11110000});
+  CheckRleBitPackedToBitMap(bytes, expected);
+}
+
+TEST(RleBitPackedToBitMapDecoder, MixedRunsAligned) {
+  // All runs end on a byte boundary, so each run starts byte-aligned in the
+  // output.
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendRleRun(bytes, expected, /*value=*/false, /*count=*/16);
+  AppendBitPackedRun(bytes, expected, {0b10101010, 0b01010101});
+  AppendRleRun(bytes, expected, /*value=*/true, /*count=*/64);
+  AppendBitPackedRun(bytes, expected, {0b00001111});
+  CheckRleBitPackedToBitMap(bytes, expected);
+}
+
+TEST(RleBitPackedToBitMapDecoder, MixedRunsUnaligned) {
+  // RLE runs with counts that are not multiples of 8 make each following run
+  // start at a non-byte-aligned output position.
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendRleRun(bytes, expected, /*value=*/true, /*count=*/13);
+  AppendBitPackedRun(bytes, expected, {0b01101001, 0b10010110});
+  AppendRleRun(bytes, expected, /*value=*/false, /*count=*/5);
+  AppendRleRun(bytes, expected, /*value=*/true, /*count=*/200);
+  AppendBitPackedRun(bytes, expected, {0b11110000});
+  AppendRleRun(bytes, expected, /*value=*/false, /*count=*/3);
+  AppendBitPackedRun(bytes, expected, {0b10110001, 0b00011101});
+  CheckRleBitPackedToBitMap(bytes, expected);
+}
+
+TEST(RleBitPackedToBitMapDecoder, ReadPastEnd) {
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendRleRun(bytes, expected, /*value=*/true, /*count=*/10);
+  AppendBitPackedRun(bytes, expected, {0b10110010});
+  const auto n = static_cast<rle_size_t>(expected.size());
+
+  RleBitPackedToBitMapDecoder decoder(bytes.data(),
+                                      static_cast<rle_size_t>(bytes.size()));
+  std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)) + 1, 0);
+  // Requesting more values than available produces only the available ones.
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n + 100), n);
+  EXPECT_TRUE(decoder.exhausted());
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), 10), 0);
+  for (rle_size_t i = 0; i < n; ++i) {
+    EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
+  }
+}
+
+TEST(RleBitPackedToBitMapDecoder, Reset) {
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendRleRun(bytes, expected, /*value=*/true, /*count=*/13);
+  AppendBitPackedRun(bytes, expected, {0b01101001, 0b10010110});
+  AppendRleRun(bytes, expected, /*value=*/false, /*count=*/20);
+  const auto n = static_cast<rle_size_t>(expected.size());
+  const auto size = static_cast<rle_size_t>(bytes.size());
+
+  RleBitPackedToBitMapDecoder decoder(bytes.data(), size);
+  std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n), n);
+  EXPECT_TRUE(decoder.exhausted());
+
+  // Reset rewinds the decoder so the same buffer decodes again.
+  decoder.Reset(bytes.data(), size);
+  EXPECT_FALSE(decoder.exhausted());
+  std::vector<uint8_t> out2(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out2.data()), n), n);
+  EXPECT_TRUE(decoder.exhausted());
+  for (rle_size_t i = 0; i < n; ++i) {
+    EXPECT_EQ(bit_util::GetBit(out2.data(), i), expected[i]) << "at bit " << i;
+  }
+}
+
+TEST(RleBitPackedToBitMapDecoder, Truncated) {
+  // GH-style malformed input: a bit-packed run declares more groups than the
+  // buffer holds. The decoder yields what it can and is not exhausted.
+  std::vector<uint8_t> bytes;
+  std::vector<bool> expected;
+  AppendRleRun(bytes, expected, /*value=*/true, /*count=*/10);
+  // Declare 4 groups (32 values) of bit-packed data but provide only 1 byte.
+  AppendLeb128(bytes, (4u << 1) | 1);
+  bytes.push_back(0b10101010);
+
+  RleBitPackedToBitMapDecoder decoder(bytes.data(),
+                                      static_cast<rle_size_t>(bytes.size()));
+  std::vector<uint8_t> out(16, 0);
+  // The RLE run decodes fully; the truncated bit-packed run cannot be parsed.
+  EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), 1000), 10);
+  EXPECT_FALSE(decoder.exhausted());
+  for (rle_size_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(bit_util::GetBit(out.data(), i), true) << "at bit " << i;
+  }
+}
 
 }  // namespace arrow::util

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -63,7 +63,7 @@ void CheckDecodedBits(const std::vector<uint8_t>& out, const std::vector<bool>& 
 ///
 /// `skip` shifts the decoder's read offset relative to the output offset.
 /// A non-zero `skip` makes the two differ, which exercises the bit-unaligned read
-/// path of BitPackedRunToBitMapDecoder. With `skip == 0` they stay in sync and
+/// path of BitPackedRunToBitmapDecoder. With `skip == 0` they stay in sync and
 /// only the aligned path runs.
 template <typename Decoder>
 void CheckChunkedDecode(const typename Decoder::RunType& run,
@@ -103,7 +103,7 @@ void CheckChunkedDecode(const typename Decoder::RunType& run,
 ///
 /// `expected` is the full sequence of booleans the run should decode to.
 template <typename Decoder>
-void CheckBitMapDecoder(const typename Decoder::RunType& run,
+void CheckBitmapDecoder(const typename Decoder::RunType& run,
                         const std::vector<bool>& expected) {
   const auto n_vals = static_cast<rle_size_t>(expected.size());
 
@@ -183,19 +183,19 @@ void CheckBitMapDecoder(const typename Decoder::RunType& run,
 }  // namespace
 
 /***************************
- *  RleRunToBitMapDecoder  *
+ *  RleRunToBitmapDecoder  *
  ***************************/
 
-struct RleBitMapCase {
+struct RleBitmapCase {
   // The repeated boolean value of the run.
   bool value;
   // The number of values in the run.
   rle_size_t count;
 };
 
-class RleRunToBitMapDecoderTest : public ::testing::TestWithParam<RleBitMapCase> {};
+class RleRunToBitmapDecoderTest : public ::testing::TestWithParam<RleBitmapCase> {};
 
-TEST_P(RleRunToBitMapDecoderTest, Decode) {
+TEST_P(RleRunToBitmapDecoderTest, Decode) {
   const auto& param = GetParam();
 
   // A boolean RLE run stores its value in a single (1-bit-wide) byte.
@@ -204,40 +204,40 @@ TEST_P(RleRunToBitMapDecoderTest, Decode) {
 
   // value() reports the repeated boolean.
   {
-    RleRunToBitMapDecoder decoder(run);
+    RleRunToBitmapDecoder decoder(run);
     EXPECT_EQ(decoder.value(), param.value);
   }
 
   const std::vector<bool> expected(param.count, param.value);
-  CheckBitMapDecoder<RleRunToBitMapDecoder>(run, expected);
+  CheckBitmapDecoder<RleRunToBitmapDecoder>(run, expected);
 }
 
 INSTANTIATE_TEST_SUITE_P(  //
-    RleBitmap, RleRunToBitMapDecoderTest,
+    RleBitmap, RleRunToBitmapDecoderTest,
     ::testing::Values(  //
-        RleBitMapCase{.value = false, .count = 0},
-        RleBitMapCase{.value = true, .count = 1},
-        RleBitMapCase{.value = false, .count = 3},
-        RleBitMapCase{.value = true, .count = 8},
-        RleBitMapCase{.value = false, .count = 9},
-        RleBitMapCase{.value = true, .count = 9},
-        RleBitMapCase{.value = false, .count = 13},
-        RleBitMapCase{.value = true, .count = 13},
-        RleBitMapCase{.value = false, .count = 64},
-        RleBitMapCase{.value = true, .count = 64},
-        RleBitMapCase{.value = false, .count = 100},
-        RleBitMapCase{.value = true, .count = 100},
-        RleBitMapCase{.value = true, .count = 1000}),
-    [](const ::testing::TestParamInfo<RleBitMapCase>& info) {
+        RleBitmapCase{.value = false, .count = 0},
+        RleBitmapCase{.value = true, .count = 1},
+        RleBitmapCase{.value = false, .count = 3},
+        RleBitmapCase{.value = true, .count = 8},
+        RleBitmapCase{.value = false, .count = 9},
+        RleBitmapCase{.value = true, .count = 9},
+        RleBitmapCase{.value = false, .count = 13},
+        RleBitmapCase{.value = true, .count = 13},
+        RleBitmapCase{.value = false, .count = 64},
+        RleBitmapCase{.value = true, .count = 64},
+        RleBitmapCase{.value = false, .count = 100},
+        RleBitmapCase{.value = true, .count = 100},
+        RleBitmapCase{.value = true, .count = 1000}),
+    [](const ::testing::TestParamInfo<RleBitmapCase>& info) {
       return std::string(info.param.value ? "true_" : "false_") +
              std::to_string(info.param.count);
     });
 
 /*********************************
- *  BitPackedRunToBitMapDecoder  *
+ *  BitPackedRunToBitmapDecoder  *
  *********************************/
 
-struct BitPackedBitMapCase {
+struct BitPackedBitmapCase {
   std::string name;
   // The raw bit-packed bytes (LSB first). Must hold at least `count` bits.
   std::vector<uint8_t> bytes;
@@ -245,10 +245,10 @@ struct BitPackedBitMapCase {
   rle_size_t count;
 };
 
-class BitPackedRunToBitMapDecoderTest
-    : public ::testing::TestWithParam<BitPackedBitMapCase> {};
+class BitPackedRunToBitmapDecoderTest
+    : public ::testing::TestWithParam<BitPackedBitmapCase> {};
 
-TEST_P(BitPackedRunToBitMapDecoderTest, Decode) {
+TEST_P(BitPackedRunToBitmapDecoderTest, Decode) {
   const auto& param = GetParam();
   ASSERT_GE(param.bytes.size(), static_cast<size_t>(bit_util::BytesForBits(param.count)));
 
@@ -256,35 +256,35 @@ TEST_P(BitPackedRunToBitMapDecoderTest, Decode) {
                                 /*max_read_bytes=*/-1);
 
   const std::vector<bool> expected = BitsFromBytes(param.bytes, param.count);
-  CheckBitMapDecoder<BitPackedRunToBitMapDecoder>(run, expected);
+  CheckBitmapDecoder<BitPackedRunToBitmapDecoder>(run, expected);
 }
 
 INSTANTIATE_TEST_SUITE_P(  //
-    RleBitmap, BitPackedRunToBitMapDecoderTest,
+    RleBitmap, BitPackedRunToBitmapDecoderTest,
     ::testing::Values(  //
-        BitPackedBitMapCase{.name = "empty", .bytes = {0b10110010}, .count = 0},
-        BitPackedBitMapCase{.name = "single", .bytes = {0b00000001}, .count = 1},
-        BitPackedBitMapCase{.name = "three", .bytes = {0b00000101}, .count = 3},
-        BitPackedBitMapCase{.name = "eight", .bytes = {0b11010010}, .count = 8},
-        BitPackedBitMapCase{
+        BitPackedBitmapCase{.name = "empty", .bytes = {0b10110010}, .count = 0},
+        BitPackedBitmapCase{.name = "single", .bytes = {0b00000001}, .count = 1},
+        BitPackedBitmapCase{.name = "three", .bytes = {0b00000101}, .count = 3},
+        BitPackedBitmapCase{.name = "eight", .bytes = {0b11010010}, .count = 8},
+        BitPackedBitmapCase{
             .name = "alternating", .bytes = {0b10101010, 0b10101010}, .count = 13},
-        BitPackedBitMapCase{.name = "all_zeros", .bytes = {0x00, 0x00}, .count = 16},
-        BitPackedBitMapCase{.name = "all_ones", .bytes = {0xFF, 0xFF}, .count = 16},
-        BitPackedBitMapCase{
+        BitPackedBitmapCase{.name = "all_zeros", .bytes = {0x00, 0x00}, .count = 16},
+        BitPackedBitmapCase{.name = "all_ones", .bytes = {0xFF, 0xFF}, .count = 16},
+        BitPackedBitmapCase{
             .name = "mixed", .bytes = {0b11001010, 0b00001111, 0b10110001}, .count = 24},
-        BitPackedBitMapCase{
+        BitPackedBitmapCase{
             .name = "unaligned_count", .bytes = {0b00110101, 0b11100100}, .count = 11},
-        BitPackedBitMapCase{
+        BitPackedBitmapCase{
             .name = "large",
             .bytes = std::vector<uint8_t>(16, 0b01101001),
             .count = 128,
         }),
-    [](const ::testing::TestParamInfo<BitPackedBitMapCase>& info) {
+    [](const ::testing::TestParamInfo<BitPackedBitmapCase>& info) {
       return info.param.name;
     });
 
 /*********************************
- *  RleBitPackedToBitMapDecoder  *
+ *  RleBitPackedToBitmapDecoder  *
  *********************************/
 
 namespace {
@@ -326,7 +326,7 @@ void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
   ARROW_SCOPED_TRACE("chunk = ", chunk, ", out_offset = ", out_offset);
   const auto n_vals = static_cast<rle_size_t>(expected.size());
 
-  RleBitPackedToBitMapDecoder decoder(bytes.data(),
+  RleBitPackedToBitmapDecoder decoder(bytes.data(),
                                       static_cast<rle_size_t>(bytes.size()));
   EXPECT_EQ(decoder.exhausted(), n_vals == 0);
 
@@ -359,7 +359,7 @@ void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
 }
 
 /// Run the decode check over a battery of chunk sizes and output offsets.
-void CheckRleBitPackedToBitMap(const std::vector<uint8_t>& bytes,
+void CheckRleBitPackedToBitmap(const std::vector<uint8_t>& bytes,
                                const std::vector<bool>& expected) {
   const auto n_vals = static_cast<rle_size_t>(expected.size());
   ASSERT_GT(n_vals, 0);
@@ -376,9 +376,9 @@ void CheckRleBitPackedToBitMap(const std::vector<uint8_t>& bytes,
 
 }  // namespace
 
-TEST(RleBitPackedToBitMapDecoder, Empty) {
+TEST(RleBitPackedToBitmapDecoder, Empty) {
   // A default-constructed decoder is already exhausted.
-  RleBitPackedToBitMapDecoder decoder;
+  RleBitPackedToBitmapDecoder decoder;
   EXPECT_TRUE(decoder.exhausted());
   uint8_t out = 0;
   auto got = decoder.GetBatch(BitmapSpanMut(&out), 8);
@@ -391,28 +391,28 @@ TEST(RleBitPackedToBitMapDecoder, Empty) {
   EXPECT_EQ(got, 0);
 }
 
-TEST(RleBitPackedToBitMapDecoder, SingleRleZeros) {
+TEST(RleBitPackedToBitmapDecoder, SingleRleZeros) {
   std::vector<uint8_t> bytes;
   std::vector<bool> expected;
   AppendRleRun(bytes, expected, /*value=*/false, /*count=*/100);
-  CheckRleBitPackedToBitMap(bytes, expected);
+  CheckRleBitPackedToBitmap(bytes, expected);
 }
 
-TEST(RleBitPackedToBitMapDecoder, SingleRleOnes) {
+TEST(RleBitPackedToBitmapDecoder, SingleRleOnes) {
   std::vector<uint8_t> bytes;
   std::vector<bool> expected;
   AppendRleRun(bytes, expected, /*value=*/true, /*count=*/100);
-  CheckRleBitPackedToBitMap(bytes, expected);
+  CheckRleBitPackedToBitmap(bytes, expected);
 }
 
-TEST(RleBitPackedToBitMapDecoder, SingleBitPacked) {
+TEST(RleBitPackedToBitmapDecoder, SingleBitPacked) {
   std::vector<uint8_t> bytes;
   std::vector<bool> expected;
   AppendBitPackedRun(bytes, expected, {0b10101010, 0b11001100, 0b11110000});
-  CheckRleBitPackedToBitMap(bytes, expected);
+  CheckRleBitPackedToBitmap(bytes, expected);
 }
 
-TEST(RleBitPackedToBitMapDecoder, MixedRunsAligned) {
+TEST(RleBitPackedToBitmapDecoder, MixedRunsAligned) {
   // All runs end on a byte boundary, so each run starts byte-aligned in the
   // output.
   std::vector<uint8_t> bytes;
@@ -421,10 +421,10 @@ TEST(RleBitPackedToBitMapDecoder, MixedRunsAligned) {
   AppendBitPackedRun(bytes, expected, {0b10101010, 0b01010101});
   AppendRleRun(bytes, expected, /*value=*/true, /*count=*/64);
   AppendBitPackedRun(bytes, expected, {0b00001111});
-  CheckRleBitPackedToBitMap(bytes, expected);
+  CheckRleBitPackedToBitmap(bytes, expected);
 }
 
-TEST(RleBitPackedToBitMapDecoder, MixedRunsUnaligned) {
+TEST(RleBitPackedToBitmapDecoder, MixedRunsUnaligned) {
   // RLE runs with counts that are not multiples of 8 make each following run
   // start at a non-byte-aligned output position.
   std::vector<uint8_t> bytes;
@@ -436,17 +436,17 @@ TEST(RleBitPackedToBitMapDecoder, MixedRunsUnaligned) {
   AppendBitPackedRun(bytes, expected, {0b11110000});
   AppendRleRun(bytes, expected, /*value=*/false, /*count=*/3);
   AppendBitPackedRun(bytes, expected, {0b10110001, 0b00011101});
-  CheckRleBitPackedToBitMap(bytes, expected);
+  CheckRleBitPackedToBitmap(bytes, expected);
 }
 
-TEST(RleBitPackedToBitMapDecoder, ReadPastEnd) {
+TEST(RleBitPackedToBitmapDecoder, ReadPastEnd) {
   std::vector<uint8_t> bytes;
   std::vector<bool> expected;
   AppendRleRun(bytes, expected, /*value=*/true, /*count=*/10);
   AppendBitPackedRun(bytes, expected, {0b10110010});
   const auto n_vals = static_cast<rle_size_t>(expected.size());
 
-  RleBitPackedToBitMapDecoder decoder(bytes.data(),
+  RleBitPackedToBitmapDecoder decoder(bytes.data(),
                                       static_cast<rle_size_t>(bytes.size()));
   std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n_vals)) + 1, 0);
   // Requesting more values than available produces only the available ones.
@@ -458,7 +458,7 @@ TEST(RleBitPackedToBitMapDecoder, ReadPastEnd) {
   CheckDecodedBits(out, expected, /*count=*/n_vals);
 }
 
-TEST(RleBitPackedToBitMapDecoder, Reset) {
+TEST(RleBitPackedToBitmapDecoder, Reset) {
   std::vector<uint8_t> bytes;
   std::vector<bool> expected;
   AppendRleRun(bytes, expected, /*value=*/true, /*count=*/13);
@@ -467,7 +467,7 @@ TEST(RleBitPackedToBitMapDecoder, Reset) {
   const auto n_vals = static_cast<rle_size_t>(expected.size());
   const auto data_size = static_cast<rle_size_t>(bytes.size());
 
-  RleBitPackedToBitMapDecoder decoder(bytes.data(), data_size);
+  RleBitPackedToBitmapDecoder decoder(bytes.data(), data_size);
   std::vector<uint8_t> out_1(static_cast<size_t>(bit_util::BytesForBits(n_vals)), 0);
   const auto got_1 = decoder.GetBatch(BitmapSpanMut(out_1.data()), n_vals);
   EXPECT_EQ(got_1, n_vals);
@@ -483,7 +483,7 @@ TEST(RleBitPackedToBitMapDecoder, Reset) {
   CheckDecodedBits(out_2, expected, /*count=*/n_vals);
 }
 
-TEST(RleBitPackedToBitMapDecoder, Truncated) {
+TEST(RleBitPackedToBitmapDecoder, Truncated) {
   // Malformed input: a bit-packed run declares more values than the buffer
   // holds. The decoder should return the values it can read and report that it
   // is not exhausted, rather than crash or read out of bounds.
@@ -495,7 +495,7 @@ TEST(RleBitPackedToBitMapDecoder, Truncated) {
   AppendLeb128(bytes, (4u << 1) | 1);
   bytes.push_back(0b10101010);
 
-  RleBitPackedToBitMapDecoder decoder(bytes.data(),
+  RleBitPackedToBitmapDecoder decoder(bytes.data(),
                                       static_cast<rle_size_t>(bytes.size()));
   std::vector<uint8_t> out(16, 0);
   // The RLE run decodes fully; the truncated bit-packed run cannot be parsed.

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -1,0 +1,285 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/rle_bitmap_internal.h"
+#include "arrow/util/rle_encoding_internal.h"
+
+namespace arrow::util {
+
+namespace {
+
+// Expand a list of bytes into the bit-packed (LSB-first) sequence of booleans
+// they encode, keeping only the first `count` bits.
+std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t count) {
+  std::vector<bool> bits(count);
+  for (rle_size_t i = 0; i < count; ++i) {
+    bits[i] = bit_util::GetBit(bytes.data(), i);
+  }
+  return bits;
+}
+
+// Skip the first `skip` values with Advance(), then decode the rest of the run
+// into a contiguous output bitmap, in successive calls of at most `chunk` values
+// each, and compare the result against `expected`.
+//
+// This drives both decoder types through their byte-aligned and bit-unaligned
+// code paths depending on `chunk`: as soon as `chunk` is not a multiple of 8,
+// later calls land on a non-zero output bit offset.
+//
+// A non-zero `skip` additionally desynchronizes the decoder's read offset from
+// the (byte-aligned) output offset, which exercises the bit-unaligned
+// (GetBatchMisaligned) path of BitPackedRunToBitMapDecoder. With `skip == 0` the
+// read and output offsets stay in lockstep and only the aligned path is used.
+template <typename Decoder>
+void CheckChunkedDecode(const typename Decoder::RunType& run,
+                        const std::vector<bool>& expected, rle_size_t chunk,
+                        rle_size_t skip = 0) {
+  ARROW_SCOPED_TRACE("chunk = ", chunk, ", skip = ", skip);
+  const auto n = static_cast<rle_size_t>(expected.size());
+  ASSERT_LE(skip, n);
+
+  Decoder decoder(run);
+  ASSERT_EQ(decoder.Advance(skip), skip);
+  const auto rest = n - skip;
+
+  // Output buffer with one guard byte to catch out-of-bounds writes.
+  std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(rest)) + 1, 0);
+  const uint8_t guard = 0xA5;
+  out.back() = guard;
+
+  rle_size_t pos = 0;
+  while (pos < rest) {
+    const auto want = std::min(chunk, rest - pos);
+    const auto got = decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/pos), want);
+    EXPECT_EQ(got, want) << "at pos " << pos;
+    pos += got;
+    EXPECT_EQ(decoder.remaining(), rest - pos);
+  }
+
+  EXPECT_EQ(decoder.remaining(), 0);
+  EXPECT_EQ(out.back(), guard) << "decoder wrote past the end of the output";
+  for (rle_size_t i = 0; i < rest; ++i) {
+    EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[skip + i]) << "at bit " << i;
+  }
+}
+
+// The full battery of checks shared by both decoder types. `expected` is the
+// full sequence of booleans the run is supposed to decode to.
+template <typename Decoder>
+void CheckBitMapDecoder(const typename Decoder::RunType& run,
+                        const std::vector<bool>& expected) {
+  const auto n = static_cast<rle_size_t>(expected.size());
+  // The sub-checks below (Advance, single Get, several chunk sizes) assume a
+  // run with a handful of values to exercise.
+  ASSERT_GE(n, 9);
+
+  // remaining() reflects the run size before any value is read.
+  {
+    Decoder decoder(run);
+    EXPECT_EQ(decoder.remaining(), n);
+  }
+
+  // Empty requests are a no-op.
+  {
+    Decoder decoder(run);
+    uint8_t out = 0;
+    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(&out), /*batch_size=*/0), 0);
+    EXPECT_EQ(decoder.remaining(), n);
+  }
+
+  // Decode the whole run with various chunk sizes: aligned (8), unaligned
+  // (1, 3, 7, 9) and all-at-once.
+  for (const rle_size_t chunk :
+       {rle_size_t{1}, rle_size_t{3}, rle_size_t{7}, rle_size_t{8}, rle_size_t{9}, n}) {
+    CheckChunkedDecode<Decoder>(run, expected, chunk);
+    // Same, but skipping the first 1..7 values first so the decoder's read
+    // offset no longer matches the byte-aligned output (driving the
+    // bit-unaligned path for decoders that have one).
+    for (rle_size_t skip = 1; skip < 8 && skip < n; ++skip) {
+      CheckChunkedDecode<Decoder>(run, expected, chunk, skip);
+    }
+  }
+
+  // Get() one value at a time, then read past the end.
+  {
+    Decoder decoder(run);
+    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)) + 1, 0);
+    for (rle_size_t i = 0; i < n; ++i) {
+      EXPECT_TRUE(decoder.Get(BitmapSpanMut(out.data(), /*bit_start=*/i)));
+      EXPECT_EQ(decoder.remaining(), n - i - 1);
+    }
+    // Exhausted: nothing more can be read or advanced.
+    EXPECT_FALSE(decoder.Get(BitmapSpanMut(out.data())));
+    EXPECT_EQ(decoder.Advance(1), 0);
+    EXPECT_EQ(decoder.remaining(), 0);
+    for (rle_size_t i = 0; i < n; ++i) {
+      EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
+    }
+  }
+
+  // Advance() skips values; the remainder still decodes correctly and
+  // contiguously from the skipped position.
+  {
+    Decoder decoder(run);
+    const rle_size_t skip = 5;
+    EXPECT_EQ(decoder.Advance(skip), skip);
+    EXPECT_EQ(decoder.remaining(), n - skip);
+
+    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)) + 1, 0);
+    rle_size_t pos = skip;
+    while (pos < n) {
+      const auto got =
+          decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/pos), n - pos);
+      EXPECT_GT(got, 0);
+      pos += got;
+    }
+    EXPECT_EQ(decoder.remaining(), 0);
+    for (rle_size_t i = skip; i < n; ++i) {
+      EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
+    }
+  }
+
+  // Advancing more than available stops at the run boundary.
+  {
+    Decoder decoder(run);
+    EXPECT_EQ(decoder.Advance(n + 100), n);
+    EXPECT_EQ(decoder.remaining(), 0);
+  }
+
+  // Reset() rewinds the decoder so the run can be decoded again.
+  {
+    Decoder decoder(run);
+    std::vector<uint8_t> scratch(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
+    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(scratch.data()), n), n);
+    EXPECT_EQ(decoder.remaining(), 0);
+
+    decoder.Reset(run);
+    EXPECT_EQ(decoder.remaining(), n);
+    std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(n)), 0);
+    EXPECT_EQ(decoder.GetBatch(BitmapSpanMut(out.data()), n), n);
+    for (rle_size_t i = 0; i < n; ++i) {
+      EXPECT_EQ(bit_util::GetBit(out.data(), i), expected[i]) << "at bit " << i;
+    }
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// RleRunToBitMapDecoder
+// ---------------------------------------------------------------------------
+
+struct RleBitMapCase {
+  // The repeated boolean value of the run.
+  bool value;
+  // The number of values in the run.
+  rle_size_t count;
+};
+
+class RleRunToBitMapDecoderTest : public ::testing::TestWithParam<RleBitMapCase> {};
+
+TEST_P(RleRunToBitMapDecoderTest, Decode) {
+  const auto& param = GetParam();
+
+  // A boolean RLE run stores its value in a single (1-bit-wide) byte.
+  const uint8_t data = param.value ? 1 : 0;
+  const auto run = RleRun(&data, param.count, /*value_bit_width=*/1);
+
+  // value() reports the repeated boolean.
+  {
+    RleRunToBitMapDecoder decoder(run);
+    EXPECT_EQ(decoder.value(), param.value);
+  }
+
+  const std::vector<bool> expected(param.count, param.value);
+  CheckBitMapDecoder<RleRunToBitMapDecoder>(run, expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(RleBitmap, RleRunToBitMapDecoderTest,
+                         ::testing::Values(RleBitMapCase{/*value=*/false, /*count=*/9},
+                                           RleBitMapCase{/*value=*/true, /*count=*/9},
+                                           RleBitMapCase{/*value=*/false, /*count=*/13},
+                                           RleBitMapCase{/*value=*/true, /*count=*/13},
+                                           RleBitMapCase{/*value=*/false, /*count=*/64},
+                                           RleBitMapCase{/*value=*/true, /*count=*/64},
+                                           RleBitMapCase{/*value=*/false, /*count=*/100},
+                                           RleBitMapCase{/*value=*/true, /*count=*/100},
+                                           RleBitMapCase{/*value=*/true, /*count=*/1000}),
+                         [](const ::testing::TestParamInfo<RleBitMapCase>& info) {
+                           return std::string(info.param.value ? "true_" : "false_") +
+                                  std::to_string(info.param.count);
+                         });
+
+// ---------------------------------------------------------------------------
+// BitPackedRunToBitMapDecoder
+// ---------------------------------------------------------------------------
+
+struct BitPackedBitMapCase {
+  std::string name;
+  // The raw bit-packed bytes (LSB first). Must hold at least `count` bits.
+  std::vector<uint8_t> bytes;
+  // The number of values in the run.
+  rle_size_t count;
+};
+
+class BitPackedRunToBitMapDecoderTest
+    : public ::testing::TestWithParam<BitPackedBitMapCase> {};
+
+TEST_P(BitPackedRunToBitMapDecoderTest, Decode) {
+  const auto& param = GetParam();
+  ASSERT_GE(param.bytes.size(), static_cast<size_t>(bit_util::BytesForBits(param.count)));
+
+  const auto run = BitPackedRun(param.bytes.data(), param.count, /*value_bit_width=*/1,
+                                /*max_read_bytes=*/-1);
+
+  const std::vector<bool> expected = BitsFromBytes(param.bytes, param.count);
+  CheckBitMapDecoder<BitPackedRunToBitMapDecoder>(run, expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RleBitmap, BitPackedRunToBitMapDecoderTest,
+    ::testing::Values(BitPackedBitMapCase{/*name=*/"alternating",
+                                          /*bytes=*/{0b10101010, 0b10101010},
+                                          /*count=*/13},
+                      BitPackedBitMapCase{/*name=*/"all_zeros",
+                                          /*bytes=*/{0x00, 0x00},
+                                          /*count=*/16},
+                      BitPackedBitMapCase{/*name=*/"all_ones",
+                                          /*bytes=*/{0xFF, 0xFF},
+                                          /*count=*/16},
+                      BitPackedBitMapCase{/*name=*/"mixed",
+                                          /*bytes=*/{0b11001010, 0b00001111, 0b10110001},
+                                          /*count=*/24},
+                      BitPackedBitMapCase{/*name=*/"unaligned_count",
+                                          /*bytes=*/{0b00110101, 0b11100100},
+                                          /*count=*/11},
+                      BitPackedBitMapCase{/*name=*/"large",
+                                          /*bytes=*/std::vector<uint8_t>(16, 0b01101001),
+                                          /*count=*/128}),
+    [](const ::testing::TestParamInfo<BitPackedBitMapCase>& info) {
+      return info.param.name;
+    });
+
+}  // namespace arrow::util

--- a/cpp/src/arrow/util/rle_bitmap_test.cc
+++ b/cpp/src/arrow/util/rle_bitmap_test.cc
@@ -41,42 +41,44 @@ std::vector<bool> BitsFromBytes(const std::vector<uint8_t>& bytes, rle_size_t co
 }
 
 /// Check the decoded output in `out` against `expected`.
-/// Bits `out[out_offset..out_offset + count]` must equal `expected[skip..skip + count]`.
-/// The `out_offset` bits before them must still be zero.
+/// Bits `out[out_offset..out_offset + count]` must equal
+/// `expected[expected_skip..expected_skip + count]`. The `out_offset` bits before them
+/// must still be zero.
 void CheckDecodedBits(const std::vector<uint8_t>& out, const std::vector<bool>& expected,
-                      rle_size_t count, rle_size_t out_offset = 0, rle_size_t skip = 0) {
-  ARROW_SCOPED_TRACE("out_offset = ", out_offset, ", skip = ", skip);
+                      rle_size_t count, rle_size_t out_offset = 0,
+                      rle_size_t expected_skip = 0) {
+  ARROW_SCOPED_TRACE("out_offset = ", out_offset, ", expected_skip = ", expected_skip);
   for (rle_size_t i = 0; i < out_offset; ++i) {
     EXPECT_FALSE(bit_util::GetBit(out.data(), i)) << "clobbered bit " << i;
   }
   for (rle_size_t i = 0; i < count; ++i) {
-    EXPECT_EQ(bit_util::GetBit(out.data(), out_offset + i), expected[skip + i])
+    EXPECT_EQ(bit_util::GetBit(out.data(), out_offset + i), expected[expected_skip + i])
         << "at bit " << i;
   }
 }
 
-/// Skip the first `skip` values with Advance(), then decode the rest of the run
-/// into one output bitmap, `chunk` values at a time. Compare against `expected`.
+/// Skip the first `expected_skip` values with Advance(), then decode the rest of the run
+/// into one output bitmap, `chunk_size` values at a time. Compare against `expected`.
 ///
-/// `chunk` controls output bit alignment. When `chunk` is not a multiple of 8,
+/// `chunk_size` controls output bit alignment. When `chunk_size` is not a multiple of 8,
 /// later calls start at a non-zero output bit offset.
 ///
-/// `skip` shifts the decoder's read offset relative to the output offset.
-/// A non-zero `skip` makes the two differ, which exercises the bit-unaligned read
-/// path of BitPackedRunToBitmapDecoder. With `skip == 0` they stay in sync and
-/// only the aligned path runs.
+/// `expected_skip` shifts the decoder's read offset relative to the output offset.
+/// A non-zero `expected_skip` makes the two differ, which exercises the bit-unaligned
+/// read path of BitPackedRunToBitmapDecoder. With `expected_skip == 0` they stay in sync
+/// and only the aligned path runs.
 template <typename Decoder>
 void CheckChunkedDecode(const typename Decoder::RunType& run,
-                        const std::vector<bool>& expected, rle_size_t chunk = 1,
-                        rle_size_t skip = 0) {
-  ARROW_SCOPED_TRACE("chunk = ", chunk, ", skip = ", skip);
+                        const std::vector<bool>& expected, rle_size_t chunk_size = 1,
+                        rle_size_t expected_skip = 0) {
+  ARROW_SCOPED_TRACE("chunk_size = ", chunk_size, ", expected_skip = ", expected_skip);
   const auto n_vals = static_cast<rle_size_t>(expected.size());
-  ASSERT_LE(skip, n_vals);
+  ASSERT_LE(expected_skip, n_vals);
 
   Decoder decoder(run);
-  const auto advanced = decoder.Advance(skip);
-  ASSERT_EQ(advanced, skip);
-  const auto rest = n_vals - skip;
+  const auto advanced = decoder.Advance(expected_skip);
+  ASSERT_EQ(advanced, expected_skip);
+  const auto rest = n_vals - expected_skip;
 
   // Output buffer with one guard byte to catch out-of-bounds writes.
   std::vector<uint8_t> out(static_cast<size_t>(bit_util::BytesForBits(rest)) + 1, 0);
@@ -85,7 +87,7 @@ void CheckChunkedDecode(const typename Decoder::RunType& run,
 
   rle_size_t read = 0;
   while (read < rest) {
-    const auto want = std::min(chunk, rest - read);
+    const auto want = std::min(chunk_size, rest - read);
     const auto got =
         decoder.GetBatch(BitmapSpanMut(out.data(), /*bit_start=*/read), want);
     EXPECT_EQ(got, want) << "at pos " << read;
@@ -96,7 +98,7 @@ void CheckChunkedDecode(const typename Decoder::RunType& run,
 
   EXPECT_EQ(decoder.remaining(), 0);
   EXPECT_EQ(out.back(), guard) << "decoder wrote past the end of the output";
-  CheckDecodedBits(out, expected, /*count=*/rest, /*out_offset=*/0, skip);
+  CheckDecodedBits(out, expected, /*count=*/rest, /*out_offset=*/0, expected_skip);
 }
 
 /// All the checks shared by both decoder types.
@@ -123,17 +125,18 @@ void CheckBitmapDecoder(const typename Decoder::RunType& run,
   }
 
   // Decode the whole run in several chunks.
-  for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
-                                 rle_size_t{8}, rle_size_t{9}, n_vals}) {
-    CheckChunkedDecode<Decoder>(run, expected, chunk);
+  for (const rle_size_t chunk_size : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
+                                      rle_size_t{8}, rle_size_t{9}, n_vals, n_vals + 1}) {
+    CheckChunkedDecode<Decoder>(run, expected, chunk_size);
   }
 
   // Decode the whole run in several chunks, after an initial Advance that shifts
   // the run and output bit alignment.
-  for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
-                                 rle_size_t{8}, rle_size_t{9}, n_vals}) {
-    for (rle_size_t skip = 1; skip < 8 && skip < n_vals; ++skip) {
-      CheckChunkedDecode<Decoder>(run, expected, chunk, skip);
+  for (const rle_size_t chunk_size : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
+                                      rle_size_t{8}, rle_size_t{9}, n_vals, n_vals + 1}) {
+    for (rle_size_t expected_skip = 1; expected_skip < 8 && expected_skip < n_vals;
+         ++expected_skip) {
+      CheckChunkedDecode<Decoder>(run, expected, chunk_size, expected_skip);
     }
   }
 
@@ -186,52 +189,31 @@ void CheckBitmapDecoder(const typename Decoder::RunType& run,
  *  RleRunToBitmapDecoder  *
  ***************************/
 
-struct RleBitmapCase {
-  // The repeated boolean value of the run.
-  bool value;
-  // The number of values in the run.
-  rle_size_t count;
-};
-
-class RleRunToBitmapDecoderTest : public ::testing::TestWithParam<RleBitmapCase> {};
+class RleRunToBitmapDecoderTest : public ::testing::TestWithParam<rle_size_t> {};
 
 TEST_P(RleRunToBitmapDecoderTest, Decode) {
-  const auto& param = GetParam();
+  const auto& count = GetParam();
 
-  // A boolean RLE run stores its value in a single (1-bit-wide) byte.
-  const uint8_t data = param.value ? 1 : 0;
-  const auto run = RleRun(&data, param.count, /*value_bit_width=*/1);
+  // Only two possible repeated value
+  for (bool value : {true, false}) {
+    ARROW_SCOPED_TRACE("value = ", value);
 
-  // value() reports the repeated boolean.
-  {
+    // A boolean RLE run stores its value in a single (1-bit-wide) byte.
+    const uint8_t data = value ? 1 : 0;
+    const auto run = RleRun(&data, count, /*value_bit_width=*/1);
+
+    // value() reports the repeated boolean.
     RleRunToBitmapDecoder decoder(run);
-    EXPECT_EQ(decoder.value(), param.value);
-  }
+    EXPECT_EQ(decoder.value(), value);
 
-  const std::vector<bool> expected(param.count, param.value);
-  CheckBitmapDecoder<RleRunToBitmapDecoder>(run, expected);
+    const std::vector<bool> expected(count, value);
+    CheckBitmapDecoder<RleRunToBitmapDecoder>(run, expected);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(  //
     RleBitmap, RleRunToBitmapDecoderTest,
-    ::testing::Values(  //
-        RleBitmapCase{.value = false, .count = 0},
-        RleBitmapCase{.value = true, .count = 1},
-        RleBitmapCase{.value = false, .count = 3},
-        RleBitmapCase{.value = true, .count = 8},
-        RleBitmapCase{.value = false, .count = 9},
-        RleBitmapCase{.value = true, .count = 9},
-        RleBitmapCase{.value = false, .count = 13},
-        RleBitmapCase{.value = true, .count = 13},
-        RleBitmapCase{.value = false, .count = 64},
-        RleBitmapCase{.value = true, .count = 64},
-        RleBitmapCase{.value = false, .count = 100},
-        RleBitmapCase{.value = true, .count = 100},
-        RleBitmapCase{.value = true, .count = 1000}),
-    [](const ::testing::TestParamInfo<RleBitmapCase>& info) {
-      return std::string(info.param.value ? "true_" : "false_") +
-             std::to_string(info.param.count);
-    });
+    ::testing::Values(0, 1, 3, 8, 9, 13, 64, 100, 100, 1000));
 
 /*********************************
  *  BitPackedRunToBitmapDecoder  *
@@ -317,13 +299,13 @@ void AppendBitPackedRun(std::vector<uint8_t>& bytes, std::vector<bool>& expected
 
 /// Decode the whole `bytes` into a bitmap and check it against `expected`.
 ///
-/// Decode `chunk` values per GetBatch call to check the decoder state between
+/// Decode `chunk_size` values per GetBatch call to check the decoder state between
 /// calls. The output starts at bit offset `out_offset`. A non-zero offset makes
 /// the output and the encoded `bytes` use different bit alignment.
 void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
-                             const std::vector<bool>& expected, rle_size_t chunk,
+                             const std::vector<bool>& expected, rle_size_t chunk_size,
                              rle_size_t out_offset = 0) {
-  ARROW_SCOPED_TRACE("chunk = ", chunk, ", out_offset = ", out_offset);
+  ARROW_SCOPED_TRACE("chunk_size = ", chunk_size, ", out_offset = ", out_offset);
   const auto n_vals = static_cast<rle_size_t>(expected.size());
 
   RleBitPackedToBitmapDecoder decoder(bytes.data(),
@@ -338,7 +320,7 @@ void CheckRleBitPackedDecode(const std::vector<uint8_t>& bytes,
 
   rle_size_t read = 0;
   while (read < n_vals) {
-    const auto want = std::min(chunk, n_vals - read);
+    const auto want = std::min(chunk_size, n_vals - read);
     const auto got = decoder.GetBatch(
         BitmapSpanMut(out.data(), /*bit_start=*/out_offset + read), want);
     EXPECT_EQ(got, want) << "at pos " << read;
@@ -363,13 +345,14 @@ void CheckRleBitPackedToBitmap(const std::vector<uint8_t>& bytes,
                                const std::vector<bool>& expected) {
   const auto n_vals = static_cast<rle_size_t>(expected.size());
   ASSERT_GT(n_vals, 0);
-  for (const rle_size_t chunk : {rle_size_t{1}, rle_size_t{3}, rle_size_t{7},
-                                 rle_size_t{8}, rle_size_t{9}, rle_size_t{33}, n_vals}) {
-    CheckRleBitPackedDecode(bytes, expected, chunk);
+  for (const rle_size_t chunk_size :
+       {rle_size_t{1}, rle_size_t{3}, rle_size_t{7}, rle_size_t{8}, rle_size_t{9},
+        rle_size_t{33}, n_vals}) {
+    CheckRleBitPackedDecode(bytes, expected, chunk_size);
     // A non-zero output offset forces the first run to start at a non-byte
     // aligned output position.
     for (rle_size_t out_offset = 1; out_offset < 8; ++out_offset) {
-      CheckRleBitPackedDecode(bytes, expected, chunk, out_offset);
+      CheckRleBitPackedDecode(bytes, expected, chunk_size, out_offset);
     }
   }
 }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -114,8 +114,11 @@ class RleRun {
     std::copy(data, data + raw_data_size(value_bit_width), data_.begin());
   }
 
-  /// The repeated value in the run
-  uint64_t value() const noexcept { return SafeLoadAs<uint64_t>(data_.data()); }
+  /// The repeated value in the run in little endian form (as stored in the buffer).
+  uint64_t value_little_endian() const noexcept {
+    // Underlying memcpy is required to avoid undefined behavior.
+    return SafeLoadAs<uint64_t>(data_.data());
+  }
 
   /// The number of repeated values in this run.
   constexpr rle_size_t values_count() const noexcept { return values_count_; }
@@ -278,10 +281,8 @@ class RleRunDecoder {
       // if the bool value isn't 0 or 1.
       value_ = *run.raw_data_ptr() & 1;
     } else {
-      // Memcopy is required to avoid undefined behavior.
-      value_ = {};
-      std::memcpy(&value_, run.raw_data_ptr(), run.raw_data_size(value_bit_width));
-      value_ = ::arrow::bit_util::FromLittleEndian(value_);
+      value_ = static_cast<value_type>(
+          ::arrow::bit_util::FromLittleEndian(run.value_little_endian()));
     }
   }
 

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -791,6 +791,10 @@ auto RleBitPackedDecoder<T>::GetBatch(value_type* out,
                                       rle_size_t batch_size) -> rle_size_t {
   using ControlFlow = RleBitPackedParser::ControlFlow;
 
+  if (ARROW_PREDICT_FALSE(batch_size == 0 || exhausted())) {
+    return 0;
+  }
+
   rle_size_t values_read = 0;
 
   // Remaining from a previous call that would have left some unread data from a run.

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <limits>
 #include <type_traits>
 #include <variant>
@@ -32,6 +33,7 @@
 #include "arrow/util/bpacking_internal.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/ubsan.h"
 
 namespace arrow::util {
 
@@ -116,6 +118,9 @@ class RleRun {
     std::copy(data, data + raw_data_size(value_bit_width), data_.begin());
   }
 
+  /// The repeated value in the run
+  uint64_t value() const noexcept { return SafeLoadAs<uint64_t>(data_.data()); }
+
   /// The number of repeated values in this run.
   constexpr rle_size_t values_count() const noexcept { return values_count_; }
 
@@ -132,7 +137,7 @@ class RleRun {
  private:
   /// The repeated value raw bytes stored inside the class with enough space to store
   /// up to a 64 bit value.
-  std::array<uint8_t, 8> data_ = {};
+  alignas(8) std::array<uint8_t, 8> data_ = {};
   /// The number of time the value is repeated.
   rle_size_t values_count_ = 0;
 };

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -490,20 +490,6 @@ class RleBitPackedDecoder {
       rle_size_t null_count, const uint8_t* valid_bits, int64_t valid_bits_offset);
 
  private:
-  /// Utility to map a run type to the associate decoder.
-  template <typename Run>
-  struct get_decoder;
-  template <>
-  struct get_decoder<RleRun> {
-    using type = RleRunDecoder<value_type>;
-  };
-  template <>
-  struct get_decoder<BitPackedRun> {
-    using type = BitPackedRunDecoder<value_type>;
-  };
-  template <typename Run>
-  using get_decoder_t = get_decoder<Run>::type;
-
   RleBitPackedParser parser_ = {};
   std::variant<RleRunDecoder<value_type>, BitPackedRunDecoder<value_type>> decoder_ = {};
   rle_size_t value_bit_width_;
@@ -780,6 +766,20 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
  *  RleBitPackedDecoder  *
  *************************/
 
+/// Utility to map a run type to the associate decoder.
+template <typename T, typename Run>
+struct RleBitPackedDecoderGetRunDecoder;
+
+template <typename T>
+struct RleBitPackedDecoderGetRunDecoder<T, RleRun> {
+  using type = RleRunDecoder<T>;
+};
+
+template <typename T>
+struct RleBitPackedDecoderGetRunDecoder<T, BitPackedRun> {
+  using type = BitPackedRunDecoder<T>;
+};
+
 template <typename T>
 bool RleBitPackedDecoder<T>::Get(value_type* val) {
   return GetBatch(val, 1) == 1;
@@ -806,7 +806,7 @@ auto RleBitPackedDecoder<T>::GetBatch(value_type* out,
   }
 
   parser_.ParseWithCallable([&](auto run) {
-    using RunDecoder = get_decoder_t<decltype(run)>;
+    using RunDecoder = RleBitPackedDecoderGetRunDecoder<value_type, decltype(run)>::type;
 
     ARROW_DCHECK_LT(values_read, batch_size);
     RunDecoder decoder(run, value_bit_width_);
@@ -1119,7 +1119,7 @@ auto RleBitPackedDecoder<T>::GetSpaced(Converter converter,
   }
 
   parser_.ParseWithCallable([&](auto run) {
-    using RunDecoder = get_decoder_t<decltype(run)>;
+    using RunDecoder = RleBitPackedDecoderGetRunDecoder<value_type, decltype(run)>::type;
 
     RunDecoder decoder(run, value_bit_width_);
 
@@ -1301,7 +1301,7 @@ auto RleBitPackedDecoder<T>::GetBatchWithDict(const V* dictionary,
   }
 
   parser_.ParseWithCallable([&](auto run) {
-    using RunDecoder = get_decoder_t<decltype(run)>;
+    using RunDecoder = RleBitPackedDecoderGetRunDecoder<value_type, decltype(run)>::type;
 
     RunDecoder decoder(run, value_bit_width_);
 

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -104,10 +104,6 @@ class RleRunDecoder;
 /// 10 % on some benchmarks.
 class RleRun {
  public:
-  /// The decoder class used to decode a single run in the given type.
-  template <typename T>
-  using DecoderType = RleRunDecoder<T>;
-
   constexpr RleRun() noexcept = default;
 
   explicit RleRun(const uint8_t* data, rle_size_t values_count,
@@ -155,10 +151,6 @@ class BitPackedRunDecoder;
 /// 10 % on some benchmarks.
 class BitPackedRun {
  public:
-  /// The decoder class used to decode a single run in the given type.
-  template <typename T>
-  using DecoderType = BitPackedRunDecoder<T>;
-
   constexpr BitPackedRun() noexcept = default;
 
   constexpr BitPackedRun(const uint8_t* data, rle_size_t values_count,
@@ -244,6 +236,10 @@ class RleBitPackedParser {
   /// ```
   template <typename Handler>
   void Parse(Handler&& handler);
+
+  /// Call the parser with a single callable for all event types.
+  template <typename Callable>
+  void ParseWithCallable(Callable&& func);
 
  private:
   /// The pointer to the beginning of the run
@@ -494,6 +490,20 @@ class RleBitPackedDecoder {
       rle_size_t null_count, const uint8_t* valid_bits, int64_t valid_bits_offset);
 
  private:
+  /// Utility to map a run type to the associate decoder.
+  template <typename Run>
+  struct get_decoder;
+  template <>
+  struct get_decoder<RleRun> {
+    using type = RleRunDecoder<value_type>;
+  };
+  template <>
+  struct get_decoder<BitPackedRun> {
+    using type = BitPackedRunDecoder<value_type>;
+  };
+  template <typename Run>
+  using get_decoder_t = get_decoder<Run>::type;
+
   RleBitPackedParser parser_ = {};
   std::variant<RleRunDecoder<value_type>, BitPackedRunDecoder<value_type>> decoder_ = {};
   rle_size_t value_bit_width_;
@@ -509,10 +519,6 @@ class RleBitPackedDecoder {
         [&](auto& dec) { return dec.GetBatch(out, batch_size, value_bit_width_); },
         decoder_);
   }
-
-  /// Call the parser with a single callable for all event types.
-  template <typename Callable>
-  void ParseWithCallable(Callable&& func);
 
   /// Utility methods for retrieving spaced values.
   template <typename Converter>
@@ -675,6 +681,17 @@ void RleBitPackedParser::Parse(Handler&& handler) {
   }
 }
 
+template <typename Callable>
+void RleBitPackedParser::ParseWithCallable(Callable&& func) {
+  struct {
+    Callable func;
+    auto OnBitPackedRun(BitPackedRun run) { return func(std::move(run)); }
+    auto OnRleRun(RleRun run) { return func(std::move(run)); }
+  } handler{std::move(func)};
+
+  return Parse(std::move(handler));
+}
+
 namespace internal {
 /// The maximal unsigned size that a variable can fit.
 template <typename T>
@@ -764,18 +781,6 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
  *************************/
 
 template <typename T>
-template <typename Callable>
-void RleBitPackedDecoder<T>::ParseWithCallable(Callable&& func) {
-  struct {
-    Callable func;
-    auto OnBitPackedRun(BitPackedRun run) { return func(std::move(run)); }
-    auto OnRleRun(RleRun run) { return func(std::move(run)); }
-  } handler{std::move(func)};
-
-  parser_.Parse(std::move(handler));
-}
-
-template <typename T>
 bool RleBitPackedDecoder<T>::Get(value_type* val) {
   return GetBatch(val, 1) == 1;
 }
@@ -800,8 +805,8 @@ auto RleBitPackedDecoder<T>::GetBatch(value_type* out,
     ARROW_DCHECK(run_remaining() == 0);
   }
 
-  ParseWithCallable([&](auto run) {
-    using RunDecoder = typename decltype(run)::template DecoderType<value_type>;
+  parser_.ParseWithCallable([&](auto run) {
+    using RunDecoder = get_decoder_t<decltype(run)>;
 
     ARROW_DCHECK_LT(values_read, batch_size);
     RunDecoder decoder(run, value_bit_width_);
@@ -1113,8 +1118,8 @@ auto RleBitPackedDecoder<T>::GetSpaced(Converter converter,
     ARROW_DCHECK(run_remaining() == 0);
   }
 
-  ParseWithCallable([&](auto run) {
-    using RunDecoder = typename decltype(run)::template DecoderType<value_type>;
+  parser_.ParseWithCallable([&](auto run) {
+    using RunDecoder = get_decoder_t<decltype(run)>;
 
     RunDecoder decoder(run, value_bit_width_);
 
@@ -1295,8 +1300,8 @@ auto RleBitPackedDecoder<T>::GetBatchWithDict(const V* dictionary,
     ARROW_DCHECK(run_remaining() == 0);
   }
 
-  ParseWithCallable([&](auto run) {
-    using RunDecoder = typename decltype(run)::template DecoderType<value_type>;
+  parser_.ParseWithCallable([&](auto run) {
+    using RunDecoder = get_decoder_t<decltype(run)>;
 
     RunDecoder decoder(run, value_bit_width_);
 


### PR DESCRIPTION
### Rationale for this change
Add a `RleBitPackedToBitmapDecoder` capable of decoding a Parquet mixed Rle / BitPacked byte stream directly into a bitmap. This is an optimization to be used when target and source bit_width = 1 that will improve decoding nullable columns in a  follow-up PR.

### What changes are included in this PR?
New classes, that reuse previous Runs and parser.
Their API is slighly different from the existing one as it fits a partilcular case.
  - `RleRunToBitmapDecoder`
  - `BitPackedRunToBitmapDecoder`
  - `RleRunToBitmapDecoder`

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.

* GitHub Issue: #50216