### PR TITLE
GH-50219: [R] Fix duckdb test for dbplyr 2.6.0

### DIFF
--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -123,6 +123,10 @@ test_that("to_duckdb then to_arrow", {
   )
 
   # Now check errors
+  # dbplyr 2.6.0 added "con" to the allowed $ fields on tbl_lazy;
+  # older versions only allow "src" and "lazy_query"
+  skip_if(packageVersion("dbplyr") < "2.6.0")
+
   ds_rt <- ds |>
     to_duckdb() |>
     # factors don't roundtrip https://github.com/duckdb/duckdb/issues/1879

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -129,7 +129,7 @@ test_that("to_duckdb then to_arrow", {
     select(-fct)
 
   # alter the class of ds_rt's connection to simulate some other database
-  class(ds_rt$src$con) <- "some_other_connection"
+  class(ds_rt$con) <- "some_other_connection"
 
   expect_error(
     to_arrow(ds_rt),


### PR DESCRIPTION
### Rationale for this change

dbplyr 2.6.0 changed `remote_con()` to read from `x$con` instead of `x$src$con`. The duckdb test that simulates a non-DuckDB connection was overriding the old path, so the expected error was no longer thrown.

### What changes are included in this PR?

Update the test to override `ds_rt$con` instead of `ds_rt$src$con`.

### Are these changes tested?

This is a test fix — the test itself verifies the behavior.

### Are there any user-facing changes?

No.
* GitHub Issue: #50219