### PR TITLE
GH-45948: [C++][Parquet] Variant shredding

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -393,6 +393,7 @@ set(ARROW_SRCS
     extension/parquet_variant.cc
     extension/variant.cc
     extension/variant_builder.cc
+    extension/variant_shredding.cc
     extension/uuid.cc
     pretty_print.cc
     record_batch.cc

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -392,6 +392,7 @@ set(ARROW_SRCS
     extension/json.cc
     extension/parquet_variant.cc
     extension/variant.cc
+    extension/variant_builder.cc
     extension/uuid.cc
     pretty_print.cc
     record_batch.cc

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -391,6 +391,7 @@ set(ARROW_SRCS
     extension/bool8.cc
     extension/json.cc
     extension/parquet_variant.cc
+    extension/variant.cc
     extension/uuid.cc
     pretty_print.cc
     record_batch.cc

--- a/cpp/src/arrow/extension/CMakeLists.txt
+++ b/cpp/src/arrow/extension/CMakeLists.txt
@@ -16,7 +16,8 @@
 # under the License.
 
 set(CANONICAL_EXTENSION_TESTS bool8_test.cc json_test.cc uuid_test.cc
-                              variant_test.cc variant_builder_test.cc)
+                              variant_test.cc variant_builder_test.cc
+                              variant_shredding_test.cc)
 
 if(ARROW_JSON)
   list(APPEND CANONICAL_EXTENSION_TESTS tensor_extension_array_test.cc opaque_test.cc)

--- a/cpp/src/arrow/extension/CMakeLists.txt
+++ b/cpp/src/arrow/extension/CMakeLists.txt
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set(CANONICAL_EXTENSION_TESTS bool8_test.cc json_test.cc uuid_test.cc)
+set(CANONICAL_EXTENSION_TESTS bool8_test.cc json_test.cc uuid_test.cc
+                              variant_test.cc)
 
 if(ARROW_JSON)
   list(APPEND CANONICAL_EXTENSION_TESTS tensor_extension_array_test.cc opaque_test.cc)

--- a/cpp/src/arrow/extension/CMakeLists.txt
+++ b/cpp/src/arrow/extension/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 set(CANONICAL_EXTENSION_TESTS bool8_test.cc json_test.cc uuid_test.cc
-                              variant_test.cc)
+                              variant_test.cc variant_builder_test.cc)
 
 if(ARROW_JSON)
   list(APPEND CANONICAL_EXTENSION_TESTS tensor_extension_array_test.cc opaque_test.cc)

--- a/cpp/src/arrow/extension/meson.build
+++ b/cpp/src/arrow/extension/meson.build
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-canonical_extension_tests = ['bool8_test.cc', 'json_test.cc', 'uuid_test.cc', 'variant_test.cc']
+canonical_extension_tests = ['bool8_test.cc', 'json_test.cc', 'uuid_test.cc', 'variant_test.cc', 'variant_builder_test.cc']
 
 if needs_json
     canonical_extension_tests += [

--- a/cpp/src/arrow/extension/meson.build
+++ b/cpp/src/arrow/extension/meson.build
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-canonical_extension_tests = ['bool8_test.cc', 'json_test.cc', 'uuid_test.cc', 'variant_test.cc', 'variant_builder_test.cc']
+canonical_extension_tests = ['bool8_test.cc', 'json_test.cc', 'uuid_test.cc', 'variant_test.cc', 'variant_builder_test.cc', 'variant_shredding_test.cc']
 
 if needs_json
     canonical_extension_tests += [
@@ -41,5 +41,6 @@ install_headers(
         'uuid.h',
         'variable_shape_tensor.h',
         'variant.h',
+        'variant_shredding.h',
     ],
 )

--- a/cpp/src/arrow/extension/meson.build
+++ b/cpp/src/arrow/extension/meson.build
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-canonical_extension_tests = ['bool8_test.cc', 'json_test.cc', 'uuid_test.cc']
+canonical_extension_tests = ['bool8_test.cc', 'json_test.cc', 'uuid_test.cc', 'variant_test.cc']
 
 if needs_json
     canonical_extension_tests += [
@@ -40,5 +40,6 @@ install_headers(
         'parquet_variant.h',
         'uuid.h',
         'variable_shape_tensor.h',
+        'variant.h',
     ],
 )

--- a/cpp/src/arrow/extension/parquet_variant.h
+++ b/cpp/src/arrow/extension/parquet_variant.h
@@ -70,7 +70,10 @@ class ARROW_EXPORT VariantExtensionType : public ExtensionType {
   std::shared_ptr<Field> value() const { return value_; }
 
  private:
-  // TODO GH-45948 added shredded_value
+  // TODO: Track shredded_value field when integrating with Parquet reader.
+  // The shredding implementation (variant_shredding.h) operates on raw arrays
+  // externally; a future PR may extend VariantExtensionType to understand
+  // shredded storage layouts for seamless Parquet I/O integration.
   std::shared_ptr<Field> metadata_;
   std::shared_ptr<Field> value_;
 };

--- a/cpp/src/arrow/extension/variant.cc
+++ b/cpp/src/arrow/extension/variant.cc
@@ -281,48 +281,50 @@ Status VisitObject(const VariantMetadata& metadata, const uint8_t* data, int64_t
     return Status::Invalid("Variant value: truncated object num_fields at offset ",
                            offset);
   }
-  auto num_fields = static_cast<int32_t>(ReadUnsignedLE(data + pos, num_fields_size));
+  auto num_fields = static_cast<int64_t>(ReadUnsignedLE(data + pos, num_fields_size));
   pos += num_fields_size;
 
-  int64_t field_ids_size = static_cast<int64_t>(num_fields) * field_id_size;
+  int64_t field_ids_size = num_fields * field_id_size;
   if (pos + field_ids_size > length) {
     return Status::Invalid("Variant value: truncated object field_ids at offset ",
                            offset);
   }
-  std::vector<uint32_t> field_ids(num_fields);
-  for (int32_t i = 0; i < num_fields; ++i) {
-    field_ids[i] = ReadUnsignedLE(data + pos, field_id_size);
+  std::vector<uint32_t> field_ids(static_cast<size_t>(num_fields));
+  for (int64_t i = 0; i < num_fields; ++i) {
+    field_ids[static_cast<size_t>(i)] = ReadUnsignedLE(data + pos, field_id_size);
     pos += field_id_size;
   }
 
-  int64_t offsets_size = (static_cast<int64_t>(num_fields) + 1) * field_offset_size;
+  int64_t offsets_size = (num_fields + 1) * field_offset_size;
   if (pos + offsets_size > length) {
     return Status::Invalid("Variant value: truncated object offsets at offset ", offset);
   }
-  std::vector<uint32_t> value_offsets(num_fields + 1);
-  for (int32_t i = 0; i <= num_fields; ++i) {
-    value_offsets[i] = ReadUnsignedLE(data + pos, field_offset_size);
+  std::vector<uint32_t> value_offsets(static_cast<size_t>(num_fields + 1));
+  for (int64_t i = 0; i <= num_fields; ++i) {
+    value_offsets[static_cast<size_t>(i)] = ReadUnsignedLE(data + pos, field_offset_size);
     pos += field_offset_size;
   }
 
   int64_t data_start = pos;
-  int64_t total_data_size = static_cast<int64_t>(value_offsets[num_fields]);
+  int64_t total_data_size =
+      static_cast<int64_t>(value_offsets[static_cast<size_t>(num_fields)]);
   if (data_start + total_data_size > length) {
     return Status::Invalid("Variant value: object data exceeds buffer at offset ",
                            offset);
   }
 
-  for (int32_t i = 0; i < num_fields; ++i) {
-    if (value_offsets[i] > static_cast<uint32_t>(total_data_size)) {
-      return Status::Invalid("Variant value: object field offset ", value_offsets[i],
-                             " at index ", i, " exceeds data size ", total_data_size);
+  for (int64_t i = 0; i < num_fields; ++i) {
+    if (value_offsets[static_cast<size_t>(i)] > static_cast<uint32_t>(total_data_size)) {
+      return Status::Invalid("Variant value: object field offset ",
+                             value_offsets[static_cast<size_t>(i)], " at index ", i,
+                             " exceeds data size ", total_data_size);
     }
   }
 
-  ARROW_RETURN_NOT_OK(visitor->StartObject(num_fields));
+  ARROW_RETURN_NOT_OK(visitor->StartObject(static_cast<int32_t>(num_fields)));
 
-  for (int32_t i = 0; i < num_fields; ++i) {
-    auto field_id = field_ids[i];
+  for (int64_t i = 0; i < num_fields; ++i) {
+    auto field_id = field_ids[static_cast<size_t>(i)];
     if (field_id >= metadata.strings.size()) {
       return Status::Invalid("Variant value: field_id ", field_id,
                              " exceeds metadata dictionary size ",
@@ -330,7 +332,7 @@ Status VisitObject(const VariantMetadata& metadata, const uint8_t* data, int64_t
     }
     ARROW_RETURN_NOT_OK(visitor->FieldName(metadata.strings[field_id]));
 
-    int64_t field_offset = data_start + value_offsets[i];
+    int64_t field_offset = data_start + value_offsets[static_cast<size_t>(i)];
     int64_t consumed = 0;
     ARROW_RETURN_NOT_OK(VisitValueAt(metadata, data, data_start + total_data_size,
                                      field_offset, visitor, &consumed, depth));
@@ -354,21 +356,22 @@ Status VisitArray(const VariantMetadata& metadata, const uint8_t* data, int64_t 
     return Status::Invalid("Variant value: truncated array num_elements at offset ",
                            offset);
   }
-  auto num_elements = static_cast<int32_t>(ReadUnsignedLE(data + pos, num_elements_size));
+  auto num_elements = static_cast<int64_t>(ReadUnsignedLE(data + pos, num_elements_size));
   pos += num_elements_size;
 
-  int64_t offsets_size = (static_cast<int64_t>(num_elements) + 1) * field_offset_size;
+  int64_t offsets_size = (num_elements + 1) * field_offset_size;
   if (pos + offsets_size > length) {
     return Status::Invalid("Variant value: truncated array offsets at offset ", offset);
   }
-  std::vector<uint32_t> value_offsets(num_elements + 1);
-  for (int32_t i = 0; i <= num_elements; ++i) {
-    value_offsets[i] = ReadUnsignedLE(data + pos, field_offset_size);
+  std::vector<uint32_t> value_offsets(static_cast<size_t>(num_elements + 1));
+  for (int64_t i = 0; i <= num_elements; ++i) {
+    value_offsets[static_cast<size_t>(i)] = ReadUnsignedLE(data + pos, field_offset_size);
     pos += field_offset_size;
   }
 
-  for (int32_t i = 1; i <= num_elements; ++i) {
-    if (value_offsets[i] < value_offsets[i - 1]) {
+  for (int64_t i = 1; i <= num_elements; ++i) {
+    if (value_offsets[static_cast<size_t>(i)] <
+        value_offsets[static_cast<size_t>(i - 1)]) {
       return Status::Invalid(
           "Variant value: array value offsets are not monotonically "
           "non-decreasing at index ",
@@ -377,15 +380,16 @@ Status VisitArray(const VariantMetadata& metadata, const uint8_t* data, int64_t 
   }
 
   int64_t data_start = pos;
-  int64_t total_data_size = static_cast<int64_t>(value_offsets[num_elements]);
+  int64_t total_data_size =
+      static_cast<int64_t>(value_offsets[static_cast<size_t>(num_elements)]);
   if (data_start + total_data_size > length) {
     return Status::Invalid("Variant value: array data exceeds buffer at offset ", offset);
   }
 
-  ARROW_RETURN_NOT_OK(visitor->StartArray(num_elements));
+  ARROW_RETURN_NOT_OK(visitor->StartArray(static_cast<int32_t>(num_elements)));
 
-  for (int32_t i = 0; i < num_elements; ++i) {
-    int64_t elem_offset = data_start + value_offsets[i];
+  for (int64_t i = 0; i < num_elements; ++i) {
+    int64_t elem_offset = data_start + value_offsets[static_cast<size_t>(i)];
     int64_t consumed = 0;
     ARROW_RETURN_NOT_OK(VisitValueAt(metadata, data, data_start + total_data_size,
                                      elem_offset, visitor, &consumed, depth));
@@ -458,30 +462,30 @@ Result<VariantMetadata> DecodeMetadata(const uint8_t* data, int64_t length) {
   if (pos + offset_size > length) {
     return Status::Invalid("Variant metadata: truncated dictionary size at byte ", pos);
   }
-  auto dict_size = static_cast<int32_t>(ReadUnsignedLE(data + pos, offset_size));
+  auto dict_size = static_cast<int64_t>(ReadUnsignedLE(data + pos, offset_size));
   pos += offset_size;
 
-  int64_t offsets_bytes = static_cast<int64_t>(dict_size + 1) * offset_size;
+  int64_t offsets_bytes = (dict_size + 1) * offset_size;
   if (pos + offsets_bytes > length) {
     return Status::Invalid("Variant metadata: truncated string offsets, need ",
                            offsets_bytes, " bytes at position ", pos,
                            " but buffer length is ", length);
   }
 
-  std::vector<uint32_t> offsets(dict_size + 1);
-  for (int32_t i = 0; i <= dict_size; ++i) {
-    offsets[i] = ReadUnsignedLE(data + pos, offset_size);
+  std::vector<uint32_t> offsets(static_cast<size_t>(dict_size + 1));
+  for (int64_t i = 0; i <= dict_size; ++i) {
+    offsets[static_cast<size_t>(i)] = ReadUnsignedLE(data + pos, offset_size);
     pos += offset_size;
   }
 
   int64_t string_data_length = length - pos;
   ARROW_RETURN_NOT_OK(ValidateOffsets(offsets, string_data_length));
 
-  std::vector<std::string_view> strings(dict_size);
-  for (int32_t i = 0; i < dict_size; ++i) {
-    auto start = static_cast<int64_t>(offsets[i]);
-    auto end = static_cast<int64_t>(offsets[i + 1]);
-    strings[i] =
+  std::vector<std::string_view> strings(static_cast<size_t>(dict_size));
+  for (int64_t i = 0; i < dict_size; ++i) {
+    auto start = static_cast<int64_t>(offsets[static_cast<size_t>(i)]);
+    auto end = static_cast<int64_t>(offsets[static_cast<size_t>(i + 1)]);
+    strings[static_cast<size_t>(i)] =
         std::string_view(reinterpret_cast<const char*>(data + pos + start), end - start);
   }
 
@@ -901,26 +905,25 @@ Result<VariantObjectView> VariantObjectView::Make(const VariantMetadata& metadat
   if (1 + num_fields_size > length) {
     return Status::Invalid("VariantObjectView: truncated num_fields");
   }
-  auto num_fields = static_cast<int32_t>(ReadUnsignedLE(data + 1, num_fields_size));
+  auto num_fields_raw = static_cast<int64_t>(ReadUnsignedLE(data + 1, num_fields_size));
 
   int64_t id_start = 1 + num_fields_size;
-  int64_t offset_start = id_start + static_cast<int64_t>(num_fields) * field_id_size;
-  int64_t data_start =
-      offset_start + (static_cast<int64_t>(num_fields) + 1) * field_offset_size;
+  int64_t offset_start = id_start + num_fields_raw * field_id_size;
+  int64_t data_start = offset_start + (num_fields_raw + 1) * field_offset_size;
 
   if (data_start > length) {
     return Status::Invalid("VariantObjectView: truncated object structure");
   }
 
   // Validate last offset is within buffer
-  int64_t last_offset_pos =
-      offset_start + static_cast<int64_t>(num_fields) * field_offset_size;
+  int64_t last_offset_pos = offset_start + num_fields_raw * field_offset_size;
   auto total_data =
       static_cast<int64_t>(ReadUnsignedLE(data + last_offset_pos, field_offset_size));
   if (data_start + total_data > length) {
     return Status::Invalid("VariantObjectView: object data exceeds buffer");
   }
 
+  auto num_fields = static_cast<int32_t>(num_fields_raw);
   return VariantObjectView(&metadata, data, length, num_fields, field_id_size,
                            field_offset_size, id_start, offset_start, data_start);
 }
@@ -1066,11 +1069,11 @@ Result<VariantArrayView> VariantArrayView::Make(const VariantMetadata& metadata,
   if (1 + num_elements_size > length) {
     return Status::Invalid("VariantArrayView: truncated num_elements");
   }
-  auto num_elements = static_cast<int32_t>(ReadUnsignedLE(data + 1, num_elements_size));
+  auto num_elements_raw =
+      static_cast<int64_t>(ReadUnsignedLE(data + 1, num_elements_size));
 
   int64_t offset_start = 1 + num_elements_size;
-  int64_t data_start =
-      offset_start + (static_cast<int64_t>(num_elements) + 1) * offset_size;
+  int64_t data_start = offset_start + (num_elements_raw + 1) * offset_size;
 
   if (data_start > length) {
     return Status::Invalid("VariantArrayView: truncated array structure");
@@ -1078,7 +1081,7 @@ Result<VariantArrayView> VariantArrayView::Make(const VariantMetadata& metadata,
 
   // Validate monotonicity and last offset in bounds
   uint32_t prev = 0;
-  for (int32_t i = 0; i <= num_elements; ++i) {
+  for (int64_t i = 0; i <= num_elements_raw; ++i) {
     auto off = ReadUnsignedLE(data + offset_start + i * offset_size, offset_size);
     if (i > 0 && off < prev) {
       return Status::Invalid(
@@ -1092,6 +1095,7 @@ Result<VariantArrayView> VariantArrayView::Make(const VariantMetadata& metadata,
     return Status::Invalid("VariantArrayView: array data exceeds buffer");
   }
 
+  auto num_elements = static_cast<int32_t>(num_elements_raw);
   return VariantArrayView(&metadata, data, length, num_elements, offset_size,
                           offset_start, data_start);
 }

--- a/cpp/src/arrow/extension/variant.cc
+++ b/cpp/src/arrow/extension/variant.cc
@@ -1,0 +1,1314 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/extension/variant.h"
+
+#include <cstring>
+
+#include "arrow/extension/variant_internal_util.h"
+#include "arrow/util/endian.h"
+#include "arrow/util/logging_internal.h"
+
+namespace arrow::extension::variant {
+
+// Ensure view classes remain lightweight (stack-allocated, cache-friendly).
+static_assert(sizeof(VariantView) <= 32, "VariantView should fit in 32 bytes");
+static_assert(sizeof(VariantObjectView) <= 80,
+              "VariantObjectView should fit in 80 bytes");
+static_assert(sizeof(VariantArrayView) <= 64, "VariantArrayView should fit in 64 bytes");
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Little-endian helpers (delegate to shared internal utility)
+// ---------------------------------------------------------------------------
+
+using internal::ReadUnsignedLE;
+
+/// \brief Validate that offsets are monotonically non-decreasing and in bounds.
+Status ValidateOffsets(const std::vector<uint32_t>& offsets, int64_t data_length) {
+  for (size_t i = 1; i < offsets.size(); ++i) {
+    if (offsets[i] < offsets[i - 1]) {
+      return Status::Invalid(
+          "Variant metadata: string offsets are not monotonically "
+          "non-decreasing at index ",
+          i);
+    }
+  }
+  if (!offsets.empty() && offsets.back() > static_cast<uint32_t>(data_length)) {
+    return Status::Invalid("Variant metadata: last string offset ", offsets.back(),
+                           " exceeds data length ", data_length);
+  }
+  return Status::OK();
+}
+
+// ---------------------------------------------------------------------------
+// Recursive visitor traversal (internal)
+// ---------------------------------------------------------------------------
+
+Status VisitValueAt(const VariantMetadata& metadata, const uint8_t* data, int64_t length,
+                    int64_t offset, VariantVisitor* visitor, int64_t* bytes_consumed,
+                    int32_t depth);
+
+Status VisitPrimitive(const uint8_t* data, int64_t length, int64_t offset, uint8_t header,
+                      VariantVisitor* visitor, int64_t* bytes_consumed) {
+  auto primitive_type = GetPrimitiveType(header);
+  int64_t pos = offset + 1;
+
+  auto check_remaining = [&](int64_t needed) -> Status {
+    if (pos + needed > length) {
+      return Status::Invalid("Variant value: truncated primitive at offset ", offset,
+                             ", need ", needed, " bytes but only ", length - pos,
+                             " remaining");
+    }
+    return Status::OK();
+  };
+
+  switch (primitive_type) {
+    case PrimitiveType::kNull:
+      ARROW_RETURN_NOT_OK(visitor->Null());
+      *bytes_consumed = 1;
+      return Status::OK();
+    case PrimitiveType::kTrue:
+      ARROW_RETURN_NOT_OK(visitor->Bool(true));
+      *bytes_consumed = 1;
+      return Status::OK();
+    case PrimitiveType::kFalse:
+      ARROW_RETURN_NOT_OK(visitor->Bool(false));
+      *bytes_consumed = 1;
+      return Status::OK();
+    case PrimitiveType::kInt8: {
+      ARROW_RETURN_NOT_OK(check_remaining(1));
+      ARROW_RETURN_NOT_OK(visitor->Int8(static_cast<int8_t>(data[pos])));
+      *bytes_consumed = 2;
+      return Status::OK();
+    }
+    case PrimitiveType::kInt16: {
+      ARROW_RETURN_NOT_OK(check_remaining(2));
+      int16_t value;
+      std::memcpy(&value, data + pos, 2);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->Int16(value));
+      *bytes_consumed = 3;
+      return Status::OK();
+    }
+    case PrimitiveType::kInt32: {
+      ARROW_RETURN_NOT_OK(check_remaining(4));
+      int32_t value;
+      std::memcpy(&value, data + pos, 4);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->Int32(value));
+      *bytes_consumed = 5;
+      return Status::OK();
+    }
+    case PrimitiveType::kInt64: {
+      ARROW_RETURN_NOT_OK(check_remaining(8));
+      int64_t value;
+      std::memcpy(&value, data + pos, 8);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->Int64(value));
+      *bytes_consumed = 9;
+      return Status::OK();
+    }
+    case PrimitiveType::kFloat: {
+      ARROW_RETURN_NOT_OK(check_remaining(4));
+      float value;
+      std::memcpy(&value, data + pos, 4);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->Float(value));
+      *bytes_consumed = 5;
+      return Status::OK();
+    }
+    case PrimitiveType::kDouble: {
+      ARROW_RETURN_NOT_OK(check_remaining(8));
+      double value;
+      std::memcpy(&value, data + pos, 8);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->Double(value));
+      *bytes_consumed = 9;
+      return Status::OK();
+    }
+    case PrimitiveType::kDecimal4: {
+      ARROW_RETURN_NOT_OK(check_remaining(5));
+      auto scale = static_cast<int32_t>(data[pos]);
+      ARROW_RETURN_NOT_OK(visitor->Decimal4(data + pos + 1, scale));
+      *bytes_consumed = 6;
+      return Status::OK();
+    }
+    case PrimitiveType::kDecimal8: {
+      ARROW_RETURN_NOT_OK(check_remaining(9));
+      auto scale = static_cast<int32_t>(data[pos]);
+      ARROW_RETURN_NOT_OK(visitor->Decimal8(data + pos + 1, scale));
+      *bytes_consumed = 10;
+      return Status::OK();
+    }
+    case PrimitiveType::kDecimal16: {
+      ARROW_RETURN_NOT_OK(check_remaining(17));
+      auto scale = static_cast<int32_t>(data[pos]);
+      ARROW_RETURN_NOT_OK(visitor->Decimal16(data + pos + 1, scale));
+      *bytes_consumed = 18;
+      return Status::OK();
+    }
+    case PrimitiveType::kDate: {
+      ARROW_RETURN_NOT_OK(check_remaining(4));
+      int32_t value;
+      std::memcpy(&value, data + pos, 4);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->Date(value));
+      *bytes_consumed = 5;
+      return Status::OK();
+    }
+    case PrimitiveType::kTimestampMicros: {
+      ARROW_RETURN_NOT_OK(check_remaining(8));
+      int64_t value;
+      std::memcpy(&value, data + pos, 8);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->TimestampMicros(value));
+      *bytes_consumed = 9;
+      return Status::OK();
+    }
+    case PrimitiveType::kTimestampMicrosNTZ: {
+      ARROW_RETURN_NOT_OK(check_remaining(8));
+      int64_t value;
+      std::memcpy(&value, data + pos, 8);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->TimestampMicrosNTZ(value));
+      *bytes_consumed = 9;
+      return Status::OK();
+    }
+    case PrimitiveType::kBinary: {
+      ARROW_RETURN_NOT_OK(check_remaining(4));
+      uint32_t bin_length;
+      std::memcpy(&bin_length, data + pos, 4);
+      bin_length = bit_util::FromLittleEndian(bin_length);
+      ARROW_RETURN_NOT_OK(check_remaining(4 + static_cast<int64_t>(bin_length)));
+      auto view =
+          std::string_view(reinterpret_cast<const char*>(data + pos + 4), bin_length);
+      ARROW_RETURN_NOT_OK(visitor->Binary(view));
+      *bytes_consumed = 1 + 4 + static_cast<int64_t>(bin_length);
+      return Status::OK();
+    }
+    case PrimitiveType::kString: {
+      ARROW_RETURN_NOT_OK(check_remaining(4));
+      uint32_t str_length;
+      std::memcpy(&str_length, data + pos, 4);
+      str_length = bit_util::FromLittleEndian(str_length);
+      ARROW_RETURN_NOT_OK(check_remaining(4 + static_cast<int64_t>(str_length)));
+      auto view =
+          std::string_view(reinterpret_cast<const char*>(data + pos + 4), str_length);
+      ARROW_RETURN_NOT_OK(visitor->String(view));
+      *bytes_consumed = 1 + 4 + static_cast<int64_t>(str_length);
+      return Status::OK();
+    }
+    case PrimitiveType::kTimeNTZ: {
+      ARROW_RETURN_NOT_OK(check_remaining(8));
+      int64_t value;
+      std::memcpy(&value, data + pos, 8);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->TimeNTZ(value));
+      *bytes_consumed = 9;
+      return Status::OK();
+    }
+    case PrimitiveType::kTimestampNanos: {
+      ARROW_RETURN_NOT_OK(check_remaining(8));
+      int64_t value;
+      std::memcpy(&value, data + pos, 8);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->TimestampNanos(value));
+      *bytes_consumed = 9;
+      return Status::OK();
+    }
+    case PrimitiveType::kTimestampNanosNTZ: {
+      ARROW_RETURN_NOT_OK(check_remaining(8));
+      int64_t value;
+      std::memcpy(&value, data + pos, 8);
+      value = bit_util::FromLittleEndian(value);
+      ARROW_RETURN_NOT_OK(visitor->TimestampNanosNTZ(value));
+      *bytes_consumed = 9;
+      return Status::OK();
+    }
+    case PrimitiveType::kUUID: {
+      ARROW_RETURN_NOT_OK(check_remaining(kUUIDByteLength));
+      ARROW_RETURN_NOT_OK(visitor->UUID(data + pos));
+      *bytes_consumed = kUUIDByteLength + 1;
+      return Status::OK();
+    }
+    default:
+      return Status::Invalid("Variant value: unknown primitive type ",
+                             static_cast<int>(primitive_type));
+  }
+}
+
+Status VisitShortString(const uint8_t* data, int64_t length, int64_t offset,
+                        uint8_t header, VariantVisitor* visitor,
+                        int64_t* bytes_consumed) {
+  int32_t str_len = (header >> 2) & 0x3F;
+  int64_t pos = offset + 1;
+  if (pos + str_len > length) {
+    return Status::Invalid("Variant value: truncated short string at offset ", offset);
+  }
+  auto view = std::string_view(reinterpret_cast<const char*>(data + pos), str_len);
+  ARROW_RETURN_NOT_OK(visitor->String(view));
+  *bytes_consumed = 1 + str_len;
+  return Status::OK();
+}
+
+Status VisitObject(const VariantMetadata& metadata, const uint8_t* data, int64_t length,
+                   int64_t offset, uint8_t header, VariantVisitor* visitor,
+                   int64_t* bytes_consumed, int32_t depth) {
+  uint8_t type_info = (header >> 2) & 0x3F;
+  int32_t field_offset_size = (type_info & 0x03) + 1;
+  int32_t field_id_size = ((type_info >> 2) & 0x03) + 1;
+  bool is_large = ((type_info >> 4) & 0x01) != 0;
+  int32_t num_fields_size = is_large ? 4 : 1;
+
+  int64_t pos = offset + 1;
+  if (pos + num_fields_size > length) {
+    return Status::Invalid("Variant value: truncated object num_fields at offset ",
+                           offset);
+  }
+  auto num_fields = static_cast<int32_t>(ReadUnsignedLE(data + pos, num_fields_size));
+  pos += num_fields_size;
+
+  int64_t field_ids_size = static_cast<int64_t>(num_fields) * field_id_size;
+  if (pos + field_ids_size > length) {
+    return Status::Invalid("Variant value: truncated object field_ids at offset ",
+                           offset);
+  }
+  std::vector<uint32_t> field_ids(num_fields);
+  for (int32_t i = 0; i < num_fields; ++i) {
+    field_ids[i] = ReadUnsignedLE(data + pos, field_id_size);
+    pos += field_id_size;
+  }
+
+  int64_t offsets_size = (static_cast<int64_t>(num_fields) + 1) * field_offset_size;
+  if (pos + offsets_size > length) {
+    return Status::Invalid("Variant value: truncated object offsets at offset ", offset);
+  }
+  std::vector<uint32_t> value_offsets(num_fields + 1);
+  for (int32_t i = 0; i <= num_fields; ++i) {
+    value_offsets[i] = ReadUnsignedLE(data + pos, field_offset_size);
+    pos += field_offset_size;
+  }
+
+  int64_t data_start = pos;
+  int64_t total_data_size = static_cast<int64_t>(value_offsets[num_fields]);
+  if (data_start + total_data_size > length) {
+    return Status::Invalid("Variant value: object data exceeds buffer at offset ",
+                           offset);
+  }
+
+  for (int32_t i = 0; i < num_fields; ++i) {
+    if (value_offsets[i] > static_cast<uint32_t>(total_data_size)) {
+      return Status::Invalid("Variant value: object field offset ", value_offsets[i],
+                             " at index ", i, " exceeds data size ", total_data_size);
+    }
+  }
+
+  ARROW_RETURN_NOT_OK(visitor->StartObject(num_fields));
+
+  for (int32_t i = 0; i < num_fields; ++i) {
+    auto field_id = field_ids[i];
+    if (field_id >= metadata.strings.size()) {
+      return Status::Invalid("Variant value: field_id ", field_id,
+                             " exceeds metadata dictionary size ",
+                             metadata.strings.size());
+    }
+    ARROW_RETURN_NOT_OK(visitor->FieldName(metadata.strings[field_id]));
+
+    int64_t field_offset = data_start + value_offsets[i];
+    int64_t consumed = 0;
+    ARROW_RETURN_NOT_OK(VisitValueAt(metadata, data, data_start + total_data_size,
+                                     field_offset, visitor, &consumed, depth));
+  }
+
+  ARROW_RETURN_NOT_OK(visitor->EndObject());
+  *bytes_consumed = (data_start - offset) + total_data_size;
+  return Status::OK();
+}
+
+Status VisitArray(const VariantMetadata& metadata, const uint8_t* data, int64_t length,
+                  int64_t offset, uint8_t header, VariantVisitor* visitor,
+                  int64_t* bytes_consumed, int32_t depth) {
+  uint8_t type_info = (header >> 2) & 0x3F;
+  int32_t field_offset_size = (type_info & 0x03) + 1;
+  bool is_large = ((type_info >> 2) & 0x01) != 0;
+  int32_t num_elements_size = is_large ? 4 : 1;
+
+  int64_t pos = offset + 1;
+  if (pos + num_elements_size > length) {
+    return Status::Invalid("Variant value: truncated array num_elements at offset ",
+                           offset);
+  }
+  auto num_elements = static_cast<int32_t>(ReadUnsignedLE(data + pos, num_elements_size));
+  pos += num_elements_size;
+
+  int64_t offsets_size = (static_cast<int64_t>(num_elements) + 1) * field_offset_size;
+  if (pos + offsets_size > length) {
+    return Status::Invalid("Variant value: truncated array offsets at offset ", offset);
+  }
+  std::vector<uint32_t> value_offsets(num_elements + 1);
+  for (int32_t i = 0; i <= num_elements; ++i) {
+    value_offsets[i] = ReadUnsignedLE(data + pos, field_offset_size);
+    pos += field_offset_size;
+  }
+
+  for (int32_t i = 1; i <= num_elements; ++i) {
+    if (value_offsets[i] < value_offsets[i - 1]) {
+      return Status::Invalid(
+          "Variant value: array value offsets are not monotonically "
+          "non-decreasing at index ",
+          i);
+    }
+  }
+
+  int64_t data_start = pos;
+  int64_t total_data_size = static_cast<int64_t>(value_offsets[num_elements]);
+  if (data_start + total_data_size > length) {
+    return Status::Invalid("Variant value: array data exceeds buffer at offset ", offset);
+  }
+
+  ARROW_RETURN_NOT_OK(visitor->StartArray(num_elements));
+
+  for (int32_t i = 0; i < num_elements; ++i) {
+    int64_t elem_offset = data_start + value_offsets[i];
+    int64_t consumed = 0;
+    ARROW_RETURN_NOT_OK(VisitValueAt(metadata, data, data_start + total_data_size,
+                                     elem_offset, visitor, &consumed, depth));
+  }
+
+  ARROW_RETURN_NOT_OK(visitor->EndArray());
+  *bytes_consumed = (data_start - offset) + total_data_size;
+  return Status::OK();
+}
+
+Status VisitValueAt(const VariantMetadata& metadata, const uint8_t* data, int64_t length,
+                    int64_t offset, VariantVisitor* visitor, int64_t* bytes_consumed,
+                    int32_t depth) {
+  if (offset >= length) {
+    return Status::Invalid("Variant value: offset ", offset,
+                           " is at or beyond buffer length ", length);
+  }
+  if (depth > kMaxNestingDepth) {
+    return Status::Invalid("Variant value: nesting depth exceeds maximum of ",
+                           kMaxNestingDepth);
+  }
+
+  uint8_t header = data[offset];
+  auto basic_type = GetBasicType(header);
+
+  switch (basic_type) {
+    case BasicType::kPrimitive:
+      return VisitPrimitive(data, length, offset, header, visitor, bytes_consumed);
+    case BasicType::kShortString:
+      return VisitShortString(data, length, offset, header, visitor, bytes_consumed);
+    case BasicType::kObject:
+      return VisitObject(metadata, data, length, offset, header, visitor, bytes_consumed,
+                         depth + 1);
+    case BasicType::kArray:
+      return VisitArray(metadata, data, length, offset, header, visitor, bytes_consumed,
+                        depth + 1);
+    default:
+      return Status::Invalid("Variant value: unknown basic type ",
+                             static_cast<int>(basic_type));
+  }
+}
+
+}  // namespace
+
+// ===========================================================================
+// Public API: Metadata
+// ===========================================================================
+
+Result<VariantMetadata> DecodeMetadata(const uint8_t* data, int64_t length) {
+  if (data == nullptr || length < 1) {
+    return Status::Invalid("Variant metadata: buffer is null or empty");
+  }
+
+  uint8_t header = data[0];
+  uint8_t version = header & 0x0F;
+  if (version != kVariantVersion) {
+    return Status::Invalid("Variant metadata: unsupported version ",
+                           static_cast<int>(version), ", expected ",
+                           static_cast<int>(kVariantVersion));
+  }
+
+  if ((header >> 5) & 0x01) {
+    return Status::Invalid("Variant metadata: reserved bit 5 is set in header");
+  }
+
+  bool is_sorted = ((header >> 4) & 0x01) != 0;
+  int32_t offset_size = ((header >> 6) & 0x03) + 1;
+
+  int64_t pos = 1;
+  if (pos + offset_size > length) {
+    return Status::Invalid("Variant metadata: truncated dictionary size at byte ", pos);
+  }
+  auto dict_size = static_cast<int32_t>(ReadUnsignedLE(data + pos, offset_size));
+  pos += offset_size;
+
+  int64_t offsets_bytes = static_cast<int64_t>(dict_size + 1) * offset_size;
+  if (pos + offsets_bytes > length) {
+    return Status::Invalid("Variant metadata: truncated string offsets, need ",
+                           offsets_bytes, " bytes at position ", pos,
+                           " but buffer length is ", length);
+  }
+
+  std::vector<uint32_t> offsets(dict_size + 1);
+  for (int32_t i = 0; i <= dict_size; ++i) {
+    offsets[i] = ReadUnsignedLE(data + pos, offset_size);
+    pos += offset_size;
+  }
+
+  int64_t string_data_length = length - pos;
+  ARROW_RETURN_NOT_OK(ValidateOffsets(offsets, string_data_length));
+
+  std::vector<std::string_view> strings(dict_size);
+  for (int32_t i = 0; i < dict_size; ++i) {
+    auto start = static_cast<int64_t>(offsets[i]);
+    auto end = static_cast<int64_t>(offsets[i + 1]);
+    strings[i] =
+        std::string_view(reinterpret_cast<const char*>(data + pos + start), end - start);
+  }
+
+  VariantMetadata result;
+  result.version = version;
+  result.is_sorted = is_sorted;
+  result.offset_size = offset_size;
+  result.strings = std::move(strings);
+  return result;
+}
+
+int32_t FindMetadataKey(const VariantMetadata& metadata, std::string_view key) {
+  if (metadata.is_sorted) {
+    int32_t lo = 0;
+    int32_t hi = static_cast<int32_t>(metadata.strings.size()) - 1;
+    while (lo <= hi) {
+      int32_t mid = lo + (hi - lo) / 2;
+      int cmp = metadata.strings[mid].compare(key);
+      if (cmp == 0) return mid;
+      if (cmp < 0)
+        lo = mid + 1;
+      else
+        hi = mid - 1;
+    }
+    return -1;
+  }
+  for (int32_t i = 0; i < static_cast<int32_t>(metadata.strings.size()); ++i) {
+    if (metadata.strings[i] == key) return i;
+  }
+  return -1;
+}
+
+int32_t PrimitiveValueSize(PrimitiveType primitive_type) {
+  switch (primitive_type) {
+    case PrimitiveType::kNull:
+    case PrimitiveType::kTrue:
+    case PrimitiveType::kFalse:
+      return 0;
+    case PrimitiveType::kInt8:
+      return 1;
+    case PrimitiveType::kInt16:
+      return 2;
+    case PrimitiveType::kInt32:
+    case PrimitiveType::kFloat:
+    case PrimitiveType::kDate:
+      return 4;
+    case PrimitiveType::kInt64:
+    case PrimitiveType::kDouble:
+    case PrimitiveType::kTimestampMicros:
+    case PrimitiveType::kTimestampMicrosNTZ:
+    case PrimitiveType::kTimeNTZ:
+    case PrimitiveType::kTimestampNanos:
+    case PrimitiveType::kTimestampNanosNTZ:
+      return 8;
+    case PrimitiveType::kDecimal4:
+      return 5;
+    case PrimitiveType::kDecimal8:
+      return 9;
+    case PrimitiveType::kDecimal16:
+      return 17;
+    case PrimitiveType::kUUID:
+      return kUUIDByteLength;
+    case PrimitiveType::kBinary:
+    case PrimitiveType::kString:
+      return -1;
+    default:
+      return -1;
+  }
+}
+
+Result<int64_t> ValueSize(const uint8_t* data, int64_t length) {
+  if (data == nullptr || length < 1) {
+    return Status::Invalid("ValueSize: buffer is null or empty");
+  }
+
+  uint8_t header = data[0];
+  auto basic_type = GetBasicType(header);
+  uint8_t type_info = (header >> 2) & 0x3F;
+
+  switch (basic_type) {
+    case BasicType::kShortString:
+      return 1 + static_cast<int64_t>(type_info);
+
+    case BasicType::kObject: {
+      bool is_large = ((type_info >> 4) & 0x01) != 0;
+      int32_t sz_bytes = is_large ? 4 : 1;
+      if (1 + sz_bytes > length) {
+        return Status::Invalid("ValueSize: truncated object header");
+      }
+      auto num_elements = static_cast<int64_t>(ReadUnsignedLE(data + 1, sz_bytes));
+      int32_t id_size = ((type_info >> 2) & 0x03) + 1;
+      int32_t offset_size = (type_info & 0x03) + 1;
+      int64_t id_start = 1 + sz_bytes;
+      int64_t offset_start = id_start + num_elements * id_size;
+      int64_t data_start = offset_start + (num_elements + 1) * offset_size;
+      int64_t last_offset_pos = offset_start + num_elements * offset_size;
+      if (last_offset_pos + offset_size > length) {
+        return Status::Invalid("ValueSize: truncated object offsets");
+      }
+      auto total_data =
+          static_cast<int64_t>(ReadUnsignedLE(data + last_offset_pos, offset_size));
+      return data_start + total_data;
+    }
+
+    case BasicType::kArray: {
+      bool is_large = ((type_info >> 2) & 0x01) != 0;
+      int32_t sz_bytes = is_large ? 4 : 1;
+      if (1 + sz_bytes > length) {
+        return Status::Invalid("ValueSize: truncated array header");
+      }
+      auto num_elements = static_cast<int64_t>(ReadUnsignedLE(data + 1, sz_bytes));
+      int32_t offset_size = (type_info & 0x03) + 1;
+      int64_t offset_start = 1 + sz_bytes;
+      int64_t data_start = offset_start + (num_elements + 1) * offset_size;
+      int64_t last_offset_pos = offset_start + num_elements * offset_size;
+      if (last_offset_pos + offset_size > length) {
+        return Status::Invalid("ValueSize: truncated array offsets");
+      }
+      auto total_data =
+          static_cast<int64_t>(ReadUnsignedLE(data + last_offset_pos, offset_size));
+      return data_start + total_data;
+    }
+
+    case BasicType::kPrimitive: {
+      auto ptype = static_cast<PrimitiveType>(type_info);
+      int32_t payload_size = PrimitiveValueSize(ptype);
+      if (payload_size >= 0) {
+        return 1 + static_cast<int64_t>(payload_size);
+      }
+      if (1 + 4 > length) {
+        return Status::Invalid("ValueSize: truncated variable-length header");
+      }
+      uint32_t var_len;
+      std::memcpy(&var_len, data + 1, 4);
+      var_len = bit_util::FromLittleEndian(var_len);
+      return 1 + 4 + static_cast<int64_t>(var_len);
+    }
+
+    default:
+      return Status::Invalid("ValueSize: unknown basic type");
+  }
+}
+
+// ===========================================================================
+// Public API: VariantView
+// ===========================================================================
+
+VariantView::VariantView(const VariantMetadata* metadata, const uint8_t* data,
+                         int64_t size, BasicType type)
+    : metadata_(metadata), data_(data), size_(size), type_(type) {}
+
+Result<VariantView> VariantView::Make(const VariantMetadata& metadata,
+                                      const uint8_t* data, int64_t length) {
+  if (data == nullptr || length < 1) {
+    return Status::Invalid("VariantView: buffer is null or empty");
+  }
+  ARROW_ASSIGN_OR_RAISE(auto size, ValueSize(data, length));
+  if (size > length) {
+    return Status::Invalid("VariantView: value size ", size, " exceeds buffer length ",
+                           length);
+  }
+  auto type = GetBasicType(data[0]);
+  return VariantView(&metadata, data, size, type);
+}
+
+bool VariantView::is_null() const {
+  return type_ == BasicType::kPrimitive &&
+         GetPrimitiveType(data_[0]) == PrimitiveType::kNull;
+}
+
+Status VariantView::Visit(VariantVisitor* visitor) const {
+  DCHECK_NE(visitor, nullptr);
+  int64_t bytes_consumed = 0;
+  return VisitValueAt(*metadata_, data_, size_, 0, visitor, &bytes_consumed, 0);
+}
+
+// --- Primitive accessors ---
+
+Result<bool> VariantView::as_bool() const {
+  if (type_ != BasicType::kPrimitive) {
+    return Status::Invalid("VariantView::as_bool: not a primitive");
+  }
+  auto pt = GetPrimitiveType(data_[0]);
+  if (pt == PrimitiveType::kTrue) return true;
+  if (pt == PrimitiveType::kFalse) return false;
+  return Status::Invalid("VariantView::as_bool: not a boolean");
+}
+
+Result<int8_t> VariantView::as_int8() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kInt8) {
+    return Status::Invalid("VariantView::as_int8: type mismatch");
+  }
+  return static_cast<int8_t>(data_[1]);
+}
+
+Result<int16_t> VariantView::as_int16() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kInt16) {
+    return Status::Invalid("VariantView::as_int16: type mismatch");
+  }
+  int16_t value;
+  std::memcpy(&value, data_ + 1, 2);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<int32_t> VariantView::as_int32() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kInt32) {
+    return Status::Invalid("VariantView::as_int32: type mismatch");
+  }
+  int32_t value;
+  std::memcpy(&value, data_ + 1, 4);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<int64_t> VariantView::as_int64() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kInt64) {
+    return Status::Invalid("VariantView::as_int64: type mismatch");
+  }
+  int64_t value;
+  std::memcpy(&value, data_ + 1, 8);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<float> VariantView::as_float() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kFloat) {
+    return Status::Invalid("VariantView::as_float: type mismatch");
+  }
+  float value;
+  std::memcpy(&value, data_ + 1, 4);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<double> VariantView::as_double() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kDouble) {
+    return Status::Invalid("VariantView::as_double: type mismatch");
+  }
+  double value;
+  std::memcpy(&value, data_ + 1, 8);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<std::string_view> VariantView::as_string() const {
+  if (type_ == BasicType::kShortString) {
+    int32_t len = (data_[0] >> 2) & 0x3F;
+    return std::string_view(reinterpret_cast<const char*>(data_ + 1), len);
+  }
+  if (type_ == BasicType::kPrimitive &&
+      GetPrimitiveType(data_[0]) == PrimitiveType::kString) {
+    uint32_t len;
+    std::memcpy(&len, data_ + 1, 4);
+    len = bit_util::FromLittleEndian(len);
+    return std::string_view(reinterpret_cast<const char*>(data_ + 5), len);
+  }
+  return Status::Invalid("VariantView::as_string: not a string");
+}
+
+Result<std::string_view> VariantView::as_binary() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kBinary) {
+    return Status::Invalid("VariantView::as_binary: not binary");
+  }
+  uint32_t len;
+  std::memcpy(&len, data_ + 1, 4);
+  len = bit_util::FromLittleEndian(len);
+  return std::string_view(reinterpret_cast<const char*>(data_ + 5), len);
+}
+
+Result<int32_t> VariantView::as_date() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kDate) {
+    return Status::Invalid("VariantView::as_date: type mismatch");
+  }
+  int32_t value;
+  std::memcpy(&value, data_ + 1, 4);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<int64_t> VariantView::as_timestamp_micros() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kTimestampMicros) {
+    return Status::Invalid("VariantView::as_timestamp_micros: type mismatch");
+  }
+  int64_t value;
+  std::memcpy(&value, data_ + 1, 8);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<int64_t> VariantView::as_timestamp_micros_ntz() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kTimestampMicrosNTZ) {
+    return Status::Invalid("VariantView::as_timestamp_micros_ntz: type mismatch");
+  }
+  int64_t value;
+  std::memcpy(&value, data_ + 1, 8);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<int64_t> VariantView::as_timestamp_nanos() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kTimestampNanos) {
+    return Status::Invalid("VariantView::as_timestamp_nanos: type mismatch");
+  }
+  int64_t value;
+  std::memcpy(&value, data_ + 1, 8);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<int64_t> VariantView::as_timestamp_nanos_ntz() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kTimestampNanosNTZ) {
+    return Status::Invalid("VariantView::as_timestamp_nanos_ntz: type mismatch");
+  }
+  int64_t value;
+  std::memcpy(&value, data_ + 1, 8);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<int64_t> VariantView::as_time_ntz() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kTimeNTZ) {
+    return Status::Invalid("VariantView::as_time_ntz: type mismatch");
+  }
+  int64_t value;
+  std::memcpy(&value, data_ + 1, 8);
+  return bit_util::FromLittleEndian(value);
+}
+
+Result<const uint8_t*> VariantView::as_uuid() const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kUUID) {
+    return Status::Invalid("VariantView::as_uuid: type mismatch");
+  }
+  return data_ + 1;
+}
+
+Result<const uint8_t*> VariantView::as_decimal4(int32_t* scale) const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kDecimal4) {
+    return Status::Invalid("VariantView::as_decimal4: type mismatch");
+  }
+  *scale = static_cast<int32_t>(data_[1]);
+  return data_ + 2;
+}
+
+Result<const uint8_t*> VariantView::as_decimal8(int32_t* scale) const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kDecimal8) {
+    return Status::Invalid("VariantView::as_decimal8: type mismatch");
+  }
+  *scale = static_cast<int32_t>(data_[1]);
+  return data_ + 2;
+}
+
+Result<const uint8_t*> VariantView::as_decimal16(int32_t* scale) const {
+  if (type_ != BasicType::kPrimitive ||
+      GetPrimitiveType(data_[0]) != PrimitiveType::kDecimal16) {
+    return Status::Invalid("VariantView::as_decimal16: type mismatch");
+  }
+  *scale = static_cast<int32_t>(data_[1]);
+  return data_ + 2;
+}
+
+Result<VariantObjectView> VariantView::as_object() const {
+  if (type_ != BasicType::kObject) {
+    return Status::Invalid("VariantView::as_object: not an object");
+  }
+  return VariantObjectView::Make(*metadata_, data_, size_);
+}
+
+Result<VariantArrayView> VariantView::as_array() const {
+  if (type_ != BasicType::kArray) {
+    return Status::Invalid("VariantView::as_array: not an array");
+  }
+  return VariantArrayView::Make(*metadata_, data_, size_);
+}
+
+// ===========================================================================
+// Public API: VariantObjectView
+// ===========================================================================
+
+VariantObjectView::VariantObjectView(const VariantMetadata* metadata, const uint8_t* data,
+                                     int64_t length, int32_t num_fields,
+                                     int8_t field_id_size, int8_t field_offset_size,
+                                     int64_t id_start, int64_t offset_start,
+                                     int64_t data_start)
+    : metadata_(metadata),
+      data_(data),
+      length_(length),
+      num_fields_(num_fields),
+      field_id_size_(field_id_size),
+      field_offset_size_(field_offset_size),
+      id_start_(id_start),
+      offset_start_(offset_start),
+      data_start_(data_start) {}
+
+Result<VariantObjectView> VariantObjectView::Make(const VariantMetadata& metadata,
+                                                  const uint8_t* data, int64_t length) {
+  if (data == nullptr || length < 1) {
+    return Status::Invalid("VariantObjectView: buffer is null or empty");
+  }
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kObject) {
+    return Status::Invalid("VariantObjectView: not an object");
+  }
+
+  uint8_t type_info = (header >> 2) & 0x3F;
+  int8_t field_offset_size = static_cast<int8_t>((type_info & 0x03) + 1);
+  int8_t field_id_size = static_cast<int8_t>(((type_info >> 2) & 0x03) + 1);
+  bool is_large = ((type_info >> 4) & 0x01) != 0;
+  int32_t num_fields_size = is_large ? 4 : 1;
+
+  if (1 + num_fields_size > length) {
+    return Status::Invalid("VariantObjectView: truncated num_fields");
+  }
+  auto num_fields = static_cast<int32_t>(ReadUnsignedLE(data + 1, num_fields_size));
+
+  int64_t id_start = 1 + num_fields_size;
+  int64_t offset_start = id_start + static_cast<int64_t>(num_fields) * field_id_size;
+  int64_t data_start =
+      offset_start + (static_cast<int64_t>(num_fields) + 1) * field_offset_size;
+
+  if (data_start > length) {
+    return Status::Invalid("VariantObjectView: truncated object structure");
+  }
+
+  // Validate last offset is within buffer
+  int64_t last_offset_pos =
+      offset_start + static_cast<int64_t>(num_fields) * field_offset_size;
+  auto total_data =
+      static_cast<int64_t>(ReadUnsignedLE(data + last_offset_pos, field_offset_size));
+  if (data_start + total_data > length) {
+    return Status::Invalid("VariantObjectView: object data exceeds buffer");
+  }
+
+  return VariantObjectView(&metadata, data, length, num_fields, field_id_size,
+                           field_offset_size, id_start, offset_start, data_start);
+}
+
+uint32_t VariantObjectView::field_id_at(int32_t i) const {
+  return ReadUnsignedLE(data_ + id_start_ + i * field_id_size_, field_id_size_);
+}
+
+int64_t VariantObjectView::value_offset_at(int32_t i) const {
+  return data_start_ +
+         static_cast<int64_t>(ReadUnsignedLE(
+             data_ + offset_start_ + i * field_offset_size_, field_offset_size_));
+}
+
+Result<std::string_view> VariantObjectView::field_name(int32_t index) const {
+  if (index < 0 || index >= num_fields_) {
+    return Status::Invalid("VariantObjectView::field_name: index out of range");
+  }
+  auto id = field_id_at(index);
+  if (id >= metadata_->strings.size()) {
+    return Status::Invalid("VariantObjectView::field_name: field_id exceeds dictionary");
+  }
+  return metadata_->strings[id];
+}
+
+Result<VariantView> VariantObjectView::field_value(int32_t index) const {
+  if (index < 0 || index >= num_fields_) {
+    return Status::Invalid("VariantObjectView::field_value: index out of range");
+  }
+  int64_t offset = value_offset_at(index);
+  return VariantView::Make(*metadata_, data_ + offset, length_ - offset);
+}
+
+std::optional<VariantView> VariantObjectView::get(std::string_view name) const {
+  // Binary search — field IDs are sorted by lexicographic key order per spec.
+  int32_t lo = 0, hi = num_fields_ - 1;
+  while (lo <= hi) {
+    int32_t mid = lo + (hi - lo) / 2;
+    auto id = field_id_at(mid);
+    if (id >= metadata_->strings.size()) {
+      return std::nullopt;  // Malformed data — graceful degradation
+    }
+    auto key = metadata_->strings[id];
+    if (key == name) {
+      int64_t offset = value_offset_at(mid);
+      auto view = VariantView::Make(*metadata_, data_ + offset, length_ - offset);
+      if (view.ok()) return *view;
+      return std::nullopt;
+    }
+    if (key < name)
+      lo = mid + 1;
+    else
+      hi = mid - 1;
+  }
+  return std::nullopt;
+}
+
+bool VariantObjectView::contains(std::string_view name) const {
+  return get(name).has_value();
+}
+
+std::optional<VariantObjectView::FieldLocation> VariantObjectView::locate(
+    std::string_view name) const {
+  // Binary search for the field
+  int32_t lo = 0, hi = num_fields_ - 1;
+  while (lo <= hi) {
+    int32_t mid = lo + (hi - lo) / 2;
+    auto id = field_id_at(mid);
+    if (id >= metadata_->strings.size()) {
+      return std::nullopt;
+    }
+    auto key = metadata_->strings[id];
+    if (key == name) {
+      int64_t offset = value_offset_at(mid);
+      auto size_result = ValueSize(data_ + offset, length_ - offset);
+      if (!size_result.ok()) return std::nullopt;
+      return FieldLocation{offset, *size_result};
+    }
+    if (key < name)
+      lo = mid + 1;
+    else
+      hi = mid - 1;
+  }
+  return std::nullopt;
+}
+
+// Object iterator
+VariantObjectView::Iterator::Iterator(const VariantObjectView* obj, int32_t index)
+    : obj_(obj), index_(index) {}
+
+VariantObjectView::Iterator::value_type VariantObjectView::Iterator::operator*() const {
+  auto name = obj_->field_name(index_).ValueOrDie();
+  auto value = obj_->field_value(index_).ValueOrDie();
+  return {name, value};
+}
+
+VariantObjectView::Iterator& VariantObjectView::Iterator::operator++() {
+  ++index_;
+  return *this;
+}
+
+bool VariantObjectView::Iterator::operator!=(const Iterator& other) const {
+  return index_ != other.index_;
+}
+
+VariantObjectView::Iterator VariantObjectView::begin() const { return Iterator(this, 0); }
+
+VariantObjectView::Iterator VariantObjectView::end() const {
+  return Iterator(this, num_fields_);
+}
+
+// ===========================================================================
+// Public API: VariantArrayView
+// ===========================================================================
+
+VariantArrayView::VariantArrayView(const VariantMetadata* metadata, const uint8_t* data,
+                                   int64_t length, int32_t num_elements,
+                                   int8_t offset_size, int64_t offset_start,
+                                   int64_t data_start)
+    : metadata_(metadata),
+      data_(data),
+      length_(length),
+      num_elements_(num_elements),
+      offset_size_(offset_size),
+      offset_start_(offset_start),
+      data_start_(data_start) {}
+
+Result<VariantArrayView> VariantArrayView::Make(const VariantMetadata& metadata,
+                                                const uint8_t* data, int64_t length) {
+  if (data == nullptr || length < 1) {
+    return Status::Invalid("VariantArrayView: buffer is null or empty");
+  }
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kArray) {
+    return Status::Invalid("VariantArrayView: not an array");
+  }
+
+  uint8_t type_info = (header >> 2) & 0x3F;
+  int8_t offset_size = static_cast<int8_t>((type_info & 0x03) + 1);
+  bool is_large = ((type_info >> 2) & 0x01) != 0;
+  int32_t num_elements_size = is_large ? 4 : 1;
+
+  if (1 + num_elements_size > length) {
+    return Status::Invalid("VariantArrayView: truncated num_elements");
+  }
+  auto num_elements = static_cast<int32_t>(ReadUnsignedLE(data + 1, num_elements_size));
+
+  int64_t offset_start = 1 + num_elements_size;
+  int64_t data_start =
+      offset_start + (static_cast<int64_t>(num_elements) + 1) * offset_size;
+
+  if (data_start > length) {
+    return Status::Invalid("VariantArrayView: truncated array structure");
+  }
+
+  // Validate monotonicity and last offset in bounds
+  uint32_t prev = 0;
+  for (int32_t i = 0; i <= num_elements; ++i) {
+    auto off = ReadUnsignedLE(data + offset_start + i * offset_size, offset_size);
+    if (i > 0 && off < prev) {
+      return Status::Invalid(
+          "VariantArrayView: offsets not monotonically non-decreasing at index ", i);
+    }
+    prev = off;
+  }
+
+  auto total_data = static_cast<int64_t>(prev);  // last offset = total data size
+  if (data_start + total_data > length) {
+    return Status::Invalid("VariantArrayView: array data exceeds buffer");
+  }
+
+  return VariantArrayView(&metadata, data, length, num_elements, offset_size,
+                          offset_start, data_start);
+}
+
+int64_t VariantArrayView::element_offset_at(int32_t i) const {
+  return data_start_ + static_cast<int64_t>(ReadUnsignedLE(
+                           data_ + offset_start_ + i * offset_size_, offset_size_));
+}
+
+Result<VariantView> VariantArrayView::get(int32_t index) const {
+  if (index < 0 || index >= num_elements_) {
+    return Status::Invalid("VariantArrayView::get: index ", index, " out of range [0, ",
+                           num_elements_, ")");
+  }
+  int64_t offset = element_offset_at(index);
+  return VariantView::Make(*metadata_, data_ + offset, length_ - offset);
+}
+
+// Array iterator
+VariantArrayView::Iterator::Iterator(const VariantArrayView* arr, int32_t index)
+    : arr_(arr), index_(index) {}
+
+VariantArrayView::Iterator::value_type VariantArrayView::Iterator::operator*() const {
+  return arr_->get(index_).ValueOrDie();
+}
+
+VariantArrayView::Iterator& VariantArrayView::Iterator::operator++() {
+  ++index_;
+  return *this;
+}
+
+bool VariantArrayView::Iterator::operator!=(const Iterator& other) const {
+  return index_ != other.index_;
+}
+
+VariantArrayView::Iterator VariantArrayView::begin() const { return Iterator(this, 0); }
+
+VariantArrayView::Iterator VariantArrayView::end() const {
+  return Iterator(this, num_elements_);
+}
+
+// ===========================================================================
+// Widening numeric accessors
+// ===========================================================================
+
+Result<int64_t> VariantView::as_int64_coerced() const {
+  if (type_ != BasicType::kPrimitive) {
+    return Status::Invalid("VariantView::as_int64_coerced: not a primitive");
+  }
+  auto pt = GetPrimitiveType(data_[0]);
+  switch (pt) {
+    case PrimitiveType::kInt8:
+      return static_cast<int64_t>(static_cast<int8_t>(data_[1]));
+    case PrimitiveType::kInt16: {
+      int16_t value;
+      std::memcpy(&value, data_ + 1, 2);
+      return static_cast<int64_t>(bit_util::FromLittleEndian(value));
+    }
+    case PrimitiveType::kInt32: {
+      int32_t value;
+      std::memcpy(&value, data_ + 1, 4);
+      return static_cast<int64_t>(bit_util::FromLittleEndian(value));
+    }
+    case PrimitiveType::kInt64: {
+      int64_t value;
+      std::memcpy(&value, data_ + 1, 8);
+      return bit_util::FromLittleEndian(value);
+    }
+    default:
+      return Status::Invalid("VariantView::as_int64_coerced: not an integer type");
+  }
+}
+
+Result<int32_t> VariantView::as_int32_coerced() const {
+  if (type_ != BasicType::kPrimitive) {
+    return Status::Invalid("VariantView::as_int32_coerced: not a primitive");
+  }
+  auto pt = GetPrimitiveType(data_[0]);
+  switch (pt) {
+    case PrimitiveType::kInt8:
+      return static_cast<int32_t>(static_cast<int8_t>(data_[1]));
+    case PrimitiveType::kInt16: {
+      int16_t value;
+      std::memcpy(&value, data_ + 1, 2);
+      return static_cast<int32_t>(bit_util::FromLittleEndian(value));
+    }
+    case PrimitiveType::kInt32: {
+      int32_t value;
+      std::memcpy(&value, data_ + 1, 4);
+      return bit_util::FromLittleEndian(value);
+    }
+    default:
+      return Status::Invalid(
+          "VariantView::as_int32_coerced: not a 32-bit-or-narrower "
+          "integer type");
+  }
+}
+
+Result<double> VariantView::as_double_coerced() const {
+  if (type_ != BasicType::kPrimitive) {
+    return Status::Invalid("VariantView::as_double_coerced: not a primitive");
+  }
+  auto pt = GetPrimitiveType(data_[0]);
+  switch (pt) {
+    case PrimitiveType::kInt8:
+      return static_cast<double>(static_cast<int8_t>(data_[1]));
+    case PrimitiveType::kInt16: {
+      int16_t value;
+      std::memcpy(&value, data_ + 1, 2);
+      return static_cast<double>(bit_util::FromLittleEndian(value));
+    }
+    case PrimitiveType::kInt32: {
+      int32_t value;
+      std::memcpy(&value, data_ + 1, 4);
+      return static_cast<double>(bit_util::FromLittleEndian(value));
+    }
+    case PrimitiveType::kInt64: {
+      int64_t value;
+      std::memcpy(&value, data_ + 1, 8);
+      return static_cast<double>(bit_util::FromLittleEndian(value));
+    }
+    case PrimitiveType::kFloat: {
+      float value;
+      std::memcpy(&value, data_ + 1, 4);
+      return static_cast<double>(bit_util::FromLittleEndian(value));
+    }
+    case PrimitiveType::kDouble: {
+      double value;
+      std::memcpy(&value, data_ + 1, 8);
+      return bit_util::FromLittleEndian(value);
+    }
+    default:
+      return Status::Invalid("VariantView::as_double_coerced: not a numeric type");
+  }
+}
+
+// ===========================================================================
+// ValidateVariant — full recursive validation
+// ===========================================================================
+
+namespace {
+
+Status ValidateVariantRecursive(const VariantMetadata& metadata, const uint8_t* data,
+                                int64_t length, int64_t offset, int32_t depth) {
+  if (offset >= length) {
+    return Status::Invalid("ValidateVariant: offset ", offset,
+                           " at or beyond buffer length ", length);
+  }
+  if (depth > kMaxNestingDepth) {
+    return Status::Invalid("ValidateVariant: nesting depth exceeds maximum of ",
+                           kMaxNestingDepth);
+  }
+
+  uint8_t header = data[offset];
+  auto basic_type = GetBasicType(header);
+
+  switch (basic_type) {
+    case BasicType::kPrimitive: {
+      // Validate the value size is computable and within bounds
+      ARROW_ASSIGN_OR_RAISE(auto size, ValueSize(data + offset, length - offset));
+      if (offset + size > length) {
+        return Status::Invalid("ValidateVariant: primitive value at offset ", offset,
+                               " requires ", size, " bytes but only ", length - offset,
+                               " available");
+      }
+      return Status::OK();
+    }
+    case BasicType::kShortString: {
+      int32_t str_len = (header >> 2) & 0x3F;
+      if (offset + 1 + str_len > length) {
+        return Status::Invalid("ValidateVariant: truncated short string at offset ",
+                               offset);
+      }
+      return Status::OK();
+    }
+    case BasicType::kObject: {
+      // Construct a view (validates structure) then recursively validate children
+      ARROW_ASSIGN_OR_RAISE(
+          auto obj, VariantObjectView::Make(metadata, data + offset, length - offset));
+      for (int32_t i = 0; i < obj.num_fields(); ++i) {
+        // Validate field name (checks field_id within dictionary bounds)
+        ARROW_RETURN_NOT_OK(obj.field_name(i).status());
+        // Validate field value recursively
+        ARROW_ASSIGN_OR_RAISE(auto field_view, obj.field_value(i));
+        auto field_offset = field_view.data() - data;
+        ARROW_RETURN_NOT_OK(
+            ValidateVariantRecursive(metadata, data, length, field_offset, depth + 1));
+      }
+      return Status::OK();
+    }
+    case BasicType::kArray: {
+      // Construct a view (validates structure) then recursively validate elements
+      ARROW_ASSIGN_OR_RAISE(
+          auto arr, VariantArrayView::Make(metadata, data + offset, length - offset));
+      for (int32_t i = 0; i < arr.num_elements(); ++i) {
+        ARROW_ASSIGN_OR_RAISE(auto elem_view, arr.get(i));
+        auto elem_offset = elem_view.data() - data;
+        ARROW_RETURN_NOT_OK(
+            ValidateVariantRecursive(metadata, data, length, elem_offset, depth + 1));
+      }
+      return Status::OK();
+    }
+    default:
+      return Status::Invalid("ValidateVariant: unknown basic type at offset ", offset);
+  }
+}
+
+}  // namespace
+
+Status ValidateVariant(const VariantMetadata& metadata, const uint8_t* data,
+                       int64_t length) {
+  if (data == nullptr || length < 1) {
+    return Status::Invalid("ValidateVariant: buffer is null or empty");
+  }
+  return ValidateVariantRecursive(metadata, data, length, 0, 0);
+}
+
+// ===========================================================================
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant.h
+++ b/cpp/src/arrow/extension/variant.h
@@ -1,0 +1,583 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+/// \file variant.h
+/// \brief Public C++ API for Variant binary encoding/decoding.
+///
+/// Provides zero-copy view classes for reading variant values (VariantView,
+/// VariantObjectView, VariantArrayView) and a visitor interface for full
+/// tree traversal. Implements the Variant Encoding Spec:
+/// https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
+///
+/// Design principles:
+///   - Parse once, query many (view classes pre-parse headers at construction)
+///   - Zero-copy (string_view into source buffers, no heap allocation for reads)
+///   - Type safety at boundaries (views validate at construction, not on access)
+///   - O(log n) field lookup always (no threshold heuristics)
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow::extension::variant {
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Variant encoding spec version 1.
+constexpr uint8_t kVariantVersion = 1;
+
+/// Maximum nesting depth for recursive value decoding.
+/// Prevents stack overflow on deeply nested (possibly malicious) input.
+constexpr int32_t kMaxNestingDepth = 128;
+
+/// UUID values are always 16 bytes (128-bit, big-endian per RFC 4122).
+constexpr int32_t kUUIDByteLength = 16;
+
+// ---------------------------------------------------------------------------
+// Enumerations
+// ---------------------------------------------------------------------------
+
+/// \brief Basic type codes from bits 0-1 of the value header byte.
+///
+/// See:
+/// https://github.com/apache/parquet-format/blob/master/VariantEncoding.md#encoding-types
+enum class BasicType : uint8_t {
+  kPrimitive = 0,
+  kShortString = 1,
+  kObject = 2,
+  kArray = 3,
+};
+
+/// \brief Primitive type codes from bits 2-7 when basic_type == kPrimitive.
+///
+/// See:
+/// https://github.com/apache/parquet-format/blob/master/VariantEncoding.md#encoding-types
+enum class PrimitiveType : uint8_t {
+  kNull = 0,
+  kTrue = 1,
+  kFalse = 2,
+  kInt8 = 3,
+  kInt16 = 4,
+  kInt32 = 5,
+  kInt64 = 6,
+  kDouble = 7,
+  kDecimal4 = 8,
+  kDecimal8 = 9,
+  kDecimal16 = 10,
+  kDate = 11,
+  kTimestampMicros = 12,
+  kTimestampMicrosNTZ = 13,
+  kFloat = 14,
+  kBinary = 15,
+  kString = 16,
+  kTimeNTZ = 17,
+  kTimestampNanos = 18,
+  kTimestampNanosNTZ = 19,
+  kUUID = 20,
+};
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+/// \brief Parsed variant metadata (string dictionary).
+///
+/// The metadata buffer contains a header byte followed by a dictionary of
+/// interned strings used as object field names. String views reference the
+/// raw buffer and are valid only as long as the underlying buffer is alive.
+///
+/// \note This is NOT a schema — it contains key names only, not value types.
+struct ARROW_EXPORT VariantMetadata {
+  /// Spec version (must be kVariantVersion).
+  uint8_t version = 0;
+
+  /// Whether the dictionary strings are sorted lexicographically.
+  bool is_sorted = false;
+
+  /// Number of bytes used for each offset (1, 2, 3, or 4).
+  int32_t offset_size = 0;
+
+  /// Dictionary of interned strings. Views into the raw metadata buffer.
+  std::vector<std::string_view> strings;
+};
+
+/// \brief Decode a variant metadata buffer.
+///
+/// Parses the header byte and string dictionary from the raw metadata
+/// buffer. The returned VariantMetadata contains string_views that
+/// reference the input buffer directly (zero-copy).
+///
+/// \param[in] data Pointer to the metadata buffer (must not be null)
+/// \param[in] length Length of the metadata buffer in bytes
+/// \return Parsed VariantMetadata on success, Status::Invalid on
+///         malformed input
+///
+/// \note The input buffer must outlive the returned VariantMetadata.
+ARROW_EXPORT Result<VariantMetadata> DecodeMetadata(const uint8_t* data, int64_t length);
+
+/// \brief Find the dictionary ID for a given key name.
+///
+/// Uses binary search if the metadata is sorted, otherwise linear scan.
+///
+/// \param[in] metadata Parsed metadata
+/// \param[in] key The key to search for
+/// \return The dictionary ID if found, or -1 if not present
+ARROW_EXPORT int32_t FindMetadataKey(const VariantMetadata& metadata,
+                                     std::string_view key);
+
+// ---------------------------------------------------------------------------
+// Header utilities
+// ---------------------------------------------------------------------------
+
+/// \brief Extract the basic type from a value header byte.
+inline BasicType GetBasicType(uint8_t header) {
+  return static_cast<BasicType>(header & 0x03);
+}
+
+/// \brief Extract the primitive type from a value header byte.
+/// Only valid when GetBasicType(header) == BasicType::kPrimitive.
+inline PrimitiveType GetPrimitiveType(uint8_t header) {
+  return static_cast<PrimitiveType>((header >> 2) & 0x3F);
+}
+
+/// \brief Get the byte size of a primitive value (excluding header).
+/// Returns -1 for variable-length types (Binary, String).
+ARROW_EXPORT int32_t PrimitiveValueSize(PrimitiveType primitive_type);
+
+/// \brief Compute the total byte size of a variant value (header + data).
+///
+/// Determines how many bytes a variant value occupies without full decoding.
+/// \param[in] data Pointer to the start of a variant value
+/// \param[in] length Maximum bytes available
+/// \return Total byte count, or Status::Invalid if truncated
+ARROW_EXPORT Result<int64_t> ValueSize(const uint8_t* data, int64_t length);
+
+/// \brief Recursively validate a variant value and all nested children.
+///
+/// Performs deep structural validation of the entire value tree:
+///   - All headers are well-formed
+///   - All field IDs reference valid dictionary entries
+///   - All offsets are within bounds and monotonically non-decreasing
+///   - All nested values are recursively valid
+///   - Nesting depth does not exceed kMaxNestingDepth
+///
+/// Use this for untrusted input where you want a single pass/fail before
+/// operating on the data. For trusted data (e.g., builder output), the
+/// per-access validation in view classes is sufficient.
+///
+/// \param[in] metadata Parsed metadata (for validating field ID references)
+/// \param[in] data Pointer to the variant value buffer
+/// \param[in] length Length of the variant value buffer in bytes
+/// \return Status::OK if valid, Status::Invalid with description of first error
+ARROW_EXPORT Status ValidateVariant(const VariantMetadata& metadata, const uint8_t* data,
+                                    int64_t length);
+
+// ---------------------------------------------------------------------------
+// Forward declarations
+// ---------------------------------------------------------------------------
+
+class VariantObjectView;
+class VariantArrayView;
+
+// ---------------------------------------------------------------------------
+// VariantView — non-owning view over a single variant value
+// ---------------------------------------------------------------------------
+
+/// \brief A non-owning, zero-copy view over a single variant value.
+///
+/// Construction validates the header byte is readable. Subsequent typed
+/// accessors validate type compatibility and return errors on mismatch.
+///
+/// Stack-allocated, ~32 bytes. No heap allocation.
+///
+/// \note The metadata and data buffers must outlive this view.
+class ARROW_EXPORT VariantView {
+ public:
+  /// \brief Construct a view over a variant value.
+  ///
+  /// Validates that the buffer has at least one byte and computes the
+  /// value's total size. Returns Invalid on empty/null buffers or if
+  /// the value is truncated.
+  ///
+  /// \param[in] metadata Parsed metadata (for resolving object field names)
+  /// \param[in] data Pointer to the value buffer
+  /// \param[in] length Length of the value buffer in bytes
+  static Result<VariantView> Make(const VariantMetadata& metadata, const uint8_t* data,
+                                  int64_t length);
+
+  /// \brief The basic type of this value.
+  BasicType type() const { return type_; }
+
+  /// \brief Whether this value is null (PrimitiveType::kNull).
+  bool is_null() const;
+
+  /// \brief Total byte size of this value (header + payload).
+  int64_t size_bytes() const { return size_; }
+
+  /// \brief Raw pointer to the value bytes.
+  const uint8_t* data() const { return data_; }
+
+  /// @name Primitive accessors
+  /// Each returns the value if the type matches, or Status::Invalid.
+  /// @{
+  Result<bool> as_bool() const;
+  Result<int8_t> as_int8() const;
+  Result<int16_t> as_int16() const;
+  Result<int32_t> as_int32() const;
+  Result<int64_t> as_int64() const;
+  Result<float> as_float() const;
+  Result<double> as_double() const;
+  Result<std::string_view> as_string() const;
+  Result<std::string_view> as_binary() const;
+  Result<int32_t> as_date() const;
+  Result<int64_t> as_timestamp_micros() const;
+  Result<int64_t> as_timestamp_micros_ntz() const;
+  Result<int64_t> as_timestamp_nanos() const;
+  Result<int64_t> as_timestamp_nanos_ntz() const;
+  Result<int64_t> as_time_ntz() const;
+  /// @}
+
+  /// @name Widening numeric accessors (Rust parity)
+  /// These coerce narrower integer types to a wider target type.
+  /// e.g., as_int64_coerced() succeeds on Int8, Int16, Int32, or Int64 values.
+  /// @{
+
+  /// \brief Read any integer variant as int64, widening if necessary.
+  /// Succeeds for Int8, Int16, Int32, and Int64 encoded values.
+  Result<int64_t> as_int64_coerced() const;
+
+  /// \brief Read any integer variant as int32, widening if necessary.
+  /// Succeeds for Int8 and Int16 and Int32 encoded values.
+  /// Returns Invalid for Int64 (would narrow).
+  Result<int32_t> as_int32_coerced() const;
+
+  /// \brief Read any numeric variant as double, coercing if necessary.
+  /// Succeeds for Int8, Int16, Int32, Int64, Float, and Double.
+  /// Note: Int64 -> double may lose precision for large values.
+  Result<double> as_double_coerced() const;
+  /// @}
+
+  /// \brief Access UUID value (16 bytes, big-endian).
+  /// Returns pointer to the 16 UUID bytes within the source buffer.
+  Result<const uint8_t*> as_uuid() const;
+
+  /// \brief Access Decimal4 (scale + 4 bytes unscaled value).
+  /// \param[out] scale Set to the decimal scale
+  /// \return Pointer to the 4 unscaled value bytes
+  Result<const uint8_t*> as_decimal4(int32_t* scale) const;
+
+  /// \brief Access Decimal8 (scale + 8 bytes unscaled value).
+  Result<const uint8_t*> as_decimal8(int32_t* scale) const;
+
+  /// \brief Access Decimal16 (scale + 16 bytes unscaled value).
+  Result<const uint8_t*> as_decimal16(int32_t* scale) const;
+  /// @}
+
+  /// @name Container accessors
+  /// @{
+
+  /// \brief Interpret this value as an object.
+  /// Returns Invalid if the basic type is not kObject.
+  Result<VariantObjectView> as_object() const;
+
+  /// \brief Interpret this value as an array.
+  /// Returns Invalid if the basic type is not kArray.
+  Result<VariantArrayView> as_array() const;
+  /// @}
+
+  /// @name Visitor traversal
+  /// @{
+
+  /// \brief Full recursive traversal via visitor pattern.
+  ///
+  /// Visits every node in the value tree, calling appropriate visitor
+  /// methods. For bulk processing of entire variant values (e.g., JSON
+  /// serialization, schema inference).
+  ///
+  /// \param[in] visitor Callback interface for decoded values
+  /// \return Status::OK on success, or first error from visitor/decode
+  Status Visit(class VariantVisitor* visitor) const;
+  /// @}
+
+ private:
+  VariantView(const VariantMetadata* metadata, const uint8_t* data, int64_t size,
+              BasicType type);
+
+  const VariantMetadata* metadata_;
+  const uint8_t* data_;
+  int64_t size_;
+  BasicType type_;
+};
+
+// ---------------------------------------------------------------------------
+// VariantObjectView — pre-parsed object for O(log n) field lookup
+// ---------------------------------------------------------------------------
+
+/// \brief A non-owning view over a variant object value with pre-parsed header.
+///
+/// Construction validates the object header structure (field counts, array
+/// bounds). After construction, field lookup is O(log n) via binary search
+/// with no redundant parsing.
+///
+/// Stack-allocated, ~72 bytes. No heap allocation.
+///
+/// \note The metadata and data buffers must outlive this view.
+class ARROW_EXPORT VariantObjectView {
+ public:
+  /// \brief Construct an object view, pre-parsing the header.
+  ///
+  /// Validates:
+  ///   1. Basic type is kObject
+  ///   2. num_fields is readable
+  ///   3. Field ID array fits in buffer
+  ///   4. Offset array fits in buffer
+  ///   5. Last offset (total data size) is within buffer
+  ///
+  /// After Make() succeeds, all field accessors are bounds-safe.
+  static Result<VariantObjectView> Make(const VariantMetadata& metadata,
+                                        const uint8_t* data, int64_t length);
+
+  /// \brief Number of fields in this object.
+  int32_t num_fields() const { return num_fields_; }
+
+  /// \brief Get the name of the i-th field (0-indexed).
+  /// \return The field name, or Invalid if index is out of range or
+  ///         field ID references an invalid dictionary entry.
+  Result<std::string_view> field_name(int32_t index) const;
+
+  /// \brief Get the value of the i-th field (0-indexed).
+  /// \return A VariantView over the field's value.
+  Result<VariantView> field_value(int32_t index) const;
+
+  /// \brief Lookup a field by name using binary search.
+  ///
+  /// Per spec, field IDs are sorted by lexicographic order of their
+  /// corresponding key names. This enables O(log n) lookup for all
+  /// object sizes.
+  ///
+  /// \param[in] name The field name to search for
+  /// \return The field's value if found, or std::nullopt if not present.
+  ///
+  /// \note Returns std::nullopt for both "field not found" AND "malformed data"
+  ///       (e.g., field ID exceeds dictionary, or field value bytes are truncated).
+  ///       For untrusted data where error reporting is needed, use field_name(i)
+  ///       and field_value(i) directly which return Result<T>.
+  std::optional<VariantView> get(std::string_view name) const;
+
+  /// \brief Check if a field exists by name.
+  bool contains(std::string_view name) const;
+
+  /// \brief Location of a field's value bytes within the object buffer.
+  struct FieldLocation {
+    int64_t offset;  ///< Byte offset from object start to field value
+    int64_t size;    ///< Byte size of the field value
+  };
+
+  /// \brief Locate a field's raw bytes by name without constructing a view.
+  ///
+  /// Useful for zero-copy extraction when you need the offset+size for
+  /// raw byte operations (e.g., shredding's UnsafeAppendEncoded).
+  ///
+  /// \param[in] name The field name to search for
+  /// \return The field location, or std::nullopt if not present.
+  std::optional<FieldLocation> locate(std::string_view name) const;
+
+  /// @name Iteration support
+  /// @{
+
+  /// \brief Iterator over (name, value) pairs.
+  ///
+  /// \warning Iteration uses ValueOrDie() internally. If the object contains
+  ///          malformed field data (corrupt value bytes), dereferencing the
+  ///          iterator will abort. Use field_name(i)/field_value(i) for
+  ///          error-safe access on untrusted data.
+  class Iterator {
+   public:
+    using value_type = std::pair<std::string_view, VariantView>;
+
+    Iterator(const VariantObjectView* obj, int32_t index);
+
+    value_type operator*() const;
+    Iterator& operator++();
+    bool operator!=(const Iterator& other) const;
+
+   private:
+    const VariantObjectView* obj_;
+    int32_t index_;
+  };
+
+  Iterator begin() const;
+  Iterator end() const;
+  /// @}
+
+ private:
+  VariantObjectView(const VariantMetadata* metadata, const uint8_t* data, int64_t length,
+                    int32_t num_fields, int8_t field_id_size, int8_t field_offset_size,
+                    int64_t id_start, int64_t offset_start, int64_t data_start);
+
+  /// \brief Read the field ID at position i.
+  uint32_t field_id_at(int32_t i) const;
+
+  /// \brief Read the value offset at position i.
+  int64_t value_offset_at(int32_t i) const;
+
+  const VariantMetadata* metadata_;
+  const uint8_t* data_;
+  int64_t length_;
+  int32_t num_fields_;
+  int8_t field_id_size_;
+  int8_t field_offset_size_;
+  int64_t id_start_;
+  int64_t offset_start_;
+  int64_t data_start_;
+};
+
+// ---------------------------------------------------------------------------
+// VariantArrayView — pre-parsed array for O(1) element access
+// ---------------------------------------------------------------------------
+
+/// \brief A non-owning view over a variant array value with pre-parsed header.
+///
+/// Construction validates the array header structure. After construction,
+/// element access is O(1) via the pre-computed offset table.
+///
+/// Stack-allocated, ~56 bytes. No heap allocation.
+class ARROW_EXPORT VariantArrayView {
+ public:
+  /// \brief Construct an array view, pre-parsing the header.
+  ///
+  /// Validates:
+  ///   1. Basic type is kArray
+  ///   2. num_elements is readable
+  ///   3. Offset array fits in buffer
+  ///   4. Offsets are monotonically non-decreasing
+  ///   5. Last offset is within buffer
+  static Result<VariantArrayView> Make(const VariantMetadata& metadata,
+                                       const uint8_t* data, int64_t length);
+
+  /// \brief Number of elements in this array.
+  int32_t num_elements() const { return num_elements_; }
+
+  /// \brief Get the i-th element (0-indexed, O(1) access).
+  /// \return A VariantView over the element, or Invalid if index is out of range.
+  Result<VariantView> get(int32_t index) const;
+
+  /// @name Iteration support
+  /// @{
+
+  /// \warning Iteration uses ValueOrDie() internally. If the array contains
+  ///          malformed element data, dereferencing the iterator will abort.
+  ///          Use get(i) for error-safe access on untrusted data.
+  class Iterator {
+   public:
+    using value_type = VariantView;
+
+    Iterator(const VariantArrayView* arr, int32_t index);
+
+    value_type operator*() const;
+    Iterator& operator++();
+    bool operator!=(const Iterator& other) const;
+
+   private:
+    const VariantArrayView* arr_;
+    int32_t index_;
+  };
+
+  Iterator begin() const;
+  Iterator end() const;
+  /// @}
+
+ private:
+  VariantArrayView(const VariantMetadata* metadata, const uint8_t* data, int64_t length,
+                   int32_t num_elements, int8_t offset_size, int64_t offset_start,
+                   int64_t data_start);
+
+  /// \brief Read the element offset at position i.
+  int64_t element_offset_at(int32_t i) const;
+
+  const VariantMetadata* metadata_;
+  const uint8_t* data_;
+  int64_t length_;
+  int32_t num_elements_;
+  int8_t offset_size_;
+  int64_t offset_start_;
+  int64_t data_start_;
+};
+
+// ---------------------------------------------------------------------------
+// Visitor interface (for full tree traversal)
+// ---------------------------------------------------------------------------
+
+/// \brief Visitor interface for variant value traversal (SAX-style).
+///
+/// Implement this interface to receive callbacks during recursive variant
+/// value traversal. Use VariantView::Visit() to drive the traversal.
+///
+/// For point-queries (reading a specific field), use the view classes
+/// directly instead. The visitor is for bulk operations that need to
+/// process every node in the tree.
+///
+/// \note String values are raw bytes without UTF-8 validation.
+class ARROW_EXPORT VariantVisitor {
+ public:
+  virtual ~VariantVisitor() = default;
+
+  /// @name Primitive value callbacks
+  /// @{
+  virtual Status Null() = 0;
+  virtual Status Bool(bool value) = 0;
+  virtual Status Int8(int8_t value) = 0;
+  virtual Status Int16(int16_t value) = 0;
+  virtual Status Int32(int32_t value) = 0;
+  virtual Status Int64(int64_t value) = 0;
+  virtual Status Float(float value) = 0;
+  virtual Status Double(double value) = 0;
+  virtual Status Decimal4(const uint8_t* bytes, int32_t scale) = 0;
+  virtual Status Decimal8(const uint8_t* bytes, int32_t scale) = 0;
+  virtual Status Decimal16(const uint8_t* bytes, int32_t scale) = 0;
+  virtual Status Date(int32_t days_since_epoch) = 0;
+  virtual Status TimestampMicros(int64_t micros_since_epoch) = 0;
+  virtual Status TimestampMicrosNTZ(int64_t micros_since_epoch) = 0;
+  virtual Status String(std::string_view value) = 0;
+  virtual Status Binary(std::string_view value) = 0;
+  virtual Status TimeNTZ(int64_t micros_since_midnight) = 0;
+  virtual Status TimestampNanos(int64_t nanos_since_epoch) = 0;
+  virtual Status TimestampNanosNTZ(int64_t nanos_since_epoch) = 0;
+  virtual Status UUID(const uint8_t* bytes) = 0;
+  /// @}
+
+  /// @name Container callbacks
+  /// @{
+  virtual Status StartObject(int32_t num_fields) = 0;
+  virtual Status FieldName(std::string_view name) = 0;
+  virtual Status EndObject() = 0;
+  virtual Status StartArray(int32_t num_elements) = 0;
+  virtual Status EndArray() = 0;
+  /// @}
+};
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant.h
+++ b/cpp/src/arrow/extension/variant.h
@@ -678,8 +678,15 @@ class ARROW_EXPORT VariantBuilder {
   void Reset();
   /// @}
 
+  /// @name Shredding support (GH-45948)
+  /// @{
+  Result<std::vector<uint8_t>> BuildWithoutMeta();
+  void UnsafeAppendEncoded(const uint8_t* data, int64_t size);
+  void SetAllowDuplicates(bool allow);
+  /// @}
+
   /// @name Internal (used by scopes and shredding)
-  /// @name Internal (used by scopes)
+  /// @{
   void Truncate(int64_t offset);
   /// @}
 

--- a/cpp/src/arrow/extension/variant.h
+++ b/cpp/src/arrow/extension/variant.h
@@ -32,9 +32,11 @@
 ///   - O(log n) field lookup always (no threshold heuristics)
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "arrow/result.h"
@@ -56,6 +58,17 @@ constexpr int32_t kMaxNestingDepth = 128;
 
 /// UUID values are always 16 bytes (128-bit, big-endian per RFC 4122).
 constexpr int32_t kUUIDByteLength = 16;
+
+/// Maximum length for short-string encoding (6 bits → 0..63).
+/// Strings longer than this use the long-string (4-byte length prefix) format.
+constexpr int32_t kMaxShortStringLength = 63;
+
+/// Maximum supported decimal scale per the variant encoding spec.
+constexpr uint8_t kMaxDecimalScale = 38;
+
+/// Container element count threshold for large encoding.
+/// Objects/arrays with more than 255 elements use 4-byte num_elements fields.
+constexpr int32_t kLargeContainerThreshold = 255;
 
 // ---------------------------------------------------------------------------
 // Enumerations
@@ -578,6 +591,224 @@ class ARROW_EXPORT VariantVisitor {
   virtual Status StartArray(int32_t num_elements) = 0;
   virtual Status EndArray() = 0;
   /// @}
+};
+
+// ---------------------------------------------------------------------------
+// VariantBuilder (encoder)
+// ---------------------------------------------------------------------------
+
+class ObjectScope;
+class ListScope;
+
+/// \brief Builder for constructing Variant binary values.
+///
+/// Provides both low-level (Offset/NextField/FinishObject) and high-level
+/// (StartObject/StartList returning RAII scopes) APIs for encoding.
+class ARROW_EXPORT VariantBuilder {
+ public:
+  VariantBuilder();
+  explicit VariantBuilder(const VariantMetadata& existing_metadata);
+  ~VariantBuilder() = default;
+
+  VariantBuilder(VariantBuilder&&) noexcept = default;
+  VariantBuilder& operator=(VariantBuilder&&) noexcept = default;
+  VariantBuilder(const VariantBuilder&) = delete;
+  VariantBuilder& operator=(const VariantBuilder&) = delete;
+
+  /// @name Primitive value setters
+  /// @{
+  Status Null();
+  Status Bool(bool value);
+  Status Int(int64_t value);  ///< Auto-selects smallest int type
+  Status Int8(int8_t value);
+  Status Int16(int16_t value);
+  Status Int32(int32_t value);
+  Status Int64(int64_t value);
+  Status Float(float value);
+  Status Double(double value);
+  Status Decimal4(uint8_t scale, const uint8_t* value_bytes);
+  Status Decimal8(uint8_t scale, const uint8_t* value_bytes);
+  Status Decimal16(uint8_t scale, const uint8_t* value_bytes);
+  Status Date(int32_t days_since_epoch);
+  Status TimestampMicros(int64_t micros);
+  Status TimestampMicrosNTZ(int64_t micros);
+  Status TimeNTZ(int64_t micros);
+  Status TimestampNanos(int64_t nanos);
+  Status TimestampNanosNTZ(int64_t nanos);
+  Status String(std::string_view value);  ///< Auto short-string for <=63 bytes
+  Status Binary(std::string_view value);
+  Status UUID(const uint8_t* bytes);
+  /// @}
+
+  /// @name Low-level container construction
+  /// @{
+  int64_t Offset() const;
+  int64_t NextElement(int64_t start) const;
+
+  struct FieldEntry {
+    std::string key;
+    uint32_t id;
+    int64_t offset;
+  };
+
+  FieldEntry NextField(int64_t start, std::string_view key);
+  Status FinishArray(int64_t start, const std::vector<int64_t>& offsets);
+  Status FinishObject(int64_t start, std::vector<FieldEntry>& fields);
+  /// @}
+
+  /// @name RAII container construction
+  /// @{
+
+  /// \brief Start building an object. Returns an RAII scope that auto-rolls
+  ///        back if Finish() is not called (e.g., on exception/early return).
+  [[nodiscard]] ObjectScope StartObject();
+
+  /// \brief Start building a list/array. Returns an RAII scope.
+  [[nodiscard]] ListScope StartList();
+  /// @}
+
+  /// @name Output
+  /// @{
+  struct EncodedVariant {
+    std::vector<uint8_t> metadata;
+    std::vector<uint8_t> value;
+  };
+
+  Result<EncodedVariant> Finish();
+  void Reset();
+  /// @}
+
+  /// @name Internal (used by scopes and shredding)
+  /// @name Internal (used by scopes)
+  void Truncate(int64_t offset);
+  /// @}
+
+ private:
+  friend class ObjectScope;
+  friend class ListScope;
+
+  uint32_t AddKey(std::string_view key);
+
+  std::vector<uint8_t> buffer_;
+  /// \brief Dictionary mapping key names to their IDs.
+  /// Uses a custom transparent hasher to allow lookups with string_view
+  /// without constructing a std::string (C++17 heterogeneous lookup).
+  struct StringHash {
+    using is_transparent = void;
+    size_t operator()(std::string_view sv) const noexcept {
+      return std::hash<std::string_view>{}(sv);
+    }
+  };
+  struct StringEqual {
+    using is_transparent = void;
+    bool operator()(std::string_view a, std::string_view b) const noexcept {
+      return a == b;
+    }
+  };
+  std::unordered_map<std::string, uint32_t, StringHash, StringEqual> dict_;
+  std::vector<std::string> dict_keys_;
+  bool allow_duplicates_ = false;
+};
+
+// ---------------------------------------------------------------------------
+// ObjectScope — RAII scoped object builder
+// ---------------------------------------------------------------------------
+
+/// \brief RAII scope for building an object. Destructor rolls back if not committed.
+///
+/// Usage:
+///   auto obj = builder.StartObject();
+///   obj.Insert("name", "Alice");
+///   obj.Insert("age", 30);
+///   obj.Finish();  // commits
+///   // If Finish() not called, destructor truncates buffer to pre-scope state
+class ARROW_EXPORT ObjectScope {
+ public:
+  ~ObjectScope();
+
+  ObjectScope(const ObjectScope&) = delete;
+  ObjectScope& operator=(const ObjectScope&) = delete;
+  ObjectScope(ObjectScope&& other) noexcept;
+  ObjectScope& operator=(ObjectScope&&) = delete;
+
+  /// @name Insert fields (delegates to VariantBuilder primitives)
+  /// @{
+  Status Insert(std::string_view key, std::nullptr_t);
+  Status Insert(std::string_view key, bool value);
+  Status Insert(std::string_view key, int64_t value);
+  Status Insert(std::string_view key, double value);
+  Status Insert(std::string_view key, std::string_view value);
+
+  /// \brief Insert a nested object. Returns an RAII scope for the sub-object.
+  [[nodiscard]] ObjectScope InsertObject(std::string_view key);
+
+  /// \brief Insert a nested list. Returns an RAII scope for the sub-list.
+  [[nodiscard]] ListScope InsertList(std::string_view key);
+  /// @}
+
+  /// \brief Commit the object (sorts fields, writes header).
+  Status Finish();
+
+ private:
+  friend class VariantBuilder;
+  friend class ListScope;
+
+  explicit ObjectScope(VariantBuilder& parent);
+
+  VariantBuilder* parent_;
+  int64_t start_offset_;
+  std::vector<VariantBuilder::FieldEntry> fields_;
+  bool committed_ = false;
+};
+
+// ---------------------------------------------------------------------------
+// ListScope — RAII scoped list/array builder
+// ---------------------------------------------------------------------------
+
+/// \brief RAII scope for building a list. Destructor rolls back if not committed.
+///
+/// Usage:
+///   auto list = builder.StartList();
+///   list.Append(1);
+///   list.Append(2);
+///   list.Finish();
+class ARROW_EXPORT ListScope {
+ public:
+  ~ListScope();
+
+  ListScope(const ListScope&) = delete;
+  ListScope& operator=(const ListScope&) = delete;
+  ListScope(ListScope&& other) noexcept;
+  ListScope& operator=(ListScope&&) = delete;
+
+  /// @name Append elements
+  /// @{
+  Status Append(std::nullptr_t);
+  Status Append(bool value);
+  Status Append(int64_t value);
+  Status Append(double value);
+  Status Append(std::string_view value);
+
+  /// \brief Append a nested object. Returns an RAII scope.
+  [[nodiscard]] ObjectScope AppendObject();
+
+  /// \brief Append a nested list. Returns an RAII scope.
+  [[nodiscard]] ListScope AppendList();
+  /// @}
+
+  /// \brief Commit the list (writes header with offsets).
+  Status Finish();
+
+ private:
+  friend class VariantBuilder;
+  friend class ObjectScope;
+
+  explicit ListScope(VariantBuilder& parent);
+
+  VariantBuilder* parent_;
+  int64_t start_offset_;
+  std::vector<int64_t> offsets_;
+  bool committed_ = false;
 };
 
 }  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_builder.cc
+++ b/cpp/src/arrow/extension/variant_builder.cc
@@ -632,4 +632,22 @@ Status ListScope::Finish() {
   return Status::OK();
 }
 
+Result<std::vector<uint8_t>> VariantBuilder::BuildWithoutMeta() {
+  if (buffer_.empty()) {
+    return Status::Invalid("VariantBuilder::BuildWithoutMeta: no value written");
+  }
+  std::vector<uint8_t> result = std::move(buffer_);
+  buffer_.clear();
+  return result;
+}
+
+void VariantBuilder::UnsafeAppendEncoded(const uint8_t* data, int64_t size) {
+  DCHECK_NE(data, nullptr);
+  DCHECK_GT(size, 0);
+  if (size <= 0) return;
+  buffer_.insert(buffer_.end(), data, data + size);
+}
+
+void VariantBuilder::SetAllowDuplicates(bool allow) { allow_duplicates_ = allow; }
+
 }  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_builder.cc
+++ b/cpp/src/arrow/extension/variant_builder.cc
@@ -1,0 +1,635 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/extension/variant.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+#include "arrow/util/endian.h"
+#include "arrow/util/logging_internal.h"
+
+namespace arrow::extension::variant {
+
+namespace {
+
+/// \brief Compute the minimum number of bytes needed to represent a value.
+/// \param[in] value Must be non-negative and fit in 4 bytes (represents a size or ID).
+int32_t IntSize(int64_t value) {
+  DCHECK_GE(value, 0);
+  DCHECK_LE(value, static_cast<int64_t>(std::numeric_limits<uint32_t>::max()));
+  if (value <= 0xFF) return 1;
+  if (value <= 0xFFFF) return 2;
+  if (value <= 0xFFFFFF) return 3;
+  return 4;
+}
+
+/// \brief Write an unsigned integer in little-endian using nbytes bytes.
+void WriteUnsignedLE(uint8_t* buf, int64_t value, int32_t nbytes) {
+  for (int32_t i = 0; i < nbytes; ++i) {
+    buf[i] = static_cast<uint8_t>((value >> (i * 8)) & 0xFF);
+  }
+}
+
+/// \brief Write a little-endian value into a vector at a given position.
+void WriteUnsignedLEAt(std::vector<uint8_t>& buf, int64_t pos, int64_t value,
+                       int32_t nbytes) {
+  for (int32_t i = 0; i < nbytes; ++i) {
+    buf[pos + i] = static_cast<uint8_t>((value >> (i * 8)) & 0xFF);
+  }
+}
+
+/// \brief Construct a primitive header byte.
+uint8_t MakePrimitiveHeader(PrimitiveType type) {
+  return static_cast<uint8_t>(BasicType::kPrimitive) | (static_cast<uint8_t>(type) << 2);
+}
+
+/// \brief Write a fixed-size numeric primitive into the buffer.
+template <typename T>
+void WritePrimitive(std::vector<uint8_t>& buf, PrimitiveType type, T value) {
+  buf.push_back(MakePrimitiveHeader(type));
+  value = bit_util::ToLittleEndian(value);
+  auto ptr = reinterpret_cast<const uint8_t*>(&value);
+  buf.insert(buf.end(), ptr, ptr + sizeof(T));
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// VariantBuilder implementation
+// ---------------------------------------------------------------------------
+
+VariantBuilder::VariantBuilder() = default;
+
+VariantBuilder::VariantBuilder(const VariantMetadata& existing_metadata) {
+  for (int32_t i = 0; i < static_cast<int32_t>(existing_metadata.strings.size()); ++i) {
+    std::string key(existing_metadata.strings[i]);
+    dict_[key] = static_cast<uint32_t>(i);
+    dict_keys_.push_back(std::move(key));
+  }
+}
+
+uint32_t VariantBuilder::AddKey(std::string_view key) {
+  // Transparent hasher allows direct string_view lookup without constructing
+  // a std::string. This eliminates per-call allocation/copy for existing keys.
+  auto it = dict_.find(key);
+  if (it != dict_.end()) {
+    return it->second;
+  }
+  // Key is new — insert into the dictionary.
+  auto id = static_cast<uint32_t>(dict_keys_.size());
+  dict_keys_.emplace_back(key);
+  dict_.emplace(dict_keys_.back(), id);
+  return id;
+}
+
+void VariantBuilder::Reset() {
+  buffer_.clear();
+  dict_.clear();
+  dict_keys_.clear();
+}
+
+int64_t VariantBuilder::Offset() const { return static_cast<int64_t>(buffer_.size()); }
+
+int64_t VariantBuilder::NextElement(int64_t start) const { return Offset() - start; }
+
+VariantBuilder::FieldEntry VariantBuilder::NextField(int64_t start,
+                                                     std::string_view key) {
+  auto id = AddKey(key);
+  return FieldEntry{std::string(key), id, Offset() - start};
+}
+
+// --- Primitive setters ---
+
+Status VariantBuilder::Null() {
+  buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kNull));
+  return Status::OK();
+}
+
+Status VariantBuilder::Bool(bool value) {
+  buffer_.push_back(
+      MakePrimitiveHeader(value ? PrimitiveType::kTrue : PrimitiveType::kFalse));
+  return Status::OK();
+}
+
+Status VariantBuilder::Int(int64_t value) {
+  if (value >= std::numeric_limits<int8_t>::min() &&
+      value <= std::numeric_limits<int8_t>::max()) {
+    return Int8(static_cast<int8_t>(value));
+  }
+  if (value >= std::numeric_limits<int16_t>::min() &&
+      value <= std::numeric_limits<int16_t>::max()) {
+    return Int16(static_cast<int16_t>(value));
+  }
+  if (value >= std::numeric_limits<int32_t>::min() &&
+      value <= std::numeric_limits<int32_t>::max()) {
+    return Int32(static_cast<int32_t>(value));
+  }
+  return Int64(value);
+}
+
+Status VariantBuilder::Int8(int8_t value) {
+  buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kInt8));
+  buffer_.push_back(static_cast<uint8_t>(value));
+  return Status::OK();
+}
+
+Status VariantBuilder::Int16(int16_t value) {
+  WritePrimitive(buffer_, PrimitiveType::kInt16, value);
+  return Status::OK();
+}
+
+Status VariantBuilder::Int32(int32_t value) {
+  WritePrimitive(buffer_, PrimitiveType::kInt32, value);
+  return Status::OK();
+}
+
+Status VariantBuilder::Int64(int64_t value) {
+  WritePrimitive(buffer_, PrimitiveType::kInt64, value);
+  return Status::OK();
+}
+
+Status VariantBuilder::Float(float value) {
+  WritePrimitive(buffer_, PrimitiveType::kFloat, value);
+  return Status::OK();
+}
+
+Status VariantBuilder::Double(double value) {
+  WritePrimitive(buffer_, PrimitiveType::kDouble, value);
+  return Status::OK();
+}
+
+Status VariantBuilder::Date(int32_t days_since_epoch) {
+  WritePrimitive(buffer_, PrimitiveType::kDate, days_since_epoch);
+  return Status::OK();
+}
+
+Status VariantBuilder::TimestampMicros(int64_t micros) {
+  WritePrimitive(buffer_, PrimitiveType::kTimestampMicros, micros);
+  return Status::OK();
+}
+
+Status VariantBuilder::TimestampMicrosNTZ(int64_t micros) {
+  WritePrimitive(buffer_, PrimitiveType::kTimestampMicrosNTZ, micros);
+  return Status::OK();
+}
+
+Status VariantBuilder::TimeNTZ(int64_t micros) {
+  WritePrimitive(buffer_, PrimitiveType::kTimeNTZ, micros);
+  return Status::OK();
+}
+
+Status VariantBuilder::TimestampNanos(int64_t nanos) {
+  WritePrimitive(buffer_, PrimitiveType::kTimestampNanos, nanos);
+  return Status::OK();
+}
+
+Status VariantBuilder::TimestampNanosNTZ(int64_t nanos) {
+  WritePrimitive(buffer_, PrimitiveType::kTimestampNanosNTZ, nanos);
+  return Status::OK();
+}
+
+Status VariantBuilder::Decimal4(uint8_t scale, const uint8_t* value_bytes) {
+  if (scale > kMaxDecimalScale) {
+    return Status::Invalid("Variant decimal scale must be in range [0, ",
+                           static_cast<int>(kMaxDecimalScale), "], got ",
+                           static_cast<int>(scale));
+  }
+  buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kDecimal4));
+  buffer_.push_back(scale);
+  buffer_.insert(buffer_.end(), value_bytes, value_bytes + 4);
+  return Status::OK();
+}
+
+Status VariantBuilder::Decimal8(uint8_t scale, const uint8_t* value_bytes) {
+  if (scale > kMaxDecimalScale) {
+    return Status::Invalid("Variant decimal scale must be in range [0, ",
+                           static_cast<int>(kMaxDecimalScale), "], got ",
+                           static_cast<int>(scale));
+  }
+  buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kDecimal8));
+  buffer_.push_back(scale);
+  buffer_.insert(buffer_.end(), value_bytes, value_bytes + 8);
+  return Status::OK();
+}
+
+Status VariantBuilder::Decimal16(uint8_t scale, const uint8_t* value_bytes) {
+  if (scale > kMaxDecimalScale) {
+    return Status::Invalid("Variant decimal scale must be in range [0, ",
+                           static_cast<int>(kMaxDecimalScale), "], got ",
+                           static_cast<int>(scale));
+  }
+  buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kDecimal16));
+  buffer_.push_back(scale);
+  buffer_.insert(buffer_.end(), value_bytes, value_bytes + 16);  // 16-byte unscaled value
+  return Status::OK();
+}
+
+Status VariantBuilder::String(std::string_view value) {
+  if (value.size() <= static_cast<size_t>(kMaxShortStringLength)) {
+    // Short string: length encoded in header bits 2-7
+    uint8_t header = static_cast<uint8_t>(BasicType::kShortString) |
+                     (static_cast<uint8_t>(value.size()) << 2);
+    buffer_.push_back(header);
+  } else {
+    // Long string: primitive type kString + 4-byte LE length
+    buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kString));
+    auto len = static_cast<uint32_t>(value.size());
+    len = bit_util::ToLittleEndian(len);
+    auto ptr = reinterpret_cast<const uint8_t*>(&len);
+    buffer_.insert(buffer_.end(), ptr, ptr + 4);
+  }
+  buffer_.insert(buffer_.end(), value.begin(), value.end());
+  return Status::OK();
+}
+
+Status VariantBuilder::Binary(std::string_view value) {
+  buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kBinary));
+  auto len = static_cast<uint32_t>(value.size());
+  len = bit_util::ToLittleEndian(len);
+  auto ptr = reinterpret_cast<const uint8_t*>(&len);
+  buffer_.insert(buffer_.end(), ptr, ptr + 4);
+  buffer_.insert(buffer_.end(), value.begin(), value.end());
+  return Status::OK();
+}
+
+Status VariantBuilder::UUID(const uint8_t* bytes) {
+  buffer_.push_back(MakePrimitiveHeader(PrimitiveType::kUUID));
+  buffer_.insert(buffer_.end(), bytes, bytes + kUUIDByteLength);
+  return Status::OK();
+}
+
+// --- Container construction ---
+
+Status VariantBuilder::FinishArray(int64_t start, const std::vector<int64_t>& offsets) {
+  // Note: offset fields are at most 4 bytes, so individual variant values
+  // cannot exceed ~4GB. This is not validated here; such values are not
+  // practically expected (Parquet row group sizes are bounded well below this).
+  auto data_size = Offset() - start;
+  if (data_size < 0) {
+    return Status::Invalid("VariantBuilder::FinishArray: invalid start position");
+  }
+
+  auto num_elements = static_cast<int64_t>(offsets.size());
+  bool is_large = num_elements > kLargeContainerThreshold;
+  int32_t size_bytes = is_large ? 4 : 1;
+  int32_t offset_size = IntSize(data_size);
+  int64_t header_size = 1 + size_bytes + (num_elements + 1) * offset_size;
+
+  // Validate offsets are non-negative (caller-provided)
+  for (int64_t i = 0; i < num_elements; ++i) {
+    if (offsets[i] < 0) {
+      return Status::Invalid("VariantBuilder::FinishArray: negative offset at index ", i);
+    }
+  }
+
+  // Shift existing data to make room for the header
+  buffer_.resize(buffer_.size() + header_size);
+  std::memmove(buffer_.data() + start + header_size, buffer_.data() + start, data_size);
+
+  // Write header byte
+  uint8_t header = static_cast<uint8_t>(BasicType::kArray) |
+                   (static_cast<uint8_t>(offset_size - 1) << 2);
+  if (is_large) {
+    header |= (1 << 4);
+  }
+  buffer_[start] = header;
+
+  // Write num_elements
+  WriteUnsignedLEAt(buffer_, start + 1, num_elements, size_bytes);
+
+  // Write offsets
+  int64_t offset_pos = start + 1 + size_bytes;
+  for (int64_t i = 0; i < num_elements; ++i) {
+    WriteUnsignedLEAt(buffer_, offset_pos + i * offset_size, offsets[i], offset_size);
+  }
+  // Last offset = total data size
+  WriteUnsignedLEAt(buffer_, offset_pos + num_elements * offset_size, data_size,
+                    offset_size);
+
+  return Status::OK();
+}
+
+Status VariantBuilder::FinishObject(int64_t start, std::vector<FieldEntry>& fields) {
+  auto data_size = Offset() - start;
+  if (data_size < 0) {
+    return Status::Invalid("VariantBuilder::FinishObject: invalid start position");
+  }
+
+  // Sort fields by key name lexicographically (spec requirement).
+  // Skip the sort if fields are already in order (common for schema-driven insertion).
+  if (!std::is_sorted(
+          fields.begin(), fields.end(),
+          [](const FieldEntry& a, const FieldEntry& b) { return a.key < b.key; })) {
+    std::sort(fields.begin(), fields.end(),
+              [](const FieldEntry& a, const FieldEntry& b) { return a.key < b.key; });
+  }
+
+  // Handle duplicate keys: reject by default, deduplicate if allowed.
+  // When allow_duplicates_ is true (used by shredding reconstruction where
+  // shredded fields and residual fields may overlap on malformed input),
+  // last-value-wins semantics are applied. After sort, duplicates are adjacent;
+  // we keep the last entry for each key group.
+  if (!allow_duplicates_) {
+    for (size_t i = 1; i < fields.size(); ++i) {
+      if (fields[i].key == fields[i - 1].key) {
+        return Status::Invalid("VariantBuilder: duplicate key '", fields[i].key, "'");
+      }
+    }
+  } else {
+    // Last-value-wins: for adjacent duplicates after sort, keep the last one.
+    // Since std::unique keeps the FIRST of each group, we reverse-iterate.
+    size_t write = 0;
+    for (size_t i = 0; i < fields.size(); ++i) {
+      // If next entry has same key, skip this one (keep the later one)
+      if (i + 1 < fields.size() && fields[i].key == fields[i + 1].key) {
+        continue;
+      }
+      if (write != i) {
+        fields[write] = std::move(fields[i]);
+      }
+      ++write;
+    }
+    fields.resize(write);
+  }
+
+  auto num_fields = static_cast<int64_t>(fields.size());
+  bool is_large = num_fields > kLargeContainerThreshold;
+  int32_t size_bytes = is_large ? 4 : 1;
+
+  // Compute id_size from max dictionary ID
+  uint32_t max_id = 0;
+  for (const auto& f : fields) {
+    max_id = std::max(max_id, f.id);
+  }
+  int32_t id_size = IntSize(static_cast<int64_t>(max_id));
+  int32_t offset_size = IntSize(data_size);
+
+  int64_t header_size =
+      1 + size_bytes + num_fields * id_size + (num_fields + 1) * offset_size;
+
+  // Shift existing data to make room for the header
+  buffer_.resize(buffer_.size() + header_size);
+  std::memmove(buffer_.data() + start + header_size, buffer_.data() + start, data_size);
+
+  // Write header byte: basic_type=2, offset_size in bits 2-3, id_size in bits 4-5,
+  //                    is_large in bit 6
+  uint8_t header = static_cast<uint8_t>(BasicType::kObject) |
+                   (static_cast<uint8_t>(offset_size - 1) << 2) |
+                   (static_cast<uint8_t>(id_size - 1) << 4);
+  if (is_large) {
+    header |= (1 << 6);
+  }
+  buffer_[start] = header;
+
+  // Write num_fields
+  WriteUnsignedLEAt(buffer_, start + 1, num_fields, size_bytes);
+
+  // Write field IDs (sorted by key)
+  int64_t id_pos = start + 1 + size_bytes;
+  for (int64_t i = 0; i < num_fields; ++i) {
+    WriteUnsignedLEAt(buffer_, id_pos + i * id_size, fields[i].id, id_size);
+  }
+
+  // Write field offsets (sorted by key)
+  int64_t offset_pos = id_pos + num_fields * id_size;
+  for (int64_t i = 0; i < num_fields; ++i) {
+    WriteUnsignedLEAt(buffer_, offset_pos + i * offset_size, fields[i].offset,
+                      offset_size);
+  }
+  // Last offset = total data size
+  WriteUnsignedLEAt(buffer_, offset_pos + num_fields * offset_size, data_size,
+                    offset_size);
+
+  return Status::OK();
+}
+
+Result<VariantBuilder::EncodedVariant> VariantBuilder::Finish() {
+  // Build metadata
+  auto num_keys = static_cast<int32_t>(dict_keys_.size());
+
+  // Compute total string data size
+  int64_t total_string_size = 0;
+  for (const auto& k : dict_keys_) {
+    total_string_size += static_cast<int64_t>(k.size());
+  }
+
+  // Validate sizes fit within the spec's 4-byte offset limit.
+  // Note: Go implementation enforces a stricter 128MB limit (metadataMaxSizeLimit).
+  // We only enforce the spec's 4-byte offset maximum (~4GB), which is the correct
+  // upper bound per the encoding format.
+  if (total_string_size > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+    return Status::Invalid("VariantBuilder: total dictionary string data (",
+                           total_string_size,
+                           " bytes) exceeds maximum representable by 4-byte offsets");
+  }
+
+  // Compute the offset_size: must accommodate both the largest string offset
+  // (total_string_size) and the dictionary_size field itself, since both use
+  // offset_size bytes in the metadata encoding.
+  int32_t offset_size =
+      IntSize(std::max(total_string_size, static_cast<int64_t>(num_keys)));
+
+  // Check if dictionary is sorted.
+  // Uniqueness is guaranteed by dict_ (AddKey prevents duplicates),
+  // so std::is_sorted with default < is sufficient for the "sorted and unique"
+  // semantics required by the spec.
+  // TODO: Cache the sorted state incrementally (check only newly-added keys
+  // against the previous last key) to avoid O(n) rescan on every Finish() call.
+  bool is_sorted = std::is_sorted(dict_keys_.begin(), dict_keys_.end());
+
+  // Build metadata buffer
+  std::vector<uint8_t> metadata;
+  // Header byte
+  uint8_t meta_header = kVariantVersion;
+  if (is_sorted) {
+    meta_header |= (1 << 4);
+  }
+  meta_header |= static_cast<uint8_t>((offset_size - 1) << 6);
+  metadata.push_back(meta_header);
+
+  // Dictionary size
+  metadata.resize(metadata.size() + offset_size);
+  WriteUnsignedLE(metadata.data() + 1, num_keys, offset_size);
+
+  // String offsets
+  int64_t cur_offset = 0;
+  for (int32_t i = 0; i <= num_keys; ++i) {
+    size_t pos = metadata.size();
+    metadata.resize(pos + offset_size);
+    WriteUnsignedLE(metadata.data() + pos, cur_offset, offset_size);
+    if (i < num_keys) {
+      cur_offset += static_cast<int64_t>(dict_keys_[i].size());
+    }
+  }
+
+  // String data
+  for (const auto& k : dict_keys_) {
+    metadata.insert(metadata.end(), k.begin(), k.end());
+  }
+
+  EncodedVariant result;
+  result.metadata = std::move(metadata);
+  result.value = std::move(buffer_);
+
+  // Note: dict_ and dict_keys_ are intentionally NOT cleared here.
+  // The dictionary is preserved so the builder can encode multiple values
+  // sharing the same key schema without re-adding keys. Call Reset()
+  // explicitly to clear everything.
+  buffer_.clear();
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// VariantBuilder RAII support
+// ---------------------------------------------------------------------------
+
+void VariantBuilder::Truncate(int64_t offset) {
+  buffer_.resize(static_cast<size_t>(offset));
+}
+
+ObjectScope VariantBuilder::StartObject() { return ObjectScope(*this); }
+
+ListScope VariantBuilder::StartList() { return ListScope(*this); }
+
+// ---------------------------------------------------------------------------
+// ObjectScope
+// ---------------------------------------------------------------------------
+
+ObjectScope::ObjectScope(VariantBuilder& parent)
+    : parent_(&parent), start_offset_(parent.Offset()), committed_(false) {}
+
+ObjectScope::ObjectScope(ObjectScope&& other) noexcept
+    : parent_(other.parent_),
+      start_offset_(other.start_offset_),
+      fields_(std::move(other.fields_)),
+      committed_(other.committed_) {
+  other.committed_ = true;  // prevent double-rollback
+}
+
+ObjectScope::~ObjectScope() {
+  if (!committed_ && parent_) {
+    parent_->Truncate(start_offset_);
+  }
+}
+
+Status ObjectScope::Insert(std::string_view key, std::nullptr_t) {
+  fields_.push_back(parent_->NextField(start_offset_, key));
+  return parent_->Null();
+}
+
+Status ObjectScope::Insert(std::string_view key, bool value) {
+  fields_.push_back(parent_->NextField(start_offset_, key));
+  return parent_->Bool(value);
+}
+
+Status ObjectScope::Insert(std::string_view key, int64_t value) {
+  fields_.push_back(parent_->NextField(start_offset_, key));
+  return parent_->Int(value);
+}
+
+Status ObjectScope::Insert(std::string_view key, double value) {
+  fields_.push_back(parent_->NextField(start_offset_, key));
+  return parent_->Double(value);
+}
+
+Status ObjectScope::Insert(std::string_view key, std::string_view value) {
+  fields_.push_back(parent_->NextField(start_offset_, key));
+  return parent_->String(value);
+}
+
+ObjectScope ObjectScope::InsertObject(std::string_view key) {
+  fields_.push_back(parent_->NextField(start_offset_, key));
+  return ObjectScope(*parent_);
+}
+
+ListScope ObjectScope::InsertList(std::string_view key) {
+  fields_.push_back(parent_->NextField(start_offset_, key));
+  return ListScope(*parent_);
+}
+
+Status ObjectScope::Finish() {
+  ARROW_RETURN_NOT_OK(parent_->FinishObject(start_offset_, fields_));
+  committed_ = true;
+  return Status::OK();
+}
+
+// ---------------------------------------------------------------------------
+// ListScope
+// ---------------------------------------------------------------------------
+
+ListScope::ListScope(VariantBuilder& parent)
+    : parent_(&parent), start_offset_(parent.Offset()), committed_(false) {}
+
+ListScope::ListScope(ListScope&& other) noexcept
+    : parent_(other.parent_),
+      start_offset_(other.start_offset_),
+      offsets_(std::move(other.offsets_)),
+      committed_(other.committed_) {
+  other.committed_ = true;  // prevent double-rollback
+}
+
+ListScope::~ListScope() {
+  if (!committed_ && parent_) {
+    parent_->Truncate(start_offset_);
+  }
+}
+
+Status ListScope::Append(std::nullptr_t) {
+  offsets_.push_back(parent_->NextElement(start_offset_));
+  return parent_->Null();
+}
+
+Status ListScope::Append(bool value) {
+  offsets_.push_back(parent_->NextElement(start_offset_));
+  return parent_->Bool(value);
+}
+
+Status ListScope::Append(int64_t value) {
+  offsets_.push_back(parent_->NextElement(start_offset_));
+  return parent_->Int(value);
+}
+
+Status ListScope::Append(double value) {
+  offsets_.push_back(parent_->NextElement(start_offset_));
+  return parent_->Double(value);
+}
+
+Status ListScope::Append(std::string_view value) {
+  offsets_.push_back(parent_->NextElement(start_offset_));
+  return parent_->String(value);
+}
+
+ObjectScope ListScope::AppendObject() {
+  offsets_.push_back(parent_->NextElement(start_offset_));
+  return ObjectScope(*parent_);
+}
+
+ListScope ListScope::AppendList() {
+  offsets_.push_back(parent_->NextElement(start_offset_));
+  return ListScope(*parent_);
+}
+
+Status ListScope::Finish() {
+  ARROW_RETURN_NOT_OK(parent_->FinishArray(start_offset_, offsets_));
+  committed_ = true;
+  return Status::OK();
+}
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_builder_test.cc
+++ b/cpp/src/arrow/extension/variant_builder_test.cc
@@ -1,0 +1,1228 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/extension/variant.h"
+#include "arrow/extension/variant_internal_test_util.h"
+
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow::extension::variant {
+
+namespace {
+
+// Test-local helpers
+Status DecodeVariantValue(const VariantMetadata& metadata, const uint8_t* data,
+                          int64_t length, VariantVisitor* visitor) {
+  ARROW_ASSIGN_OR_RAISE(auto view, VariantView::Make(metadata, data, length));
+  return view.Visit(visitor);
+}
+
+Status FindObjectField(const VariantMetadata& metadata, const uint8_t* data,
+                       int64_t length, std::string_view field_name, int64_t* field_offset,
+                       int64_t* field_size) {
+  *field_offset = -1;
+  *field_size = 0;
+  ARROW_ASSIGN_OR_RAISE(auto obj, VariantObjectView::Make(metadata, data, length));
+  auto result = obj.get(field_name);
+  if (result.has_value()) {
+    *field_offset = result->data() - data;
+    *field_size = result->size_bytes();
+  }
+  return Status::OK();
+}
+
+Status GetArrayElement(const uint8_t* data, int64_t length, int32_t index,
+                       int64_t* element_offset, int64_t* element_size) {
+  VariantMetadata empty_meta;
+  ARROW_ASSIGN_OR_RAISE(auto arr, VariantArrayView::Make(empty_meta, data, length));
+  ARROW_ASSIGN_OR_RAISE(auto elem, arr.get(index));
+  *element_offset = elem.data() - data;
+  *element_size = elem.size_bytes();
+  return Status::OK();
+}
+
+Status GetObjectFieldAt(const VariantMetadata& metadata, const uint8_t* data,
+                        int64_t length, int32_t index, std::string_view* field_name,
+                        int64_t* field_offset, int64_t* field_size) {
+  ARROW_ASSIGN_OR_RAISE(auto obj, VariantObjectView::Make(metadata, data, length));
+  ARROW_ASSIGN_OR_RAISE(*field_name, obj.field_name(index));
+  ARROW_ASSIGN_OR_RAISE(auto value, obj.field_value(index));
+  *field_offset = value.data() - data;
+  *field_size = value.size_bytes();
+  return Status::OK();
+}
+
+Result<int32_t> GetObjectFieldCount(const uint8_t* data, int64_t length) {
+  VariantMetadata empty_meta;
+  ARROW_ASSIGN_OR_RAISE(auto obj, VariantObjectView::Make(empty_meta, data, length));
+  return obj.num_fields();
+}
+
+}  // namespace
+
+// ===========================================================================
+// Helper: decode an EncodedVariant and return visitor events
+// ===========================================================================
+
+/// Encode with builder, decode, return events.
+/// Note: Uses .ValueOrDie() because ASSERT_OK_AND_ASSIGN cannot be used
+/// in a non-void function. Test-only; will crash with a descriptive message
+/// on failure rather than producing a clean test failure.
+std::vector<std::string> RoundTrip(VariantBuilder& builder) {
+  auto result = builder.Finish().ValueOrDie();
+  auto metadata =
+      DecodeMetadata(result.metadata.data(), static_cast<int64_t>(result.metadata.size()))
+          .ValueOrDie();
+  RecordingVisitor visitor;
+  auto status = DecodeVariantValue(metadata, result.value.data(),
+                                   static_cast<int64_t>(result.value.size()), &visitor);
+  EXPECT_TRUE(status.ok()) << "DecodeVariantValue failed: " << status.ToString();
+  return visitor.events;
+}
+
+// ===========================================================================
+// Primitive round-trip tests
+// ===========================================================================
+
+class VariantBuilderPrimitiveTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderPrimitiveTest, Null) {
+  VariantBuilder b;
+  ASSERT_OK(b.Null());
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Null");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, BoolTrue) {
+  VariantBuilder b;
+  ASSERT_OK(b.Bool(true));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Bool(true)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, BoolFalse) {
+  VariantBuilder b;
+  ASSERT_OK(b.Bool(false));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Bool(false)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, IntAutoSizesInt8) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(42));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int8(42)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, IntAutoSizesInt16) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(300));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int16(300)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, IntAutoSizesInt32) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(100000));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int32(100000)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, IntAutoSizesInt64) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(5000000000LL));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int64(5000000000)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, IntNegative) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(-42));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int8(-42)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, ShortString) {
+  VariantBuilder b;
+  ASSERT_OK(b.String("hello"));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "String(\"hello\")");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, LongString) {
+  std::string long_str(100, 'x');
+  VariantBuilder b;
+  ASSERT_OK(b.String(long_str));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "String(\"" + long_str + "\")");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, ShortStringBoundary63) {
+  std::string str63(63, 'a');
+  VariantBuilder b;
+  ASSERT_OK(b.String(str63));
+  ASSERT_OK_AND_ASSIGN(auto result, b.Finish());
+  // Should use short string encoding: 1 byte header + 63 bytes
+  ASSERT_EQ(result.value.size(), 64);
+}
+
+TEST_F(VariantBuilderPrimitiveTest, LongStringBoundary64) {
+  std::string str64(64, 'a');
+  VariantBuilder b;
+  ASSERT_OK(b.String(str64));
+  ASSERT_OK_AND_ASSIGN(auto result, b.Finish());
+  // Should use long string encoding: 1 byte header + 4 byte length + 64 bytes
+  ASSERT_EQ(result.value.size(), 69);
+}
+
+TEST_F(VariantBuilderPrimitiveTest, Date) {
+  VariantBuilder b;
+  ASSERT_OK(b.Date(19000));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Date(19000)");
+}
+
+TEST_F(VariantBuilderPrimitiveTest, Double) {
+  VariantBuilder b;
+  ASSERT_OK(b.Double(3.14));
+  auto events = RoundTrip(b);
+  ASSERT_TRUE(events[0].find("Double(") == 0);
+}
+
+// ===========================================================================
+// Array round-trip tests
+// ===========================================================================
+
+class VariantBuilderArrayTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderArrayTest, EmptyArray) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<int64_t> offsets;
+  ASSERT_OK(b.FinishArray(start, offsets));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events.size(), 2);
+  ASSERT_EQ(events[0], "StartArray(0)");
+  ASSERT_EQ(events[1], "EndArray");
+}
+
+TEST_F(VariantBuilderArrayTest, SimpleArray) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<int64_t> offsets;
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Int(1));
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Int(2));
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Int(3));
+  ASSERT_OK(b.FinishArray(start, offsets));
+
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events.size(), 5);
+  ASSERT_EQ(events[0], "StartArray(3)");
+  ASSERT_EQ(events[1], "Int8(1)");
+  ASSERT_EQ(events[2], "Int8(2)");
+  ASSERT_EQ(events[3], "Int8(3)");
+  ASSERT_EQ(events[4], "EndArray");
+}
+
+TEST_F(VariantBuilderArrayTest, NestedArray) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<int64_t> offsets;
+
+  // First element: nested array [10, 20]
+  offsets.push_back(b.NextElement(start));
+  auto inner_start = b.Offset();
+  std::vector<int64_t> inner_offsets;
+  inner_offsets.push_back(b.NextElement(inner_start));
+  ASSERT_OK(b.Int(10));
+  inner_offsets.push_back(b.NextElement(inner_start));
+  ASSERT_OK(b.Int(20));
+  ASSERT_OK(b.FinishArray(inner_start, inner_offsets));
+
+  // Second element: 30
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Int(30));
+
+  ASSERT_OK(b.FinishArray(start, offsets));
+
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "StartArray(2)");
+  ASSERT_EQ(events[1], "StartArray(2)");
+  ASSERT_EQ(events[2], "Int8(10)");
+  ASSERT_EQ(events[3], "Int8(20)");
+  ASSERT_EQ(events[4], "EndArray");
+  ASSERT_EQ(events[5], "Int8(30)");
+  ASSERT_EQ(events[6], "EndArray");
+}
+
+// ===========================================================================
+// Object round-trip tests
+// ===========================================================================
+
+class VariantBuilderObjectTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderObjectTest, EmptyObject) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  ASSERT_OK(b.FinishObject(start, fields));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events.size(), 2);
+  ASSERT_EQ(events[0], "StartObject(0)");
+  ASSERT_EQ(events[1], "EndObject");
+}
+
+TEST_F(VariantBuilderObjectTest, SimpleObject) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "name"));
+  ASSERT_OK(b.String("Alice"));
+  fields.push_back(b.NextField(start, "age"));
+  ASSERT_OK(b.Int(30));
+  ASSERT_OK(b.FinishObject(start, fields));
+
+  auto events = RoundTrip(b);
+  // Fields sorted by key: "age" before "name"
+  ASSERT_EQ(events[0], "StartObject(2)");
+  ASSERT_EQ(events[1], "FieldName(\"age\")");
+  ASSERT_EQ(events[2], "Int8(30)");
+  ASSERT_EQ(events[3], "FieldName(\"name\")");
+  ASSERT_EQ(events[4], "String(\"Alice\")");
+  ASSERT_EQ(events[5], "EndObject");
+}
+
+TEST_F(VariantBuilderObjectTest, NestedObject) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "inner"));
+  {
+    auto inner_start = b.Offset();
+    std::vector<VariantBuilder::FieldEntry> inner_fields;
+    inner_fields.push_back(b.NextField(inner_start, "key"));
+    ASSERT_OK(b.String("value"));
+    ASSERT_OK(b.FinishObject(inner_start, inner_fields));
+  }
+  ASSERT_OK(b.FinishObject(start, fields));
+
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "StartObject(1)");
+  ASSERT_EQ(events[1], "FieldName(\"inner\")");
+  ASSERT_EQ(events[2], "StartObject(1)");
+  ASSERT_EQ(events[3], "FieldName(\"key\")");
+  ASSERT_EQ(events[4], "String(\"value\")");
+  ASSERT_EQ(events[5], "EndObject");
+  ASSERT_EQ(events[6], "EndObject");
+}
+
+TEST_F(VariantBuilderObjectTest, DuplicateKeyError) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "key"));
+  ASSERT_OK(b.Int(1));
+  fields.push_back(b.NextField(start, "key"));
+  ASSERT_OK(b.Int(2));
+  ASSERT_RAISES(Invalid, b.FinishObject(start, fields));
+}
+
+TEST_F(VariantBuilderObjectTest, FieldsSortedByKey) {
+  // Insert fields in reverse order; verify they come out sorted
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "z_last"));
+  ASSERT_OK(b.Int(3));
+  fields.push_back(b.NextField(start, "a_first"));
+  ASSERT_OK(b.Int(1));
+  fields.push_back(b.NextField(start, "m_middle"));
+  ASSERT_OK(b.Int(2));
+  ASSERT_OK(b.FinishObject(start, fields));
+
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[1], "FieldName(\"a_first\")");
+  ASSERT_EQ(events[2], "Int8(1)");
+  ASSERT_EQ(events[3], "FieldName(\"m_middle\")");
+  ASSERT_EQ(events[4], "Int8(2)");
+  ASSERT_EQ(events[5], "FieldName(\"z_last\")");
+  ASSERT_EQ(events[6], "Int8(3)");
+}
+
+// ===========================================================================
+// Builder features
+// ===========================================================================
+
+class VariantBuilderFeatureTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderFeatureTest, Reset) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(42));
+  auto events1 = RoundTrip(b);
+  ASSERT_EQ(events1[0], "Int8(42)");
+
+  b.Reset();
+  ASSERT_OK(b.String("hello"));
+  auto events2 = RoundTrip(b);
+  ASSERT_EQ(events2[0], "String(\"hello\")");
+}
+
+TEST_F(VariantBuilderFeatureTest, BuilderFromExistingMetadata) {
+  // First, build a variant to get metadata
+  VariantBuilder b1;
+  auto start = b1.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b1.NextField(start, "name"));
+  ASSERT_OK(b1.String("Alice"));
+  ASSERT_OK(b1.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded1, b1.Finish());
+
+  // Decode the metadata
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded1.metadata.data(),
+                                      static_cast<int64_t>(encoded1.metadata.size())));
+
+  // Build a new variant reusing the same metadata
+  VariantBuilder b2(meta);
+  auto start2 = b2.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields2;
+  fields2.push_back(b2.NextField(start2, "name"));
+  ASSERT_OK(b2.String("Bob"));
+  ASSERT_OK(b2.FinishObject(start2, fields2));
+
+  auto events = RoundTrip(b2);
+  ASSERT_EQ(events[1], "FieldName(\"name\")");
+  ASSERT_EQ(events[2], "String(\"Bob\")");
+}
+
+TEST_F(VariantBuilderFeatureTest, MetadataSortedFlag) {
+  // If keys are inserted in sorted order, metadata should have sorted flag
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "alpha"));
+  ASSERT_OK(b.Int(1));
+  fields.push_back(b.NextField(start, "beta"));
+  ASSERT_OK(b.Int(2));
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+  ASSERT_TRUE(meta.is_sorted);
+}
+
+TEST_F(VariantBuilderFeatureTest, MetadataUnsortedFlag) {
+  // If keys are inserted out of order, sorted flag should be false
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "beta"));
+  ASSERT_OK(b.Int(1));
+  fields.push_back(b.NextField(start, "alpha"));
+  ASSERT_OK(b.Int(2));
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+  ASSERT_FALSE(meta.is_sorted);
+}
+
+// ===========================================================================
+// Integration: full round-trip of complex structure
+// ===========================================================================
+
+class VariantBuilderIntegrationTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderIntegrationTest, ComplexObject) {
+  // {"name": "Alice", "scores": [95, 87, 92], "active": true}
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+
+  fields.push_back(b.NextField(start, "name"));
+  ASSERT_OK(b.String("Alice"));
+
+  fields.push_back(b.NextField(start, "scores"));
+  {
+    auto arr_start = b.Offset();
+    std::vector<int64_t> arr_offsets;
+    arr_offsets.push_back(b.NextElement(arr_start));
+    ASSERT_OK(b.Int(95));
+    arr_offsets.push_back(b.NextElement(arr_start));
+    ASSERT_OK(b.Int(87));
+    arr_offsets.push_back(b.NextElement(arr_start));
+    ASSERT_OK(b.Int(92));
+    ASSERT_OK(b.FinishArray(arr_start, arr_offsets));
+  }
+
+  fields.push_back(b.NextField(start, "active"));
+  ASSERT_OK(b.Bool(true));
+
+  ASSERT_OK(b.FinishObject(start, fields));
+
+  auto events = RoundTrip(b);
+  // Fields sorted: "active", "name", "scores"
+  ASSERT_EQ(events[0], "StartObject(3)");
+  ASSERT_EQ(events[1], "FieldName(\"active\")");
+  ASSERT_EQ(events[2], "Bool(true)");
+  ASSERT_EQ(events[3], "FieldName(\"name\")");
+  ASSERT_EQ(events[4], "String(\"Alice\")");
+  ASSERT_EQ(events[5], "FieldName(\"scores\")");
+  ASSERT_EQ(events[6], "StartArray(3)");
+  ASSERT_EQ(events[7], "Int8(95)");
+  ASSERT_EQ(events[8], "Int8(87)");
+  ASSERT_EQ(events[9], "Int8(92)");
+  ASSERT_EQ(events[10], "EndArray");
+  ASSERT_EQ(events[11], "EndObject");
+}
+
+TEST_F(VariantBuilderIntegrationTest, LargeMetadataOffsetSize) {
+  // Build an object with enough unique keys to trigger 2-byte metadata offsets.
+  // 300 keys of ~4 chars each = ~1200 bytes total string data > 255.
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  for (int i = 0; i < 300; ++i) {
+    std::string key = "k" + std::to_string(i);
+    fields.push_back(b.NextField(start, key));
+    ASSERT_OK(b.Int(i));
+  }
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  // Verify metadata can be decoded
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+  ASSERT_EQ(static_cast<int32_t>(meta.strings.size()), 300);
+  // offset_size should be >= 2 (total string data > 255 bytes)
+  ASSERT_GE(meta.offset_size, 2);
+
+  // Verify value can be decoded
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeVariantValue(meta, encoded.value.data(),
+                               static_cast<int64_t>(encoded.value.size()), &visitor));
+  // StartObject(300) + 300*(FieldName + Int8) + EndObject = 602 events
+  ASSERT_EQ(visitor.events.size(), 602);
+  ASSERT_EQ(visitor.events[0], "StartObject(300)");
+  ASSERT_EQ(visitor.events[601], "EndObject");
+}
+
+TEST_F(VariantBuilderIntegrationTest, MetadataOffsetSizeFromKeyCount) {
+  // Verify that offset_size is computed from max(total_string_size, num_keys).
+  // Use 260 single-character keys: total_string_size=260 (>255, needs 2 bytes)
+  // but num_keys=260 also exceeds 255. This ensures the formula handles both.
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  // Generate 260 unique 1-char keys using characters + numeric suffixes
+  for (int i = 0; i < 260; ++i) {
+    // Use 2-char keys to guarantee uniqueness: "a0" through "z9", then "A0"...
+    char c1 = (i < 260) ? static_cast<char>('a' + (i / 10) % 26) : 'A';
+    char c2 = static_cast<char>('0' + (i % 10));
+    std::string key = {c1, c2};
+    fields.push_back(b.NextField(start, key));
+    ASSERT_OK(b.Null());
+  }
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+  // 260 keys of 2 chars = 520 bytes total string data > 255, needs 2-byte offsets
+  ASSERT_GE(meta.offset_size, 2);
+  // Also verify num_keys is correctly stored
+  ASSERT_EQ(static_cast<int32_t>(meta.strings.size()), 260);
+
+  // Verify round-trip
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeVariantValue(meta, encoded.value.data(),
+                               static_cast<int64_t>(encoded.value.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "StartObject(260)");
+}
+
+TEST_F(VariantBuilderIntegrationTest, InvalidStartPosition) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(42));
+  // start=999 is beyond the buffer — should fail
+  std::vector<int64_t> offsets;
+  ASSERT_RAISES(Invalid, b.FinishArray(999, offsets));
+
+  std::vector<VariantBuilder::FieldEntry> fields;
+  ASSERT_RAISES(Invalid, b.FinishObject(999, fields));
+}
+
+TEST_F(VariantBuilderIntegrationTest, NegativeArrayOffsetRejected) {
+  VariantBuilder b;
+  auto start = b.Offset();
+  ASSERT_OK(b.Int(1));
+  std::vector<int64_t> offsets = {-1};
+  ASSERT_RAISES(Invalid, b.FinishArray(start, offsets));
+}
+
+// ===========================================================================
+// Additional primitive round-trip tests (coverage gaps)
+// ===========================================================================
+
+class VariantBuilderPrimitiveExtraTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderPrimitiveExtraTest, FloatRoundTrip) {
+  VariantBuilder b;
+  ASSERT_OK(b.Float(2.5f));
+  auto events = RoundTrip(b);
+  ASSERT_TRUE(events[0].find("Float(") == 0);
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, BinaryRoundTrip) {
+  std::string_view bin_data("\x00\x01\x02\x03", 4);
+  VariantBuilder b;
+  ASSERT_OK(b.Binary(bin_data));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Binary(len=4)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, EmptyBinaryRoundTrip) {
+  VariantBuilder b;
+  ASSERT_OK(b.Binary(""));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Binary(len=0)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, UUIDRoundTrip) {
+  uint8_t uuid_bytes[16];
+  for (int i = 0; i < 16; ++i) uuid_bytes[i] = static_cast<uint8_t>(i + 1);
+  VariantBuilder b;
+  ASSERT_OK(b.UUID(uuid_bytes));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "UUID");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, TimestampMicrosRoundTrip) {
+  VariantBuilder b;
+  ASSERT_OK(b.TimestampMicros(1654041600000000LL));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "TimestampMicros(1654041600000000)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, TimestampMicrosNTZRoundTrip) {
+  VariantBuilder b;
+  ASSERT_OK(b.TimestampMicrosNTZ(1654041600000000LL));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "TimestampMicrosNTZ(1654041600000000)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, TimestampNanosRoundTrip) {
+  VariantBuilder b;
+  ASSERT_OK(b.TimestampNanos(1654041600000000000LL));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "TimestampNanos(1654041600000000000)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, TimestampNanosNTZRoundTrip) {
+  VariantBuilder b;
+  ASSERT_OK(b.TimestampNanosNTZ(1654041600000000000LL));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "TimestampNanosNTZ(1654041600000000000)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, TimeNTZRoundTrip) {
+  VariantBuilder b;
+  ASSERT_OK(b.TimeNTZ(43200000000LL));  // 12:00:00 in microseconds
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "TimeNTZ(43200000000)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, Decimal4RoundTrip) {
+  int32_t val = 12345;
+  uint8_t bytes[4];
+  std::memcpy(bytes, &val, 4);
+  VariantBuilder b;
+  ASSERT_OK(b.Decimal4(2, bytes));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Decimal4(scale=2)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, Decimal8RoundTrip) {
+  int64_t val = 123456789012345LL;
+  uint8_t bytes[8];
+  std::memcpy(bytes, &val, 8);
+  VariantBuilder b;
+  ASSERT_OK(b.Decimal8(5, bytes));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Decimal8(scale=5)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, Decimal16RoundTrip) {
+  uint8_t bytes[16] = {};
+  bytes[0] = 0x01;  // value = 1 in low byte
+  VariantBuilder b;
+  ASSERT_OK(b.Decimal16(10, bytes));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Decimal16(scale=10)");
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, DecimalScaleValidation) {
+  uint8_t bytes[16] = {};
+  VariantBuilder b;
+  // Scale 39 exceeds spec maximum of 38
+  ASSERT_RAISES(Invalid, b.Decimal4(39, bytes));
+  ASSERT_RAISES(Invalid, b.Decimal8(39, bytes));
+  ASSERT_RAISES(Invalid, b.Decimal16(39, bytes));
+  // Scale 38 is valid
+  ASSERT_OK(b.Decimal4(38, bytes));
+}
+
+TEST_F(VariantBuilderPrimitiveExtraTest, EmptyString) {
+  VariantBuilder b;
+  ASSERT_OK(b.String(""));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "String(\"\")");
+}
+
+// ===========================================================================
+// Special float/double values: NaN, ±Inf
+// ===========================================================================
+
+class VariantBuilderSpecialFloatTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderSpecialFloatTest, FloatNaN) {
+  VariantBuilder b;
+  ASSERT_OK(b.Float(std::numeric_limits<float>::quiet_NaN()));
+  ASSERT_OK_AND_ASSIGN(auto result, b.Finish());
+  // Verify it round-trips (NaN != NaN, so just check we get a Float event)
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(result.metadata.data(),
+                                      static_cast<int64_t>(result.metadata.size())));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeVariantValue(metadata, result.value.data(),
+                               static_cast<int64_t>(result.value.size()), &visitor));
+  ASSERT_TRUE(visitor.events[0].find("Float(") == 0);
+}
+
+TEST_F(VariantBuilderSpecialFloatTest, FloatPositiveInf) {
+  VariantBuilder b;
+  ASSERT_OK(b.Float(std::numeric_limits<float>::infinity()));
+  auto events = RoundTrip(b);
+  ASSERT_TRUE(events[0].find("Float(") == 0);
+}
+
+TEST_F(VariantBuilderSpecialFloatTest, FloatNegativeInf) {
+  VariantBuilder b;
+  ASSERT_OK(b.Float(-std::numeric_limits<float>::infinity()));
+  auto events = RoundTrip(b);
+  ASSERT_TRUE(events[0].find("Float(") == 0);
+}
+
+TEST_F(VariantBuilderSpecialFloatTest, DoubleNaN) {
+  VariantBuilder b;
+  ASSERT_OK(b.Double(std::numeric_limits<double>::quiet_NaN()));
+  ASSERT_OK_AND_ASSIGN(auto result, b.Finish());
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(result.metadata.data(),
+                                      static_cast<int64_t>(result.metadata.size())));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeVariantValue(metadata, result.value.data(),
+                               static_cast<int64_t>(result.value.size()), &visitor));
+  ASSERT_TRUE(visitor.events[0].find("Double(") == 0);
+}
+
+TEST_F(VariantBuilderSpecialFloatTest, DoublePositiveInf) {
+  VariantBuilder b;
+  ASSERT_OK(b.Double(std::numeric_limits<double>::infinity()));
+  auto events = RoundTrip(b);
+  ASSERT_TRUE(events[0].find("Double(") == 0);
+}
+
+TEST_F(VariantBuilderSpecialFloatTest, DoubleNegativeInf) {
+  VariantBuilder b;
+  ASSERT_OK(b.Double(-std::numeric_limits<double>::infinity()));
+  auto events = RoundTrip(b);
+  ASSERT_TRUE(events[0].find("Double(") == 0);
+}
+
+// ===========================================================================
+// Int auto-sizing boundary tests
+// ===========================================================================
+
+class VariantBuilderIntBoundaryTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderIntBoundaryTest, Int8MaxBecomesInt8) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(127));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int8(127)");
+}
+
+TEST_F(VariantBuilderIntBoundaryTest, Int8MaxPlusOneBecomesInt16) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(128));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int16(128)");
+}
+
+TEST_F(VariantBuilderIntBoundaryTest, Int8MinBecomesInt8) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(-128));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int8(-128)");
+}
+
+TEST_F(VariantBuilderIntBoundaryTest, Int8MinMinusOneBecomesInt16) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(-129));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int16(-129)");
+}
+
+TEST_F(VariantBuilderIntBoundaryTest, Int16MaxBecomesInt16) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(32767));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int16(32767)");
+}
+
+TEST_F(VariantBuilderIntBoundaryTest, Int16MaxPlusOneBecomesInt32) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(32768));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int32(32768)");
+}
+
+TEST_F(VariantBuilderIntBoundaryTest, Int32MaxBecomesInt32) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(2147483647LL));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int32(2147483647)");
+}
+
+TEST_F(VariantBuilderIntBoundaryTest, Int32MaxPlusOneBecomesInt64) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int(2147483648LL));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int64(2147483648)");
+}
+
+// ===========================================================================
+// Large array round-trip (is_large flag)
+// ===========================================================================
+
+class VariantBuilderLargeContainerTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderLargeContainerTest, LargeArrayIsLarge) {
+  // Build an array with 300 elements (>255) to trigger is_large=true.
+  // This exercises the same code path as the Go bug (apache/arrow-go#839).
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<int64_t> offsets;
+  for (int i = 0; i < 300; ++i) {
+    offsets.push_back(b.NextElement(start));
+    ASSERT_OK(b.Null());
+  }
+  ASSERT_OK(b.FinishArray(start, offsets));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  // Verify the header byte has is_large set correctly
+  ASSERT_FALSE(encoded.value.empty());
+  uint8_t header = encoded.value[0];
+  ASSERT_EQ(GetBasicType(header), BasicType::kArray);
+  // is_large at bit 4 of full byte
+  ASSERT_TRUE(((header >> 4) & 0x01) != 0);
+
+  // Verify round-trip: decode and check element count
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeVariantValue(meta, encoded.value.data(),
+                               static_cast<int64_t>(encoded.value.size()), &visitor));
+  // StartArray(300) + 300 Nulls + EndArray = 302 events
+  ASSERT_EQ(visitor.events.size(), 302);
+  ASSERT_EQ(visitor.events[0], "StartArray(300)");
+  ASSERT_EQ(visitor.events[301], "EndArray");
+
+  // Also verify ValueSize works correctly on this large array
+  ASSERT_OK_AND_ASSIGN(auto size, ValueSize(encoded.value.data(),
+                                            static_cast<int64_t>(encoded.value.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(encoded.value.size()));
+}
+
+TEST_F(VariantBuilderLargeContainerTest, LargeObjectIsLarge) {
+  // Build an object with 300 fields (>255) to trigger is_large=true.
+  // Verifies that the encoder correctly sets is_large at bit 6 of the
+  // full header byte (bit 4 of the 6-bit type_info / value_header).
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  for (int i = 0; i < 300; ++i) {
+    std::string key = "field_" + std::to_string(i);
+    fields.push_back(b.NextField(start, key));
+    ASSERT_OK(b.Null());
+  }
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  // Verify the header byte has is_large set correctly at bit 6
+  ASSERT_FALSE(encoded.value.empty());
+  uint8_t header = encoded.value[0];
+  ASSERT_EQ(GetBasicType(header), BasicType::kObject);
+  // Object is_large at bit 6 of full byte (bit 4 of type_info)
+  ASSERT_TRUE(((header >> 6) & 0x01) != 0);
+
+  // Verify round-trip: decode and check field count
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(auto field_count,
+                       GetObjectFieldCount(encoded.value.data(),
+                                           static_cast<int64_t>(encoded.value.size())));
+  ASSERT_EQ(field_count, 300);
+
+  // Verify full decode
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeVariantValue(meta, encoded.value.data(),
+                               static_cast<int64_t>(encoded.value.size()), &visitor));
+  // StartObject(300) + 300*(FieldName + Null) + EndObject = 602 events
+  ASSERT_EQ(visitor.events.size(), 602);
+  ASSERT_EQ(visitor.events[0], "StartObject(300)");
+  ASSERT_EQ(visitor.events[601], "EndObject");
+
+  // Verify ValueSize matches buffer size
+  ASSERT_OK_AND_ASSIGN(auto size, ValueSize(encoded.value.data(),
+                                            static_cast<int64_t>(encoded.value.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(encoded.value.size()));
+}
+
+// ===========================================================================
+// Decoder utility round-trips through builder output
+// ===========================================================================
+
+class VariantBuilderDecoderUtilTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderDecoderUtilTest, FindObjectFieldOnBuilderOutput) {
+  // Build {alpha: 1, beta: "two", gamma: true} and verify FindObjectField works
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "alpha"));
+  ASSERT_OK(b.Int(1));
+  fields.push_back(b.NextField(start, "beta"));
+  ASSERT_OK(b.String("two"));
+  fields.push_back(b.NextField(start, "gamma"));
+  ASSERT_OK(b.Bool(true));
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+
+  // Find "beta"
+  int64_t field_offset = -1, field_size = 0;
+  ASSERT_OK(FindObjectField(meta, encoded.value.data(),
+                            static_cast<int64_t>(encoded.value.size()), "beta",
+                            &field_offset, &field_size));
+  ASSERT_GT(field_offset, 0);
+  ASSERT_GT(field_size, 0);
+
+  // Decode the field value
+  RecordingVisitor v;
+  ASSERT_OK(
+      DecodeVariantValue(meta, encoded.value.data() + field_offset, field_size, &v));
+  ASSERT_EQ(v.events[0], "String(\"two\")");
+
+  // Find non-existent key
+  int64_t nf_offset = -1, nf_size = 0;
+  ASSERT_OK(FindObjectField(meta, encoded.value.data(),
+                            static_cast<int64_t>(encoded.value.size()), "missing",
+                            &nf_offset, &nf_size));
+  ASSERT_EQ(nf_offset, -1);
+}
+
+TEST_F(VariantBuilderDecoderUtilTest, GetArrayElementOnBuilderOutput) {
+  // Build [10, 20, 30] and verify GetArrayElement works
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<int64_t> offsets;
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Int(10));
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Int(20));
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Int(30));
+  ASSERT_OK(b.FinishArray(start, offsets));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+
+  // Access element at index 2
+  int64_t elem_offset = 0, elem_size = 0;
+  ASSERT_OK(GetArrayElement(encoded.value.data(),
+                            static_cast<int64_t>(encoded.value.size()), 2, &elem_offset,
+                            &elem_size));
+  ASSERT_GT(elem_offset, 0);
+  ASSERT_EQ(elem_size, 2);  // Int8(30) = 2 bytes
+
+  RecordingVisitor v;
+  ASSERT_OK(DecodeVariantValue(meta, encoded.value.data() + elem_offset, elem_size, &v));
+  ASSERT_EQ(v.events[0], "Int8(30)");
+}
+
+TEST_F(VariantBuilderDecoderUtilTest, GetObjectFieldAtOnBuilderOutput) {
+  // Build {x: 100, y: 200} and access by positional index
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "x"));
+  ASSERT_OK(b.Int(100));
+  fields.push_back(b.NextField(start, "y"));
+  ASSERT_OK(b.Int(200));
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  ASSERT_OK_AND_ASSIGN(auto meta,
+                       DecodeMetadata(encoded.metadata.data(),
+                                      static_cast<int64_t>(encoded.metadata.size())));
+
+  // Fields are sorted by key: "x" at index 0, "y" at index 1
+  std::string_view field_name;
+  int64_t field_offset = 0, field_size = 0;
+  ASSERT_OK(GetObjectFieldAt(meta, encoded.value.data(),
+                             static_cast<int64_t>(encoded.value.size()), 0, &field_name,
+                             &field_offset, &field_size));
+  ASSERT_EQ(field_name, "x");
+
+  RecordingVisitor v;
+  ASSERT_OK(
+      DecodeVariantValue(meta, encoded.value.data() + field_offset, field_size, &v));
+  ASSERT_EQ(v.events[0], "Int8(100)");
+}
+
+TEST_F(VariantBuilderDecoderUtilTest, ValueSizeOnBuilderOutput) {
+  // Build a nested structure and verify ValueSize matches buffer size
+  VariantBuilder b;
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "data"));
+  {
+    auto arr_start = b.Offset();
+    std::vector<int64_t> arr_offsets;
+    arr_offsets.push_back(b.NextElement(arr_start));
+    ASSERT_OK(b.String("hello"));
+    arr_offsets.push_back(b.NextElement(arr_start));
+    ASSERT_OK(b.Int(42));
+    ASSERT_OK(b.FinishArray(arr_start, arr_offsets));
+  }
+  ASSERT_OK(b.FinishObject(start, fields));
+  ASSERT_OK_AND_ASSIGN(auto encoded, b.Finish());
+
+  // ValueSize of the top-level value should equal the total buffer size
+  ASSERT_OK_AND_ASSIGN(auto size, ValueSize(encoded.value.data(),
+                                            static_cast<int64_t>(encoded.value.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(encoded.value.size()));
+}
+
+// ===========================================================================
+// Direct integer type method tests (verify explicit types not auto-sized)
+// ===========================================================================
+
+class VariantBuilderDirectIntTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderDirectIntTest, ExplicitInt8) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int8(42));
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int8(42)");
+}
+
+TEST_F(VariantBuilderDirectIntTest, ExplicitInt16) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int16(42));  // Would be Int8 if auto-sized
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int16(42)");
+}
+
+TEST_F(VariantBuilderDirectIntTest, ExplicitInt32) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int32(42));  // Would be Int8 if auto-sized
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int32(42)");
+}
+
+TEST_F(VariantBuilderDirectIntTest, ExplicitInt64) {
+  VariantBuilder b;
+  ASSERT_OK(b.Int64(42));  // Would be Int8 if auto-sized
+  auto events = RoundTrip(b);
+  ASSERT_EQ(events[0], "Int64(42)");
+}
+
+// ===========================================================================
+// Builder reuse: multiple Finish() calls with preserved dictionary
+// ===========================================================================
+
+class VariantBuilderReuseTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderReuseTest, MultipleFinishPreservesDictionary) {
+  VariantBuilder b;
+
+  // Build first value: {name: "Alice"}
+  auto start1 = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields1;
+  fields1.push_back(b.NextField(start1, "name"));
+  ASSERT_OK(b.String("Alice"));
+  ASSERT_OK(b.FinishObject(start1, fields1));
+  ASSERT_OK_AND_ASSIGN(auto encoded1, b.Finish());
+
+  // Build second value: {name: "Bob"} — reuses dictionary from first build
+  auto start2 = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields2;
+  fields2.push_back(b.NextField(start2, "name"));
+  ASSERT_OK(b.String("Bob"));
+  ASSERT_OK(b.FinishObject(start2, fields2));
+  ASSERT_OK_AND_ASSIGN(auto encoded2, b.Finish());
+
+  // Verify first value decodes correctly
+  ASSERT_OK_AND_ASSIGN(auto meta1,
+                       DecodeMetadata(encoded1.metadata.data(),
+                                      static_cast<int64_t>(encoded1.metadata.size())));
+  RecordingVisitor v1;
+  ASSERT_OK(DecodeVariantValue(meta1, encoded1.value.data(),
+                               static_cast<int64_t>(encoded1.value.size()), &v1));
+  ASSERT_EQ(v1.events[1], "FieldName(\"name\")");
+  ASSERT_EQ(v1.events[2], "String(\"Alice\")");
+
+  // Verify second value decodes correctly
+  ASSERT_OK_AND_ASSIGN(auto meta2,
+                       DecodeMetadata(encoded2.metadata.data(),
+                                      static_cast<int64_t>(encoded2.metadata.size())));
+  RecordingVisitor v2;
+  ASSERT_OK(DecodeVariantValue(meta2, encoded2.value.data(),
+                               static_cast<int64_t>(encoded2.value.size()), &v2));
+  ASSERT_EQ(v2.events[1], "FieldName(\"name\")");
+  ASSERT_EQ(v2.events[2], "String(\"Bob\")");
+
+  // Both should have the same dictionary content (same metadata structure)
+  ASSERT_EQ(meta1.strings.size(), meta2.strings.size());
+  ASSERT_EQ(meta1.strings[0], "name");
+  ASSERT_EQ(meta2.strings[0], "name");
+}
+
+TEST_F(VariantBuilderReuseTest, DictionaryGrowsAcrossFinishCalls) {
+  VariantBuilder b;
+
+  // Build first value with key "x"
+  auto start1 = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields1;
+  fields1.push_back(b.NextField(start1, "x"));
+  ASSERT_OK(b.Int(1));
+  ASSERT_OK(b.FinishObject(start1, fields1));
+  ASSERT_OK_AND_ASSIGN(auto encoded1, b.Finish());
+
+  // Build second value with keys "x" and "y" — dictionary should grow
+  auto start2 = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields2;
+  fields2.push_back(b.NextField(start2, "x"));
+  ASSERT_OK(b.Int(2));
+  fields2.push_back(b.NextField(start2, "y"));
+  ASSERT_OK(b.Int(3));
+  ASSERT_OK(b.FinishObject(start2, fields2));
+  ASSERT_OK_AND_ASSIGN(auto encoded2, b.Finish());
+
+  // First metadata has 1 key
+  ASSERT_OK_AND_ASSIGN(auto meta1,
+                       DecodeMetadata(encoded1.metadata.data(),
+                                      static_cast<int64_t>(encoded1.metadata.size())));
+  ASSERT_EQ(meta1.strings.size(), 1);
+
+  // Second metadata has 2 keys (dictionary grew)
+  ASSERT_OK_AND_ASSIGN(auto meta2,
+                       DecodeMetadata(encoded2.metadata.data(),
+                                      static_cast<int64_t>(encoded2.metadata.size())));
+  ASSERT_EQ(meta2.strings.size(), 2);
+
+  // Verify second value decodes correctly
+  RecordingVisitor v2;
+  ASSERT_OK(DecodeVariantValue(meta2, encoded2.value.data(),
+                               static_cast<int64_t>(encoded2.value.size()), &v2));
+  ASSERT_EQ(v2.events[0], "StartObject(2)");
+  // Fields sorted: "x" before "y"
+  ASSERT_EQ(v2.events[1], "FieldName(\"x\")");
+  ASSERT_EQ(v2.events[2], "Int8(2)");
+  ASSERT_EQ(v2.events[3], "FieldName(\"y\")");
+  ASSERT_EQ(v2.events[4], "Int8(3)");
+}
+
+// ===========================================================================
+// Edge case: FinishObject/FinishArray with pre-existing buffer content
+// ===========================================================================
+
+class VariantBuilderPreExistingBufferTest : public ::testing::Test {};
+
+TEST_F(VariantBuilderPreExistingBufferTest, ObjectAfterPrimitive) {
+  // Write a primitive value first, then build an object. This exercises
+  // the case where start > 0 (data_size = buffer.size() - start).
+  // The builder is designed for single top-level values, but this tests
+  // the internal arithmetic correctness.
+  VariantBuilder b;
+  // Write a "prefix" value that occupies buffer space before our object
+  ASSERT_OK(b.Int(99));
+  int64_t prefix_size = b.Offset();  // should be 2 (Int8 header + 1 byte)
+  ASSERT_EQ(prefix_size, 2);
+
+  auto start = b.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields;
+  fields.push_back(b.NextField(start, "key"));
+  ASSERT_OK(b.String("val"));
+  ASSERT_OK(b.FinishObject(start, fields));
+
+  // The buffer now contains [Int8(99)] + [Object{key: "val"}].
+  // We can't call Finish() meaningfully for a two-value buffer,
+  // but verify no crash or corruption occurred and the object portion
+  // is correctly sized.
+  ASSERT_GT(b.Offset(), prefix_size);
+}
+
+TEST_F(VariantBuilderPreExistingBufferTest, ArrayAfterPrimitive) {
+  // Same as above but for arrays.
+  VariantBuilder b;
+  ASSERT_OK(b.Int(99));
+  int64_t prefix_size = b.Offset();
+
+  auto start = b.Offset();
+  std::vector<int64_t> offsets;
+  offsets.push_back(b.NextElement(start));
+  ASSERT_OK(b.Null());
+  ASSERT_OK(b.FinishArray(start, offsets));
+
+  ASSERT_GT(b.Offset(), prefix_size);
+}
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_internal_test_util.h
+++ b/cpp/src/arrow/extension/variant_internal_test_util.h
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+// This file is for tests only and is not installed as a public header.
+
+#include <string>
+#include <vector>
+
+#include "arrow/extension/variant.h"
+
+namespace arrow::extension::variant {
+
+/// \brief A visitor that records all callbacks as a vector of strings
+///        for easy assertion in tests.
+class RecordingVisitor : public VariantVisitor {
+ public:
+  std::vector<std::string> events;
+
+  Status Null() override {
+    events.push_back("Null");
+    return Status::OK();
+  }
+  Status Bool(bool value) override {
+    events.push_back(std::string("Bool(") + (value ? "true" : "false") + ")");
+    return Status::OK();
+  }
+  Status Int8(int8_t value) override {
+    events.push_back("Int8(" + std::to_string(value) + ")");
+    return Status::OK();
+  }
+  Status Int16(int16_t value) override {
+    events.push_back("Int16(" + std::to_string(value) + ")");
+    return Status::OK();
+  }
+  Status Int32(int32_t value) override {
+    events.push_back("Int32(" + std::to_string(value) + ")");
+    return Status::OK();
+  }
+  Status Int64(int64_t value) override {
+    events.push_back("Int64(" + std::to_string(value) + ")");
+    return Status::OK();
+  }
+  Status Float(float value) override {
+    events.push_back("Float(" + std::to_string(value) + ")");
+    return Status::OK();
+  }
+  Status Double(double value) override {
+    events.push_back("Double(" + std::to_string(value) + ")");
+    return Status::OK();
+  }
+  Status Decimal4(const uint8_t* /*bytes*/, int32_t scale) override {
+    events.push_back("Decimal4(scale=" + std::to_string(scale) + ")");
+    return Status::OK();
+  }
+  Status Decimal8(const uint8_t* /*bytes*/, int32_t scale) override {
+    events.push_back("Decimal8(scale=" + std::to_string(scale) + ")");
+    return Status::OK();
+  }
+  Status Decimal16(const uint8_t* /*bytes*/, int32_t scale) override {
+    events.push_back("Decimal16(scale=" + std::to_string(scale) + ")");
+    return Status::OK();
+  }
+  Status Date(int32_t days) override {
+    events.push_back("Date(" + std::to_string(days) + ")");
+    return Status::OK();
+  }
+  Status TimestampMicros(int64_t micros) override {
+    events.push_back("TimestampMicros(" + std::to_string(micros) + ")");
+    return Status::OK();
+  }
+  Status TimestampMicrosNTZ(int64_t micros) override {
+    events.push_back("TimestampMicrosNTZ(" + std::to_string(micros) + ")");
+    return Status::OK();
+  }
+  Status String(std::string_view value) override {
+    events.push_back("String(\"" + std::string(value) + "\")");
+    return Status::OK();
+  }
+  Status Binary(std::string_view value) override {
+    events.push_back("Binary(len=" + std::to_string(value.size()) + ")");
+    return Status::OK();
+  }
+  Status TimeNTZ(int64_t micros) override {
+    events.push_back("TimeNTZ(" + std::to_string(micros) + ")");
+    return Status::OK();
+  }
+  Status TimestampNanos(int64_t nanos) override {
+    events.push_back("TimestampNanos(" + std::to_string(nanos) + ")");
+    return Status::OK();
+  }
+  Status TimestampNanosNTZ(int64_t nanos) override {
+    events.push_back("TimestampNanosNTZ(" + std::to_string(nanos) + ")");
+    return Status::OK();
+  }
+  Status UUID(const uint8_t* /*bytes*/) override {
+    events.push_back("UUID");
+    return Status::OK();
+  }
+  Status StartObject(int32_t num_fields) override {
+    events.push_back("StartObject(" + std::to_string(num_fields) + ")");
+    return Status::OK();
+  }
+  Status FieldName(std::string_view name) override {
+    events.push_back("FieldName(\"" + std::string(name) + "\")");
+    return Status::OK();
+  }
+  Status EndObject() override {
+    events.push_back("EndObject");
+    return Status::OK();
+  }
+  Status StartArray(int32_t num_elements) override {
+    events.push_back("StartArray(" + std::to_string(num_elements) + ")");
+    return Status::OK();
+  }
+  Status EndArray() override {
+    events.push_back("EndArray");
+    return Status::OK();
+  }
+};
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_internal_util.h
+++ b/cpp/src/arrow/extension/variant_internal_util.h
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+/// \file variant_internal_util.h
+/// \brief Internal utilities shared by variant implementation files.
+///
+/// NOT part of the public API — not installed. Used only by variant.cc
+/// and variant_shredding.cc to avoid duplicating low-level helpers.
+
+#include <cstdint>
+#include <cstring>
+
+#include "arrow/util/endian.h"
+
+namespace arrow::extension::variant::internal {
+
+/// \brief Read an unsigned integer of 1-4 bytes in little-endian order.
+///
+/// Reads exactly \p num_bytes from \p data, interprets them as an unsigned
+/// little-endian integer, and returns the result as uint32_t.
+///
+/// \pre num_bytes must be in [1, 4]
+/// \pre data must point to at least num_bytes readable bytes
+inline uint32_t ReadUnsignedLE(const uint8_t* data, int32_t num_bytes) {
+  uint32_t result = 0;
+  std::memcpy(&result, data, num_bytes);
+  result = ::arrow::bit_util::FromLittleEndian(result);
+  if (num_bytes < 4) {
+    result &= (static_cast<uint32_t>(1) << (num_bytes * 8)) - 1;
+  }
+  return result;
+}
+
+/// \brief Read an unsigned integer of 1-8 bytes in little-endian order.
+///
+/// Extended version that supports reading up to 8-byte values (for int64
+/// extraction in shredding paths). Returns int64_t for compatibility with
+/// Arrow's signed-offset conventions.
+///
+/// \pre num_bytes must be in [1, 8]
+/// \pre data must point to at least num_bytes readable bytes
+inline int64_t ReadUnsignedLE64(const uint8_t* data, int32_t num_bytes) {
+  if (num_bytes <= 4) {
+    return static_cast<int64_t>(ReadUnsignedLE(data, num_bytes));
+  }
+  uint64_t result = 0;
+  std::memcpy(&result, data, num_bytes);
+  result = ::arrow::bit_util::FromLittleEndian(result);
+  if (num_bytes < 8) {
+    result &= (static_cast<uint64_t>(1) << (num_bytes * 8)) - 1;
+  }
+  return static_cast<int64_t>(result);
+}
+
+}  // namespace arrow::extension::variant::internal

--- a/cpp/src/arrow/extension/variant_shredding.cc
+++ b/cpp/src/arrow/extension/variant_shredding.cc
@@ -1,0 +1,2140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/extension/variant_shredding.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "arrow/array/array_binary.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_decimal.h"
+#include "arrow/array/builder_nested.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/buffer.h"
+#include "arrow/extension/variant.h"
+#include "arrow/extension/variant_internal_util.h"
+#include "arrow/memory_pool.h"
+#include "arrow/type.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/decimal.h"
+#include "arrow/util/endian.h"
+#include "arrow/util/logging_internal.h"
+
+namespace arrow::extension::variant {
+
+// Forward declaration
+static Result<std::shared_ptr<StructArray>> ShredVariantColumnObject(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array, const VariantShreddingSchema& schema);
+
+static Result<std::shared_ptr<StructArray>> ShredVariantColumnArray(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array, const VariantShreddingSchema& schema);
+
+static Result<std::shared_ptr<Array>> ReconstructVariantColumnObject(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array,
+    const std::shared_ptr<Array>& typed_value_array,
+    const VariantShreddingSchema& schema);
+
+static Result<std::shared_ptr<Array>> ReconstructVariantColumnArray(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array,
+    const std::shared_ptr<Array>& typed_value_array,
+    const VariantShreddingSchema& schema);
+
+// ---------------------------------------------------------------------------
+// VariantShreddingSchema implementation
+// ---------------------------------------------------------------------------
+
+VariantShreddingSchema VariantShreddingSchema::Primitive(std::shared_ptr<DataType> type) {
+  VariantShreddingSchema schema;
+  schema.kind_ = Kind::kPrimitive;
+  schema.type_ = std::move(type);
+  return schema;
+}
+
+VariantShreddingSchema VariantShreddingSchema::Object(
+    std::vector<std::pair<std::string, VariantShreddingSchema>> fields) {
+  VariantShreddingSchema schema;
+  schema.kind_ = Kind::kObject;
+  schema.fields_ = std::move(fields);
+  return schema;
+}
+
+VariantShreddingSchema VariantShreddingSchema::Array(
+    VariantShreddingSchema element_schema) {
+  VariantShreddingSchema schema;
+  schema.kind_ = Kind::kArray;
+  schema.element_schema_ =
+      std::make_shared<VariantShreddingSchema>(std::move(element_schema));
+  return schema;
+}
+
+std::shared_ptr<DataType> VariantShreddingSchema::ToArrowType() const {
+  switch (kind_) {
+    case Kind::kPrimitive:
+      return type_;
+
+    case Kind::kObject: {
+      std::vector<std::shared_ptr<Field>> arrow_fields;
+      arrow_fields.reserve(fields_.size());
+      for (const auto& [name, sub_schema] : fields_) {
+        auto typed_value_type = sub_schema.ToArrowType();
+        auto field_struct = struct_({
+            field("value", binary(), /*nullable=*/true),
+            field("typed_value", typed_value_type, /*nullable=*/true),
+        });
+        arrow_fields.push_back(field(name, field_struct, /*nullable=*/false));
+      }
+      return struct_(std::move(arrow_fields));
+    }
+
+    case Kind::kArray: {
+      auto elem_typed_type = element_schema_->ToArrowType();
+      auto element_struct = struct_({
+          field("value", binary(), /*nullable=*/true),
+          field("typed_value", elem_typed_type, /*nullable=*/true),
+      });
+      return list(field("element", element_struct, /*nullable=*/false));
+    }
+  }
+  // All enum values are handled above; this is unreachable.
+  DCHECK(false) << "Unknown VariantShreddingSchema kind";
+  return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Type compatibility check
+// ---------------------------------------------------------------------------
+
+bool IsVariantCompatibleWithType(const uint8_t* variant_data, int64_t variant_length,
+                                 const DataType& target_type) {
+  if (variant_length < 1) return false;
+
+  uint8_t header = variant_data[0];
+  auto basic_type = GetBasicType(header);
+
+  if (basic_type == BasicType::kShortString) {
+    // Short strings are semantically UTF-8 text (same as kString), not binary data.
+    // They should NOT match BINARY/LARGE_BINARY targets — only string targets.
+    // Rust's shredding makes the same distinction: strings → Utf8/LargeUtf8/Utf8View,
+    // binary → Binary/LargeBinary/BinaryView.
+    return target_type.id() == Type::STRING || target_type.id() == Type::LARGE_STRING ||
+           target_type.id() == Type::STRING_VIEW;
+  }
+
+  if (basic_type == BasicType::kObject || basic_type == BasicType::kArray) {
+    return false;
+  }
+
+  if (basic_type == BasicType::kPrimitive) {
+    auto prim_type = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+    switch (prim_type) {
+      case PrimitiveType::kNull:
+        // Per Rust/spec semantics: Variant::Null is NOT shredded into typed
+        // columns. It is stored as-is in the value column. This distinguishes
+        // "variant-typed null" (value = 0x00 byte) from "SQL NULL / missing"
+        // (both value and typed_value are null).
+        return false;
+      case PrimitiveType::kTrue:
+      case PrimitiveType::kFalse:
+        return target_type.id() == Type::BOOL;
+      case PrimitiveType::kInt8:
+        return target_type.id() == Type::INT8 || target_type.id() == Type::INT16 ||
+               target_type.id() == Type::INT32 || target_type.id() == Type::INT64;
+      case PrimitiveType::kInt16:
+        return target_type.id() == Type::INT16 || target_type.id() == Type::INT32 ||
+               target_type.id() == Type::INT64;
+      case PrimitiveType::kInt32:
+        return target_type.id() == Type::INT32 || target_type.id() == Type::INT64;
+      case PrimitiveType::kInt64:
+        return target_type.id() == Type::INT64;
+      case PrimitiveType::kFloat:
+        // Note: Float→Double widening means shred(Float)→reconstruct produces Double.
+        // This is a lossy round-trip for the type tag (value precision is preserved).
+        return target_type.id() == Type::FLOAT || target_type.id() == Type::DOUBLE;
+      case PrimitiveType::kDouble:
+        return target_type.id() == Type::DOUBLE;
+      case PrimitiveType::kDecimal4:
+      case PrimitiveType::kDecimal8:
+      case PrimitiveType::kDecimal16: {
+        if (target_type.id() != Type::DECIMAL128 &&
+            target_type.id() != Type::DECIMAL256) {
+          return false;
+        }
+        // Verify scale matches: read scale byte from variant data (byte after header).
+        int32_t min_size = (prim_type == PrimitiveType::kDecimal4)    ? 6
+                           : (prim_type == PrimitiveType::kDecimal8)  ? 10
+                           : (prim_type == PrimitiveType::kDecimal16) ? 18
+                                                                      : 0;
+        if (variant_length < min_size) return false;
+        auto variant_scale = static_cast<int32_t>(variant_data[1]);
+        if (target_type.id() == Type::DECIMAL128) {
+          return variant_scale == static_cast<const Decimal128Type&>(target_type).scale();
+        }
+        return true;  // DECIMAL256 — accept any scale for now
+        // TODO: This is asymmetric with DECIMAL128 which validates scale.
+        // Consider adding scale matching for DECIMAL256 once usage is
+        // established. Currently pragmatic since DECIMAL256 is rarely used.
+      }
+      case PrimitiveType::kDate:
+        return target_type.id() == Type::DATE32;
+      case PrimitiveType::kTimestampMicros: {
+        if (target_type.id() != Type::TIMESTAMP) return false;
+        auto& ts = static_cast<const TimestampType&>(target_type);
+        return ts.unit() == TimeUnit::MICRO && !ts.timezone().empty();
+      }
+      case PrimitiveType::kTimestampMicrosNTZ: {
+        if (target_type.id() != Type::TIMESTAMP) return false;
+        auto& ts = static_cast<const TimestampType&>(target_type);
+        return ts.unit() == TimeUnit::MICRO && ts.timezone().empty();
+      }
+      case PrimitiveType::kTimestampNanos: {
+        if (target_type.id() != Type::TIMESTAMP) return false;
+        auto& ts = static_cast<const TimestampType&>(target_type);
+        return ts.unit() == TimeUnit::NANO && !ts.timezone().empty();
+      }
+      case PrimitiveType::kTimestampNanosNTZ: {
+        if (target_type.id() != Type::TIMESTAMP) return false;
+        auto& ts = static_cast<const TimestampType&>(target_type);
+        return ts.unit() == TimeUnit::NANO && ts.timezone().empty();
+      }
+      case PrimitiveType::kTimeNTZ: {
+        if (target_type.id() != Type::TIME64) return false;
+        // The variant spec's kTimeNTZ stores microseconds since midnight.
+        // Only accept time64(MICRO) targets — a time64(NANO) target would
+        // cause misinterpretation of the shredded values in typed_value.
+        auto& t = static_cast<const Time64Type&>(target_type);
+        return t.unit() == TimeUnit::MICRO;
+      }
+      case PrimitiveType::kString:
+        return target_type.id() == Type::STRING ||
+               target_type.id() == Type::LARGE_STRING ||
+               target_type.id() == Type::STRING_VIEW;
+      case PrimitiveType::kBinary:
+        return target_type.id() == Type::BINARY ||
+               target_type.id() == Type::LARGE_BINARY ||
+               target_type.id() == Type::BINARY_VIEW;
+      case PrimitiveType::kUUID:
+        return target_type.id() == Type::FIXED_SIZE_BINARY &&
+               static_cast<const FixedSizeBinaryType&>(target_type).byte_width() ==
+                   kUUIDByteLength;
+      default:
+        // Unknown or future primitive types are not compatible with any target.
+        return false;
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Supports BINARY, LARGE_BINARY, BINARY_VIEW, and STRING_VIEW arrays.
+// Rust supports all of these via GenericByteViewArray / GenericByteArray.
+std::string_view GetBinaryValue(const Array& array, int64_t i) {
+  if (array.type_id() == Type::BINARY) {
+    auto& bin = static_cast<const BinaryArray&>(array);
+    auto view = bin.GetView(i);
+    return {reinterpret_cast<const char*>(view.data()), static_cast<size_t>(view.size())};
+  }
+  if (array.type_id() == Type::LARGE_BINARY) {
+    auto& bin = static_cast<const LargeBinaryArray&>(array);
+    auto view = bin.GetView(i);
+    return {reinterpret_cast<const char*>(view.data()), static_cast<size_t>(view.size())};
+  }
+  if (array.type_id() == Type::BINARY_VIEW || array.type_id() == Type::STRING_VIEW) {
+    auto& bin = static_cast<const BinaryViewArray&>(array);
+    return bin.GetView(i);
+  }
+  // Callers validate input types at public entry points (ShredVariantColumn,
+  // ReconstructVariantColumn). Reaching here indicates a programming error.
+  DCHECK(false) << "GetBinaryValue: unsupported array type " << array.type()->ToString();
+  return {};
+}
+
+/// Alias the shared internal ReadLE utilities for use in this file.
+/// ReadUnsignedLE64 handles 1-8 byte reads and returns int64_t, which
+/// matches the needs of shredding's extraction functions.
+using internal::ReadUnsignedLE64;
+
+/// Convenience alias matching the local calling convention.
+/// All callers in this file use ReadLE(buf, nbytes) → int64_t.
+inline int64_t ReadLE(const uint8_t* buf, int32_t nbytes) {
+  return ReadUnsignedLE64(buf, nbytes);
+}
+
+/// Extract a native int64 value from variant-encoded bytes (handles all int sizes).
+/// Returns true if extraction succeeded, false if type is not an integer.
+bool ExtractInt64(const uint8_t* data, int64_t length, int64_t* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  switch (prim) {
+    case PrimitiveType::kInt8:
+      if (length < 2) return false;
+      *out = static_cast<int64_t>(static_cast<int8_t>(data[1]));
+      return true;
+    case PrimitiveType::kInt16:
+      if (length < 3) return false;
+      // ReadLE returns zero-extended int64_t; narrow to int16_t for sign-extension,
+      // then widen back to int64_t explicitly.
+      *out = static_cast<int64_t>(static_cast<int16_t>(ReadLE(data + 1, 2)));
+      return true;
+    case PrimitiveType::kInt32:
+      if (length < 5) return false;
+      // ReadLE returns zero-extended int64_t; narrow to int32_t for sign-extension,
+      // then widen back to int64_t explicitly.
+      *out = static_cast<int64_t>(static_cast<int32_t>(ReadLE(data + 1, 4)));
+      return true;
+    case PrimitiveType::kInt64:
+      if (length < 9) return false;
+      *out = ReadLE(data + 1, 8);
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// Extract a boolean from variant-encoded bytes.
+bool ExtractBool(const uint8_t* data, int64_t length, bool* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kTrue) {
+    *out = true;
+    return true;
+  }
+  if (prim == PrimitiveType::kFalse) {
+    *out = false;
+    return true;
+  }
+  return false;
+}
+
+/// Extract a double from variant-encoded bytes (handles float→double widening and
+/// native double). Named "ExtractDoubleOrFloat" to clarify that it accepts both
+/// kFloat (widened to double) and kDouble variant types.
+bool ExtractDoubleOrFloat(const uint8_t* data, int64_t length, double* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kDouble && length >= 9) {
+    uint64_t bits;
+    std::memcpy(&bits, data + 1, 8);
+    bits = bit_util::FromLittleEndian(bits);
+    std::memcpy(out, &bits, 8);
+    return true;
+  }
+  if (prim == PrimitiveType::kFloat && length >= 5) {
+    uint32_t bits;
+    std::memcpy(&bits, data + 1, 4);
+    bits = bit_util::FromLittleEndian(bits);
+    float f;
+    std::memcpy(&f, &bits, 4);
+    *out = static_cast<double>(f);
+    return true;
+  }
+  return false;
+}
+
+/// Extract a string_view from variant-encoded bytes (handles short and long strings).
+bool ExtractString(const uint8_t* data, int64_t length, std::string_view* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  auto basic_type = GetBasicType(header);
+  if (basic_type == BasicType::kShortString) {
+    int32_t str_len = (header >> 2) & 0x3F;
+    if (length < 1 + str_len) return false;
+    *out = std::string_view(reinterpret_cast<const char*>(data + 1), str_len);
+    return true;
+  }
+  if (basic_type == BasicType::kPrimitive) {
+    auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+    if (prim == PrimitiveType::kString && length >= 5) {
+      uint32_t str_len;
+      std::memcpy(&str_len, data + 1, 4);
+      str_len = bit_util::FromLittleEndian(str_len);
+      if (length < 5 + static_cast<int64_t>(str_len)) return false;
+      *out = std::string_view(reinterpret_cast<const char*>(data + 5), str_len);
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Check if the variant value is Variant Null.
+bool IsVariantNull(const uint8_t* data, int64_t length) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  return GetBasicType(header) == BasicType::kPrimitive &&
+         static_cast<PrimitiveType>((header >> 2) & 0x3F) == PrimitiveType::kNull;
+}
+
+/// Extract a float from variant-encoded bytes.
+bool ExtractFloat(const uint8_t* data, int64_t length, float* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kFloat && length >= 5) {
+    uint32_t bits;
+    std::memcpy(&bits, data + 1, 4);
+    bits = bit_util::FromLittleEndian(bits);
+    std::memcpy(out, &bits, 4);
+    return true;
+  }
+  return false;
+}
+
+/// Extract a date32 (days since epoch) from variant-encoded bytes.
+bool ExtractDate32(const uint8_t* data, int64_t length, int32_t* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kDate && length >= 5) {
+    *out = static_cast<int32_t>(ReadLE(data + 1, 4));
+    return true;
+  }
+  return false;
+}
+
+/// Extract a timestamp (micros or nanos) from variant-encoded bytes.
+bool ExtractTimestamp(const uint8_t* data, int64_t length, int64_t* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if ((prim == PrimitiveType::kTimestampMicros ||
+       prim == PrimitiveType::kTimestampMicrosNTZ ||
+       prim == PrimitiveType::kTimestampNanos ||
+       prim == PrimitiveType::kTimestampNanosNTZ) &&
+      length >= 9) {
+    *out = static_cast<int64_t>(ReadLE(data + 1, 8));
+    return true;
+  }
+  return false;
+}
+
+/// Extract binary data from variant-encoded bytes.
+bool ExtractBinary(const uint8_t* data, int64_t length, const uint8_t** out_data,
+                   int32_t* out_size) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kBinary && length >= 5) {
+    uint32_t bin_len;
+    std::memcpy(&bin_len, data + 1, 4);
+    bin_len = bit_util::FromLittleEndian(bin_len);
+    if (length < 5 + static_cast<int64_t>(bin_len)) return false;
+    *out_data = data + 5;
+    *out_size = static_cast<int32_t>(bin_len);
+    return true;
+  }
+  return false;
+}
+
+/// Extract an int32 from variant-encoded bytes (handles int8, int16, int32).
+bool ExtractInt32(const uint8_t* data, int64_t length, int32_t* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  switch (prim) {
+    case PrimitiveType::kInt8:
+      if (length < 2) return false;
+      *out = static_cast<int32_t>(static_cast<int8_t>(data[1]));
+      return true;
+    case PrimitiveType::kInt16:
+      if (length < 3) return false;
+      *out = static_cast<int32_t>(static_cast<int16_t>(ReadLE(data + 1, 2)));
+      return true;
+    case PrimitiveType::kInt32:
+      if (length < 5) return false;
+      *out = static_cast<int32_t>(ReadLE(data + 1, 4));
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// Extract an int8 from variant-encoded bytes (handles only int8).
+bool ExtractInt8(const uint8_t* data, int64_t length, int8_t* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kInt8 && length >= 2) {
+    *out = static_cast<int8_t>(data[1]);
+    return true;
+  }
+  return false;
+}
+
+/// Extract an int16 from variant-encoded bytes (handles int8, int16).
+bool ExtractInt16(const uint8_t* data, int64_t length, int16_t* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  switch (prim) {
+    case PrimitiveType::kInt8:
+      if (length < 2) return false;
+      *out = static_cast<int16_t>(static_cast<int8_t>(data[1]));
+      return true;
+    case PrimitiveType::kInt16:
+      if (length < 3) return false;
+      *out = static_cast<int16_t>(ReadLE(data + 1, 2));
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// Extract time64 (microseconds since midnight) from variant-encoded bytes.
+bool ExtractTime64(const uint8_t* data, int64_t length, int64_t* out) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kTimeNTZ && length >= 9) {
+    *out = static_cast<int64_t>(ReadLE(data + 1, 8));
+    return true;
+  }
+  return false;
+}
+
+/// Extract UUID (16 big-endian bytes) from variant-encoded bytes.
+bool ExtractUUID(const uint8_t* data, int64_t length, uint8_t* out16) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  if (prim == PrimitiveType::kUUID && length >= kUUIDByteLength + 1) {
+    std::memcpy(out16, data + 1, kUUIDByteLength);
+    return true;
+  }
+  return false;
+}
+
+/// Extract a Decimal128 (scale + unscaled value) from variant-encoded bytes.
+/// Handles decimal4 (4-byte), decimal8 (8-byte), and decimal16 (16-byte).
+/// The output is a 128-bit unscaled integer value suitable for Arrow's Decimal128Type.
+bool ExtractDecimal128(const uint8_t* data, int64_t length, int64_t* out_low,
+                       int64_t* out_high, uint8_t* out_scale) {
+  if (length < 1) return false;
+  uint8_t header = data[0];
+  if (GetBasicType(header) != BasicType::kPrimitive) return false;
+  auto prim = static_cast<PrimitiveType>((header >> 2) & 0x3F);
+  switch (prim) {
+    case PrimitiveType::kDecimal4:
+      if (length < 6) return false;  // 1 header + 1 scale + 4 value
+      *out_scale = data[1];
+      {
+        int32_t val;
+        // memcpy + FromLittleEndian is safe here: we copy the full variable width
+        // (4 bytes into int32), then swap. This differs from ReadLE's byte-shift
+        // approach which handles partial-width reads.
+        std::memcpy(&val, data + 2, 4);
+        val = bit_util::FromLittleEndian(val);
+        *out_low = static_cast<int64_t>(val);
+        *out_high = (val < 0) ? -1 : 0;  // sign-extend
+      }
+      return true;
+    case PrimitiveType::kDecimal8:
+      if (length < 10) return false;  // 1 header + 1 scale + 8 value
+      *out_scale = data[1];
+      {
+        int64_t val;
+        // memcpy + FromLittleEndian is safe here: we copy the full variable width
+        // (8 bytes into int64), then swap. This differs from ReadLE's byte-shift
+        // approach which handles partial-width reads.
+        std::memcpy(&val, data + 2, 8);
+        val = bit_util::FromLittleEndian(val);
+        *out_low = val;
+        *out_high = (val < 0) ? -1 : 0;  // sign-extend
+      }
+      return true;
+    case PrimitiveType::kDecimal16:
+      if (length < 18) return false;  // 1 header + 1 scale + 16 value
+      *out_scale = data[1];
+      {
+        std::memcpy(out_low, data + 2, 8);
+        std::memcpy(out_high, data + 10, 8);
+        *out_low = bit_util::FromLittleEndian(*out_low);
+        *out_high = bit_util::FromLittleEndian(*out_high);
+      }
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// ShredVariantColumnObject — object field-level shredding
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Shred a single object variant value, routing named fields to sub-builders.
+/// Produces: for each schema field, the field value (or null if missing).
+///           Residual = object with remaining fields not in schema.
+///
+/// For fields with Primitive sub-schemas, the output construction phase
+/// (in ShredVariantColumnObject) performs recursive native extraction by
+/// calling ShredVariantColumn on the per-field BinaryArray. This matches
+/// Rust's VariantToShreddedObjectVariantRowBuilder behavior: compatible
+/// field values go to typed_value, incompatible remain in value.
+///
+/// For fields with Object or Array sub-schemas, field values are stored
+/// as variant binary in the "value" sub-column (recursive nested shredding
+/// is a potential follow-up optimization).
+// TODO GH-45948 follow-up: Recursive shredding for nested Object/Array
+// sub-schemas (not just Primitive).
+struct ObjectFieldShredder {
+  ObjectFieldShredder(const VariantShreddingSchema& schema, int64_t num_rows)
+      : schema(schema), num_rows(num_rows) {}
+
+  const VariantShreddingSchema& schema;
+  int64_t num_rows;
+
+  // One BinaryBuilder per schema field (stores variant bytes of matching fields).
+  // For Primitive sub-schemas, the output construction phase re-shreds these
+  // into {value, typed_value} using ShredVariantColumn. For other sub-schemas,
+  // these bytes go directly to the "value" sub-column.
+  std::vector<BinaryBuilder> field_value_builders;
+
+  // Residual: object bytes for fields not in schema
+  BinaryBuilder residual_builder;
+
+  Status Init() {
+    field_value_builders.resize(schema.fields().size());
+    for (auto& b : field_value_builders) {
+      ARROW_RETURN_NOT_OK(b.Reserve(num_rows));
+    }
+    ARROW_RETURN_NOT_OK(residual_builder.Reserve(num_rows));
+    return Status::OK();
+  }
+
+  Status AppendNull() {
+    // Object is missing/null → all field builders get null, residual gets null
+    for (auto& b : field_value_builders) {
+      ARROW_RETURN_NOT_OK(b.AppendNull());
+    }
+    ARROW_RETURN_NOT_OK(residual_builder.AppendNull());
+    return Status::OK();
+  }
+
+  Status AppendNonObject(std::string_view variant_bytes) {
+    // Value is not an object → residual gets the whole value, fields get null
+    for (auto& b : field_value_builders) {
+      ARROW_RETURN_NOT_OK(b.AppendNull());
+    }
+    ARROW_RETURN_NOT_OK(residual_builder.Append(
+        reinterpret_cast<const uint8_t*>(variant_bytes.data()), variant_bytes.size()));
+    return Status::OK();
+  }
+
+  Status AppendObject(const VariantMetadata& meta, const uint8_t* obj_data,
+                      int64_t obj_length) {
+    // Determine which fields from the schema are present in this object
+    const auto& schema_fields = schema.fields();
+
+    // Parse the object header ONCE — all subsequent field access is O(1).
+    ARROW_ASSIGN_OR_RAISE(auto obj_view,
+                          VariantObjectView::Make(meta, obj_data, obj_length));
+    auto field_count = obj_view.num_fields();
+
+    // Single pass over object fields: build a name→(index, offset, size) map.
+    // This eliminates the previous O(s × k) inner marking loop by allowing
+    // O(1) positional index lookup when marking shredded fields.
+    // PERF TODO: This allocates an unordered_map per row. For column-scan
+    // workloads with millions of rows, consider lifting the map to the
+    // ObjectFieldShredder struct and clearing/reusing it across rows.
+    // Duplicate keys (spec-invalid): last occurrence wins in map, earlier
+    // occurrences remain in residual. Matches last-value-wins semantics.
+    struct FieldInfo {
+      int32_t index;
+      int64_t offset;
+      int64_t size;
+      std::string_view name;
+    };
+    std::unordered_map<std::string_view, FieldInfo> object_field_map;
+    object_field_map.reserve(field_count);
+    for (int32_t fi = 0; fi < field_count; ++fi) {
+      ARROW_ASSIGN_OR_RAISE(auto fname, obj_view.field_name(fi));
+      ARROW_ASSIGN_OR_RAISE(auto fvalue, obj_view.field_value(fi));
+      auto foff = fvalue.data() - obj_data;
+      auto fsz = fvalue.size_bytes();
+      object_field_map[fname] = FieldInfo{fi, foff, fsz, fname};
+    }
+
+    // Track which object fields are shredded vs residual
+    std::vector<bool> is_shredded(field_count, false);
+
+    // For each schema field, look it up in the pre-built map.
+    // Total complexity: O(k) for map construction + O(s) for lookups = O(s + k).
+    for (size_t sf = 0; sf < schema_fields.size(); ++sf) {
+      auto it = object_field_map.find(schema_fields[sf].first);
+      if (it != object_field_map.end()) {
+        const auto& info = it->second;
+        ARROW_RETURN_NOT_OK(field_value_builders[sf].Append(
+            obj_data + info.offset, static_cast<int32_t>(info.size)));
+        is_shredded[info.index] = true;
+      } else {
+        // Not found — null for this field
+        ARROW_RETURN_NOT_OK(field_value_builders[sf].AppendNull());
+      }
+    }
+
+    // Build residual object with non-shredded fields
+    bool has_residual = false;
+    for (int32_t fi = 0; fi < field_count; ++fi) {
+      if (!is_shredded[fi]) {
+        has_residual = true;
+        break;
+      }
+    }
+
+    if (has_residual) {
+      // Build a residual variant object with non-shredded fields.
+      // Uses the pre-built object_field_map to avoid re-parsing the object header.
+      VariantBuilder vb(meta);
+      auto start = vb.Offset();
+      std::vector<VariantBuilder::FieldEntry> residual_fields;
+      for (const auto& [fname, info] : object_field_map) {
+        if (!is_shredded[info.index]) {
+          residual_fields.push_back(vb.NextField(start, fname));
+          vb.UnsafeAppendEncoded(obj_data + info.offset, info.size);
+        }
+      }
+      ARROW_RETURN_NOT_OK(vb.FinishObject(start, residual_fields));
+      ARROW_ASSIGN_OR_RAISE(auto residual_bytes, vb.BuildWithoutMeta());
+      ARROW_RETURN_NOT_OK(residual_builder.Append(
+          residual_bytes.data(), static_cast<int32_t>(residual_bytes.size())));
+    } else {
+      // All fields were shredded → residual is null
+      ARROW_RETURN_NOT_OK(residual_builder.AppendNull());
+    }
+
+    return Status::OK();
+  }
+};
+
+}  // namespace
+
+Result<std::shared_ptr<StructArray>> ShredVariantColumnObject(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array, const VariantShreddingSchema& schema) {
+  const int64_t num_rows = value_array->length();
+  const auto& schema_fields = schema.fields();
+
+  ObjectFieldShredder shredder(schema, num_rows);
+  ARROW_RETURN_NOT_OK(shredder.Init());
+
+  for (int64_t i = 0; i < num_rows; ++i) {
+    if (value_array->IsNull(i)) {
+      ARROW_RETURN_NOT_OK(shredder.AppendNull());
+      continue;
+    }
+
+    auto bytes = GetBinaryValue(*value_array, i);
+    auto* data = reinterpret_cast<const uint8_t*>(bytes.data());
+    auto len = static_cast<int64_t>(bytes.size());
+
+    if (len < 1) {
+      ARROW_RETURN_NOT_OK(shredder.AppendNull());
+      continue;
+    }
+
+    auto basic_type = GetBasicType(data[0]);
+    if (basic_type != BasicType::kObject) {
+      // Not an object → goes entirely to residual value
+      ARROW_RETURN_NOT_OK(shredder.AppendNonObject(bytes));
+      continue;
+    }
+
+    // Decode metadata for this row
+    auto meta_bytes = GetBinaryValue(*metadata_array, i);
+    ARROW_ASSIGN_OR_RAISE(
+        auto meta, DecodeMetadata(reinterpret_cast<const uint8_t*>(meta_bytes.data()),
+                                  static_cast<int64_t>(meta_bytes.size())));
+
+    ARROW_RETURN_NOT_OK(shredder.AppendObject(meta, data, len));
+  }
+
+  // Build output: typed_value is a struct with one field per schema field.
+  // Each field is a struct {value: binary(nullable), typed_value: <type>(nullable)}.
+  // For fields with Primitive sub-schemas, we perform native extraction:
+  // compatible values go to typed_value, incompatible remain in value.
+  // This matches Rust's recursive shredding behavior.
+  std::vector<std::shared_ptr<Array>> typed_value_columns;
+  std::vector<std::shared_ptr<Field>> typed_value_fields;
+
+  for (size_t sf = 0; sf < schema_fields.size(); ++sf) {
+    std::shared_ptr<Array> field_arr;
+    ARROW_RETURN_NOT_OK(shredder.field_value_builders[sf].Finish(&field_arr));
+
+    const auto& sub_schema = schema_fields[sf].second;
+
+    if (sub_schema.kind() == VariantShreddingSchema::Kind::kPrimitive) {
+      // Recursive native extraction: shred the field values through the
+      // primitive path. This produces a struct {metadata, value, typed_value}
+      // from which we extract just {value, typed_value} for the sub-field.
+      // We use the top-level metadata_array since field values reference
+      // the same metadata dictionary.
+      ARROW_ASSIGN_OR_RAISE(auto field_shredded,
+                            ShredVariantColumn(metadata_array, field_arr, sub_schema));
+      auto field_value_col = field_shredded->field(1);  // "value" (nullable)
+      auto field_typed_col = field_shredded->field(2);  // "typed_value" (nullable)
+
+      // Determine typed_value field type — for TIMESTAMP/TIME64, the builder
+      // produces Int64Array, so the field declares int64().
+      auto typed_field_type = sub_schema.type();
+      if (typed_field_type->id() == Type::TIMESTAMP ||
+          typed_field_type->id() == Type::TIME64) {
+        typed_field_type = int64();
+      }
+
+      auto inner_fields = std::vector<std::shared_ptr<Field>>{
+          field("value", binary(), true),
+          field("typed_value", typed_field_type, true),
+      };
+      ARROW_ASSIGN_OR_RAISE(
+          auto field_struct,
+          StructArray::Make({field_value_col, field_typed_col}, inner_fields));
+      typed_value_columns.push_back(field_struct);
+      typed_value_fields.push_back(
+          field(schema_fields[sf].first, field_struct->type(), false));
+    } else {
+      // Non-primitive sub-schemas (Object, Array): store field values as
+      // variant binary in the "value" sub-column. Recursive shredding of
+      // nested objects/arrays is a potential follow-up optimization.
+      //
+      // NOTE: We use NullArray here for the typed_value sub-column. The field
+      // metadata declares the logical type (from sub_schema.ToArrowType()),
+      // but the actual array is type null(). This is semantically acceptable
+      // because the field is always null (no typed extraction for non-primitive
+      // sub-schemas), so no consumer will attempt to access typed data. The
+      // declared field type serves only as schema documentation for readers
+      // inspecting the shredded output structure.
+      auto null_arr = std::make_shared<NullArray>(num_rows);
+      auto inner_fields = std::vector<std::shared_ptr<Field>>{
+          field("value", binary(), true),
+          field("typed_value", sub_schema.ToArrowType(), true),
+      };
+      ARROW_ASSIGN_OR_RAISE(auto field_struct,
+                            StructArray::Make({field_arr, null_arr}, inner_fields));
+      typed_value_columns.push_back(field_struct);
+      typed_value_fields.push_back(
+          field(schema_fields[sf].first, field_struct->type(), false));
+    }
+  }
+
+  std::shared_ptr<Array> typed_value_struct;
+  if (!typed_value_fields.empty()) {
+    ARROW_ASSIGN_OR_RAISE(typed_value_struct,
+                          StructArray::Make(typed_value_columns, typed_value_fields));
+  } else {
+    typed_value_struct = std::make_shared<NullArray>(num_rows);
+  }
+
+  std::shared_ptr<Array> residual_result;
+  ARROW_RETURN_NOT_OK(shredder.residual_builder.Finish(&residual_result));
+
+  auto output_fields = std::vector<std::shared_ptr<Field>>{
+      field("metadata", metadata_array->type(), false),
+      field("value", binary(), true),
+      field("typed_value", typed_value_struct->type(), true),
+  };
+
+  return StructArray::Make({metadata_array, residual_result, typed_value_struct},
+                           output_fields);
+}
+
+// ---------------------------------------------------------------------------
+// ShredVariantColumnArray — array element-wise shredding
+// ---------------------------------------------------------------------------
+
+Result<std::shared_ptr<StructArray>> ShredVariantColumnArray(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array, const VariantShreddingSchema& schema) {
+  const int64_t num_rows = value_array->length();
+
+  // For array shredding, typed_value is a ListArray where each element
+  // is a struct {value: binary, typed_value: <elem_type>}.
+  // Per the spec: if the variant is an array → typed_value is the list, value is null.
+  //              if the variant is NOT an array → typed_value is null, value has the
+  //              bytes.
+  //
+  // Rust parity: elements are recursively shredded according to the element schema,
+  // producing native typed columns for compatible elements. Incompatible elements
+  // remain in the per-element value column as variant binary. This enables
+  // statistics-based predicate pushdown on array element values.
+
+  BinaryBuilder residual_value_builder;
+  ARROW_RETURN_NOT_OK(residual_value_builder.Reserve(num_rows));
+
+  // Phase 1: Extract array element bytes into a flat BinaryArray.
+  // Track list offsets and validity manually (rather than using ListBuilder)
+  // to avoid double-finish issues with the internal value builder.
+  BinaryBuilder elem_value_builder;
+  BinaryBuilder elem_metadata_builder;
+  std::vector<int32_t> list_offsets;
+  list_offsets.reserve(num_rows + 1);
+  list_offsets.push_back(0);
+  std::vector<bool> list_validity(num_rows, false);
+
+  for (int64_t i = 0; i < num_rows; ++i) {
+    if (value_array->IsNull(i)) {
+      ARROW_RETURN_NOT_OK(residual_value_builder.AppendNull());
+      list_offsets.push_back(list_offsets.back());
+      // list_validity[i] remains false (null)
+      continue;
+    }
+
+    auto bytes = GetBinaryValue(*value_array, i);
+    auto* data = reinterpret_cast<const uint8_t*>(bytes.data());
+    auto len = static_cast<int64_t>(bytes.size());
+
+    if (len < 1 || GetBasicType(data[0]) != BasicType::kArray) {
+      // Not an array → residual value, typed_value null
+      ARROW_RETURN_NOT_OK(residual_value_builder.Append(
+          reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+      list_offsets.push_back(list_offsets.back());
+      // list_validity[i] remains false (null)
+      continue;
+    }
+
+    // Is an array → extract elements
+    ARROW_RETURN_NOT_OK(residual_value_builder.AppendNull());
+    list_validity[i] = true;
+
+    // Get the row's metadata for element replication
+    auto meta_bytes = GetBinaryValue(*metadata_array, i);
+
+    VariantMetadata empty_meta;
+    ARROW_ASSIGN_OR_RAISE(auto arr_view, VariantArrayView::Make(empty_meta, data, len));
+    auto elem_count = arr_view.num_elements();
+    for (int32_t ei = 0; ei < elem_count; ++ei) {
+      ARROW_ASSIGN_OR_RAISE(auto elem, arr_view.get(ei));
+      ARROW_RETURN_NOT_OK(elem_value_builder.Append(
+          elem.data(), static_cast<int32_t>(elem.size_bytes())));
+      ARROW_RETURN_NOT_OK(elem_metadata_builder.Append(
+          reinterpret_cast<const uint8_t*>(meta_bytes.data()), meta_bytes.size()));
+    }
+    list_offsets.push_back(static_cast<int32_t>(list_offsets.back() + elem_count));
+  }
+
+  // Phase 2: Recursively shred the flattened element array through the element schema.
+  std::shared_ptr<Array> elem_values_arr;
+  ARROW_RETURN_NOT_OK(elem_value_builder.Finish(&elem_values_arr));
+
+  std::shared_ptr<Array> elem_metadata_arr;
+  ARROW_RETURN_NOT_OK(elem_metadata_builder.Finish(&elem_metadata_arr));
+
+  ARROW_ASSIGN_OR_RAISE(
+      auto elem_shredded,
+      ShredVariantColumn(elem_metadata_arr, elem_values_arr, schema.element_schema()));
+
+  // Extract the {value, typed_value} columns from the recursively shredded result.
+  auto elem_value_col = elem_shredded->field(1);  // per-element residual value
+  auto elem_typed_col = elem_shredded->field(2);  // per-element typed_value
+
+  // Determine typed_value field type for the element struct.
+  auto elem_typed_field_type = schema.element_schema().type();
+  if (schema.element_schema().kind() == VariantShreddingSchema::Kind::kPrimitive) {
+    if (elem_typed_field_type && (elem_typed_field_type->id() == Type::TIMESTAMP ||
+                                  elem_typed_field_type->id() == Type::TIME64)) {
+      elem_typed_field_type = int64();
+    }
+  } else {
+    // For Object/Array element schemas, use the shredded output's actual type
+    elem_typed_field_type = elem_typed_col->type();
+  }
+
+  // Build the element struct array: {value: binary, typed_value: <elem_type>}
+  auto elem_struct_fields = std::vector<std::shared_ptr<Field>>{
+      field("value", binary(), true),
+      field("typed_value", elem_typed_field_type, true),
+  };
+  ARROW_ASSIGN_OR_RAISE(
+      auto elem_struct_arr,
+      StructArray::Make({elem_value_col, elem_typed_col}, elem_struct_fields));
+
+  // Phase 3: Build the ListArray from manually tracked offsets and the element struct.
+  auto offsets_buf = Buffer::FromVector(std::move(list_offsets));
+
+  // Build null bitmap for the list
+  int64_t null_count = 0;
+  std::shared_ptr<Buffer> null_bitmap;
+  for (int64_t i = 0; i < num_rows; ++i) {
+    if (!list_validity[i]) ++null_count;
+  }
+  if (null_count > 0) {
+    ARROW_ASSIGN_OR_RAISE(null_bitmap, AllocateBitmap(num_rows));
+    for (int64_t i = 0; i < num_rows; ++i) {
+      if (list_validity[i]) {
+        bit_util::SetBit(null_bitmap->mutable_data(), i);
+      } else {
+        bit_util::ClearBit(null_bitmap->mutable_data(), i);
+      }
+    }
+  }
+
+  auto typed_value_list = std::make_shared<ListArray>(
+      list(field("element", elem_struct_arr->type(), false)), num_rows, offsets_buf,
+      elem_struct_arr, null_bitmap, null_count);
+
+  std::shared_ptr<Array> residual_result;
+  ARROW_RETURN_NOT_OK(residual_value_builder.Finish(&residual_result));
+
+  auto output_fields = std::vector<std::shared_ptr<Field>>{
+      field("metadata", metadata_array->type(), false),
+      field("value", binary(), true),
+      field("typed_value", typed_value_list->type(), true),
+  };
+
+  return StructArray::Make({metadata_array, residual_result,
+                            std::static_pointer_cast<Array>(typed_value_list)},
+                           output_fields);
+}
+
+// ---------------------------------------------------------------------------
+// Template helpers for primitive shredding
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Generic primitive shredding loop. For each row:
+///  - If input is null → both builders get null
+///  - If Variant::Null → value column gets bytes, typed gets null
+///  - If extraction succeeds → typed gets value, residual gets null
+///  - Otherwise → value column gets bytes, typed gets null
+///
+/// This eliminates ~360 lines of per-type copy-paste that previously existed
+/// as individual switch cases with identical structure.
+template <typename BuilderT, typename NativeT, typename ExtractFn>
+Status ShredPrimitiveLoop(const Array& value_array, int64_t num_rows,
+                          BinaryBuilder& residual, std::shared_ptr<Array>* out,
+                          ExtractFn&& extract) {
+  BuilderT typed_builder;
+  ARROW_RETURN_NOT_OK(typed_builder.Reserve(num_rows));
+  for (int64_t i = 0; i < num_rows; ++i) {
+    if (value_array.IsNull(i)) {
+      ARROW_RETURN_NOT_OK(residual.AppendNull());
+      ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+      continue;
+    }
+    auto bytes = GetBinaryValue(value_array, i);
+    auto* data = reinterpret_cast<const uint8_t*>(bytes.data());
+    auto len = static_cast<int64_t>(bytes.size());
+    // Default-initialized; only read when extract() returns true.
+    NativeT native_val{};
+    if (IsVariantNull(data, len)) {
+      // Variant::Null goes to value column — distinguishes from SQL NULL
+      ARROW_RETURN_NOT_OK(
+          residual.Append(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+      ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+    } else if (extract(data, len, &native_val)) {
+      ARROW_RETURN_NOT_OK(residual.AppendNull());
+      ARROW_RETURN_NOT_OK(typed_builder.Append(native_val));
+    } else {
+      ARROW_RETURN_NOT_OK(
+          residual.Append(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+      ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+    }
+  }
+  return typed_builder.Finish(out);
+}
+
+/// Specialization for BINARY/LARGE_BINARY extraction (uses pointer+size output).
+template <typename BuilderT>
+Status ShredBinaryLoop(const Array& value_array, int64_t num_rows,
+                       BinaryBuilder& residual, std::shared_ptr<Array>* out) {
+  BuilderT typed_builder;
+  ARROW_RETURN_NOT_OK(typed_builder.Reserve(num_rows));
+  for (int64_t i = 0; i < num_rows; ++i) {
+    if (value_array.IsNull(i)) {
+      ARROW_RETURN_NOT_OK(residual.AppendNull());
+      ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+      continue;
+    }
+    auto bytes = GetBinaryValue(value_array, i);
+    auto* data = reinterpret_cast<const uint8_t*>(bytes.data());
+    auto len = static_cast<int64_t>(bytes.size());
+    const uint8_t* bin_data;
+    int32_t bin_size;
+    if (IsVariantNull(data, len)) {
+      ARROW_RETURN_NOT_OK(
+          residual.Append(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+      ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+    } else if (ExtractBinary(data, len, &bin_data, &bin_size)) {
+      ARROW_RETURN_NOT_OK(residual.AppendNull());
+      ARROW_RETURN_NOT_OK(typed_builder.Append(bin_data, bin_size));
+    } else {
+      ARROW_RETURN_NOT_OK(
+          residual.Append(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+      ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+    }
+  }
+  return typed_builder.Finish(out);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// ShredVariantColumn — dispatch by schema kind
+// ---------------------------------------------------------------------------
+
+Result<std::shared_ptr<StructArray>> ShredVariantColumn(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array, const VariantShreddingSchema& schema) {
+  // Validate input array types — GetBinaryValue silently returns empty for
+  // unsupported types, which would cause subtle data corruption.
+  if (metadata_array->type_id() != Type::BINARY &&
+      metadata_array->type_id() != Type::LARGE_BINARY &&
+      metadata_array->type_id() != Type::BINARY_VIEW) {
+    return Status::Invalid(
+        "ShredVariantColumn: metadata_array must be BINARY, LARGE_BINARY, or "
+        "BINARY_VIEW, got ",
+        metadata_array->type()->ToString());
+  }
+  if (value_array->type_id() != Type::BINARY &&
+      value_array->type_id() != Type::LARGE_BINARY &&
+      value_array->type_id() != Type::BINARY_VIEW) {
+    return Status::Invalid(
+        "ShredVariantColumn: value_array must be BINARY, LARGE_BINARY, or BINARY_VIEW, "
+        "got ",
+        value_array->type()->ToString());
+  }
+  if (metadata_array->length() != value_array->length()) {
+    return Status::Invalid(
+        "ShredVariantColumn: metadata_array and value_array length mismatch (",
+        metadata_array->length(), " vs ", value_array->length(), ")");
+  }
+
+  if (schema.kind() == VariantShreddingSchema::Kind::kArray) {
+    return ShredVariantColumnArray(metadata_array, value_array, schema);
+  }
+
+  if (schema.kind() == VariantShreddingSchema::Kind::kObject) {
+    return ShredVariantColumnObject(metadata_array, value_array, schema);
+  }
+
+  // Primitive shredding
+  const int64_t num_rows = value_array->length();
+  const auto& target_type = *schema.type();
+
+  // Residual value builder (variant bytes for non-matching rows)
+  BinaryBuilder residual_value_builder;
+  ARROW_RETURN_NOT_OK(residual_value_builder.Reserve(num_rows));
+
+  // NOTE (Rust divergence): Rust's shredding uses arrow::compute::cast() which
+  // allows cross-type conversions (e.g., Int32→Float64, Float32→Int32). C++
+  // only shreds values whose variant type matches the target column type
+  // directly (with safe widening within the same numeric family, e.g.,
+  // Int8→Int64). This is spec-compliant but less aggressive for predicate
+  // pushdown. A future cast-based approach could be added as a separate mode.
+  //
+  // NOTE (Rust divergence — additional types): Rust additionally supports
+  // Uint8/16/32/64, Float16, Decimal32, Decimal64, Decimal256, and
+  // TimestampSecond/Millisecond as shredding targets. These require the
+  // cast-based mode (variant spec only encodes signed ints, float32/64,
+  // and timestamp micros/nanos natively). Adding them is straightforward
+  // once the CastOptions mode is implemented.
+  std::shared_ptr<Array> typed_result;
+
+  switch (target_type.id()) {
+    case Type::INT64: {
+      // Note: No IsVariantCompatibleWithType() gatekeeper here because
+      // ExtractInt64() already accepts only Int8/Int16/Int32/Int64 variants,
+      // and all int→int64 widening is unconditionally valid per the spec.
+      // This differs from TIMESTAMP/DECIMAL which need explicit type matching.
+      auto st = ShredPrimitiveLoop<Int64Builder, int64_t>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, int64_t* out) {
+            return ExtractInt64(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::DOUBLE: {
+      auto st = ShredPrimitiveLoop<DoubleBuilder, double>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, double* out) {
+            return ExtractDoubleOrFloat(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::BOOL: {
+      auto st = ShredPrimitiveLoop<BooleanBuilder, bool>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, bool* out) {
+            return ExtractBool(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::STRING: {
+      auto st = ShredPrimitiveLoop<StringBuilder, std::string_view>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, std::string_view* out) {
+            return ExtractString(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::LARGE_STRING: {
+      auto st = ShredPrimitiveLoop<LargeStringBuilder, std::string_view>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, std::string_view* out) {
+            return ExtractString(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::FLOAT: {
+      auto st = ShredPrimitiveLoop<FloatBuilder, float>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, float* out) {
+            return ExtractFloat(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::DATE32: {
+      auto st = ShredPrimitiveLoop<Date32Builder, int32_t>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, int32_t* out) {
+            return ExtractDate32(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::TIMESTAMP: {
+      // Use Int64 storage for timestamps (Arrow stores timestamps as int64).
+      // IsVariantCompatibleWithType enforces TimeUnit and timezone matching,
+      // so only correctly-matching timestamp variants reach the typed column.
+      auto st = ShredPrimitiveLoop<Int64Builder, int64_t>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, int64_t* out) {
+            return IsVariantCompatibleWithType(data, len, target_type) &&
+                   ExtractTimestamp(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::INT8: {
+      auto st = ShredPrimitiveLoop<Int8Builder, int8_t>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, int8_t* out) {
+            return ExtractInt8(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::INT16: {
+      auto st = ShredPrimitiveLoop<Int16Builder, int16_t>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, int16_t* out) {
+            return ExtractInt16(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::INT32: {
+      auto st = ShredPrimitiveLoop<Int32Builder, int32_t>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, int32_t* out) {
+            return ExtractInt32(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::BINARY: {
+      auto st = ShredBinaryLoop<BinaryBuilder>(*value_array, num_rows,
+                                               residual_value_builder, &typed_result);
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::LARGE_BINARY: {
+      auto st = ShredBinaryLoop<LargeBinaryBuilder>(
+          *value_array, num_rows, residual_value_builder, &typed_result);
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::STRING_VIEW: {
+      auto st = ShredPrimitiveLoop<StringViewBuilder, std::string_view>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, std::string_view* out) {
+            return ExtractString(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::BINARY_VIEW: {
+      // Note: ShredBinaryLoop calls typed_builder.Append(bin_data, bin_size) where
+      // bin_size is int32_t. BinaryViewBuilder::Append accepts int64_t — the implicit
+      // widening from int32_t is safe and produces correct results.
+      auto st = ShredBinaryLoop<BinaryViewBuilder>(*value_array, num_rows,
+                                                   residual_value_builder, &typed_result);
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::TIME64: {
+      auto st = ShredPrimitiveLoop<Int64Builder, int64_t>(
+          *value_array, num_rows, residual_value_builder, &typed_result,
+          [&](const uint8_t* data, int64_t len, int64_t* out) {
+            return ExtractTime64(data, len, out);
+          });
+      ARROW_RETURN_NOT_OK(st);
+      break;
+    }
+
+    case Type::FIXED_SIZE_BINARY: {
+      // UUID = FixedSizeBinary(16)
+      auto& fsb_type = static_cast<const FixedSizeBinaryType&>(target_type);
+      if (fsb_type.byte_width() != 16) {
+        return Status::NotImplemented(
+            "ShredVariantColumn: only FixedSizeBinary(16) for UUID is supported");
+      }
+      FixedSizeBinaryBuilder typed_builder(fixed_size_binary(kUUIDByteLength));
+      ARROW_RETURN_NOT_OK(typed_builder.Reserve(num_rows));
+      for (int64_t i = 0; i < num_rows; ++i) {
+        if (value_array->IsNull(i)) {
+          ARROW_RETURN_NOT_OK(residual_value_builder.AppendNull());
+          ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+          continue;
+        }
+        auto bytes = GetBinaryValue(*value_array, i);
+        auto* data = reinterpret_cast<const uint8_t*>(bytes.data());
+        auto len = static_cast<int64_t>(bytes.size());
+        uint8_t uuid_bytes[kUUIDByteLength];
+        if (IsVariantNull(data, len)) {
+          ARROW_RETURN_NOT_OK(residual_value_builder.Append(
+              reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+          ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+        } else if (ExtractUUID(data, len, uuid_bytes)) {
+          ARROW_RETURN_NOT_OK(residual_value_builder.AppendNull());
+          ARROW_RETURN_NOT_OK(typed_builder.Append(uuid_bytes));
+        } else {
+          ARROW_RETURN_NOT_OK(residual_value_builder.Append(
+              reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+          ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+        }
+      }
+      ARROW_RETURN_NOT_OK(typed_builder.Finish(&typed_result));
+      break;
+    }
+
+    case Type::DECIMAL128: {
+      // Decimal128 shredding — extracts scale from variant, stores unscaled value.
+      // IsVariantCompatibleWithType checks both type and scale compatibility.
+      // Note: Rust also supports Decimal32/Decimal64 as separate shredding targets
+      // (via VariantDecimal4/VariantDecimal8 types). C++ Arrow only has Decimal128/256,
+      // so we consolidate all decimal widths into Decimal128 storage.
+      Decimal128Builder typed_builder(schema.type());
+      ARROW_RETURN_NOT_OK(typed_builder.Reserve(num_rows));
+      for (int64_t i = 0; i < num_rows; ++i) {
+        if (value_array->IsNull(i)) {
+          ARROW_RETURN_NOT_OK(residual_value_builder.AppendNull());
+          ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+          continue;
+        }
+        auto bytes = GetBinaryValue(*value_array, i);
+        auto* data = reinterpret_cast<const uint8_t*>(bytes.data());
+        auto len = static_cast<int64_t>(bytes.size());
+        int64_t low = 0, high = 0;
+        uint8_t scale = 0;
+        if (IsVariantNull(data, len)) {
+          ARROW_RETURN_NOT_OK(residual_value_builder.Append(
+              reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+          ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+        } else if (IsVariantCompatibleWithType(data, len, target_type) &&
+                   ExtractDecimal128(data, len, &low, &high, &scale)) {
+          Decimal128 dec_val(high, static_cast<uint64_t>(low));
+          ARROW_RETURN_NOT_OK(typed_builder.Append(dec_val));
+          ARROW_RETURN_NOT_OK(residual_value_builder.AppendNull());
+        } else {
+          ARROW_RETURN_NOT_OK(residual_value_builder.Append(
+              reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+          ARROW_RETURN_NOT_OK(typed_builder.AppendNull());
+        }
+      }
+      ARROW_RETURN_NOT_OK(typed_builder.Finish(&typed_result));
+      break;
+    }
+
+      // TODO GH-45948 follow-up: Add FixedSizeList and ListView as array
+      // shredding targets (Rust supports all list-like types via GenericListArray).
+      // LargeList is supported in reconstruction but not as a distinct shredding
+      // output (shredding always produces ListArray with 32-bit offsets).
+      // TODO GH-45948 follow-up (Rust parity — cast mode): Add support for:
+      //   - Uint8/16/32/64 (variant spec only encodes signed ints; requires cast)
+      //   - Float16 (variant spec encodes Float32/64; requires cast/truncation)
+      //   - Decimal32, Decimal64 (Rust has VariantDecimal4/8 dedicated types)
+      //   - TimestampSecond, TimestampMillisecond (variant spec only has micros/nanos;
+      //     requires unit conversion similar to Rust's CastOptions approach)
+      //   These all require a CastOptions-based extraction mode analogous to Rust's
+      //   `shred_variant_with_options()` which uses arrow::compute::cast().
+
+    default:
+      return Status::NotImplemented("ShredVariantColumn: unsupported target type ",
+                                    target_type.ToString());
+  }
+
+  std::shared_ptr<Array> residual_result;
+  ARROW_RETURN_NOT_OK(residual_value_builder.Finish(&residual_result));
+
+  // Determine the output field type for typed_value. For most types this is
+  // schema.type() directly. For TIMESTAMP and TIME64, the builder produces
+  // Int64Array (physical storage), so declare the field as int64() to match.
+  // The reconstruction path uses schema.type()->id() to re-encode correctly.
+  auto typed_field_type = schema.type();
+  if (typed_field_type->id() == Type::TIMESTAMP ||
+      typed_field_type->id() == Type::TIME64) {
+    typed_field_type = int64();
+  }
+
+  auto output_fields = std::vector<std::shared_ptr<Field>>{
+      field("metadata", metadata_array->type(), /*nullable=*/false),
+      field("value", binary(), /*nullable=*/true),
+      field("typed_value", typed_field_type, /*nullable=*/true),
+  };
+
+  return StructArray::Make({metadata_array, residual_result, typed_result},
+                           output_fields);
+}
+
+// ---------------------------------------------------------------------------
+// ReconstructVariantColumnArray
+// ---------------------------------------------------------------------------
+
+static Result<std::shared_ptr<Array>> ReconstructVariantColumnArray(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array,
+    const std::shared_ptr<Array>& typed_value_array,
+    const VariantShreddingSchema& schema) {
+  const int64_t num_rows = metadata_array->length();
+
+  // Validate typed_value_array is a list-like array with binary elements.
+  // Accept LIST, LARGE_LIST, FIXED_SIZE_LIST, LIST_VIEW, and LARGE_LIST_VIEW
+  // to support all Parquet list-like representations (Rust parity).
+  if (typed_value_array->type_id() != Type::LIST &&
+      typed_value_array->type_id() != Type::LARGE_LIST &&
+      typed_value_array->type_id() != Type::FIXED_SIZE_LIST &&
+      typed_value_array->type_id() != Type::LIST_VIEW &&
+      typed_value_array->type_id() != Type::LARGE_LIST_VIEW) {
+    return Status::Invalid(
+        "ReconstructVariantColumnArray: typed_value_array must be LIST, LARGE_LIST, "
+        "FIXED_SIZE_LIST, LIST_VIEW, or LARGE_LIST_VIEW, got ",
+        typed_value_array->type()->ToString());
+  }
+
+  BinaryBuilder output_builder;
+  ARROW_RETURN_NOT_OK(output_builder.Reserve(num_rows));
+
+  // Generic lambda that handles any list-like type with value_offset(i) + values().
+  // Works for LIST, LARGE_LIST, FIXED_SIZE_LIST, LIST_VIEW, and LARGE_LIST_VIEW.
+  // Elements can be either raw BINARY (legacy format) or STRUCT{value, typed_value}
+  // (recursively shredded format). We detect which format at runtime.
+  auto reconstruct_rows_offset_based = [&](auto* list_arr) -> Status {
+    auto value_type_id = list_arr->value_type()->id();
+
+    if (value_type_id == Type::BINARY) {
+      // Legacy format: elements are raw binary variant bytes.
+      DCHECK_NE(list_arr->values(), nullptr);
+      const auto* elem_arr = static_cast<const BinaryArray*>(list_arr->values().get());
+
+      for (int64_t i = 0; i < num_rows; ++i) {
+        bool value_present = value_array && value_array->IsValid(i);
+        bool typed_present = typed_value_array && typed_value_array->IsValid(i);
+
+        if (!value_present && !typed_present) {
+          uint8_t null_byte = 0x00;
+          ARROW_RETURN_NOT_OK(output_builder.Append(&null_byte, 1));
+        } else if (value_present && !typed_present) {
+          auto bytes = GetBinaryValue(*value_array, i);
+          ARROW_RETURN_NOT_OK(output_builder.Append(
+              reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+        } else if (!value_present && typed_present) {
+          VariantBuilder vb;
+          auto start = vb.Offset();
+          std::vector<int64_t> offsets;
+
+          auto list_start = list_arr->value_offset(i);
+          auto list_length = list_arr->value_length(i);
+          for (decltype(list_length) ei = 0; ei < list_length; ++ei) {
+            offsets.push_back(vb.NextElement(start));
+            auto elem_view = elem_arr->GetView(static_cast<int64_t>(list_start + ei));
+            vb.UnsafeAppendEncoded(reinterpret_cast<const uint8_t*>(elem_view.data()),
+                                   static_cast<int64_t>(elem_view.size()));
+          }
+
+          ARROW_RETURN_NOT_OK(vb.FinishArray(start, offsets));
+          ARROW_ASSIGN_OR_RAISE(auto arr_bytes, vb.BuildWithoutMeta());
+          ARROW_RETURN_NOT_OK(output_builder.Append(
+              arr_bytes.data(), static_cast<int32_t>(arr_bytes.size())));
+        } else {
+          return Status::Invalid(
+              "ReconstructVariantColumn: both value and typed_value non-null "
+              "at row ",
+              i, " (not valid for array schemas)");
+        }
+      }
+    } else if (value_type_id == Type::STRUCT) {
+      // Recursively shredded format: elements are struct{value, typed_value}.
+      // Reconstruct elements first at the column level, then use the
+      // reconstructed per-element binary to build variant arrays.
+      DCHECK_NE(list_arr->values(), nullptr);
+      const auto* elem_struct = static_cast<const StructArray*>(list_arr->values().get());
+
+      if (elem_struct->num_fields() != 2) {
+        return Status::Invalid(
+            "ReconstructVariantColumnArray: element struct must have 2 fields "
+            "(value, typed_value), got ",
+            elem_struct->num_fields());
+      }
+      auto elem_value_col = elem_struct->field(0);
+      auto elem_typed_col = elem_struct->field(1);
+
+      // Build a metadata array for elements by replicating row metadata.
+      int64_t total_elements = elem_struct->length();
+      BinaryBuilder elem_meta_builder;
+      ARROW_RETURN_NOT_OK(elem_meta_builder.Reserve(total_elements));
+      for (int64_t i = 0; i < num_rows; ++i) {
+        if (!typed_value_array->IsValid(i)) continue;
+        auto meta_bytes = GetBinaryValue(*metadata_array, i);
+        auto list_length = list_arr->value_length(i);
+        for (decltype(list_length) ei = 0; ei < list_length; ++ei) {
+          ARROW_RETURN_NOT_OK(elem_meta_builder.Append(
+              reinterpret_cast<const uint8_t*>(meta_bytes.data()), meta_bytes.size()));
+        }
+      }
+      std::shared_ptr<Array> elem_meta_arr;
+      ARROW_RETURN_NOT_OK(elem_meta_builder.Finish(&elem_meta_arr));
+
+      if (elem_meta_arr->length() != total_elements) {
+        return Status::Invalid(
+            "ReconstructVariantColumnArray: element metadata count mismatch (",
+            elem_meta_arr->length(), " vs ", total_elements, " elements)");
+      }
+
+      // Recursively reconstruct all elements at once (column-level operation)
+      ARROW_ASSIGN_OR_RAISE(
+          auto reconstructed_elements,
+          ReconstructVariantColumn(elem_meta_arr, elem_value_col, elem_typed_col,
+                                   schema.element_schema()));
+
+      // Build variant arrays from the reconstructed element bytes
+      for (int64_t i = 0; i < num_rows; ++i) {
+        bool value_present = value_array && value_array->IsValid(i);
+        bool typed_present = typed_value_array && typed_value_array->IsValid(i);
+
+        if (!value_present && !typed_present) {
+          uint8_t null_byte = 0x00;
+          ARROW_RETURN_NOT_OK(output_builder.Append(&null_byte, 1));
+        } else if (value_present && !typed_present) {
+          auto bytes = GetBinaryValue(*value_array, i);
+          ARROW_RETURN_NOT_OK(output_builder.Append(
+              reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+        } else if (!value_present && typed_present) {
+          VariantBuilder vb;
+          auto start = vb.Offset();
+          std::vector<int64_t> offsets;
+
+          auto list_start = list_arr->value_offset(i);
+          auto list_length = list_arr->value_length(i);
+          for (decltype(list_length) ei = 0; ei < list_length; ++ei) {
+            offsets.push_back(vb.NextElement(start));
+            auto elem_bytes = GetBinaryValue(*reconstructed_elements,
+                                             static_cast<int64_t>(list_start + ei));
+            vb.UnsafeAppendEncoded(reinterpret_cast<const uint8_t*>(elem_bytes.data()),
+                                   static_cast<int64_t>(elem_bytes.size()));
+          }
+
+          ARROW_RETURN_NOT_OK(vb.FinishArray(start, offsets));
+          ARROW_ASSIGN_OR_RAISE(auto arr_bytes, vb.BuildWithoutMeta());
+          ARROW_RETURN_NOT_OK(output_builder.Append(
+              arr_bytes.data(), static_cast<int32_t>(arr_bytes.size())));
+        } else {
+          return Status::Invalid(
+              "ReconstructVariantColumn: both value and typed_value non-null "
+              "at row ",
+              i, " (not valid for array schemas)");
+        }
+      }
+    } else {
+      return Status::Invalid(
+          "ReconstructVariantColumnArray: list elements must be BINARY or "
+          "STRUCT{value, typed_value}, got ",
+          list_arr->value_type()->ToString());
+    }
+    return Status::OK();
+  };
+
+  switch (typed_value_array->type_id()) {
+    case Type::LIST:
+      ARROW_RETURN_NOT_OK(reconstruct_rows_offset_based(
+          static_cast<const ListArray*>(typed_value_array.get())));
+      break;
+    case Type::LARGE_LIST:
+      ARROW_RETURN_NOT_OK(reconstruct_rows_offset_based(
+          static_cast<const LargeListArray*>(typed_value_array.get())));
+      break;
+    case Type::FIXED_SIZE_LIST:
+      ARROW_RETURN_NOT_OK(reconstruct_rows_offset_based(
+          static_cast<const FixedSizeListArray*>(typed_value_array.get())));
+      break;
+    case Type::LIST_VIEW:
+      ARROW_RETURN_NOT_OK(reconstruct_rows_offset_based(
+          static_cast<const ListViewArray*>(typed_value_array.get())));
+      break;
+    case Type::LARGE_LIST_VIEW:
+      ARROW_RETURN_NOT_OK(reconstruct_rows_offset_based(
+          static_cast<const LargeListViewArray*>(typed_value_array.get())));
+      break;
+    default:
+      return Status::Invalid(
+          "ReconstructVariantColumnArray: unexpected typed_value type ",
+          typed_value_array->type()->ToString());
+  }
+
+  std::shared_ptr<Array> result;
+  ARROW_RETURN_NOT_OK(output_builder.Finish(&result));
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// ReconstructVariantColumnObject
+// ---------------------------------------------------------------------------
+
+static Result<std::shared_ptr<Array>> ReconstructVariantColumnObject(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array,
+    const std::shared_ptr<Array>& typed_value_array,
+    const VariantShreddingSchema& schema) {
+  const int64_t num_rows = metadata_array->length();
+  const auto& schema_fields = schema.fields();
+
+  // Validate typed_value_array is the expected StructArray.
+  if (typed_value_array->type_id() != Type::STRUCT) {
+    return Status::Invalid(
+        "ReconstructVariantColumnObject: typed_value_array must be STRUCT, got ",
+        typed_value_array->type()->ToString());
+  }
+
+  BinaryBuilder output_builder;
+  ARROW_RETURN_NOT_OK(output_builder.Reserve(num_rows));
+
+  // typed_value should be a StructArray with one field per schema field
+  const auto* typed_struct = static_cast<const StructArray*>(typed_value_array.get());
+
+  // Validate that the typed_value struct has the expected number of fields.
+  if (typed_struct->num_fields() != static_cast<int>(schema_fields.size())) {
+    return Status::Invalid("ReconstructVariantColumnObject: typed_value struct has ",
+                           typed_struct->num_fields(), " fields but schema expects ",
+                           schema_fields.size());
+  }
+
+  // Pre-compute per-field reconstructed variant arrays for fields with
+  // primitive sub-schemas. This avoids O(n²) by calling ReconstructVariantColumn
+  // once per field (column-level) rather than once per row.
+  std::vector<std::shared_ptr<Array>> field_reconstructed_arrays(schema_fields.size());
+  for (size_t sf = 0; sf < schema_fields.size(); ++sf) {
+    const auto& sub_schema = schema_fields[sf].second;
+    if (sub_schema.kind() == VariantShreddingSchema::Kind::kPrimitive) {
+      auto field_struct_col = typed_struct->field(static_cast<int>(sf));
+      auto* field_struct = static_cast<const StructArray*>(field_struct_col.get());
+      auto field_value_col = field_struct->field(0);  // "value" sub-column
+      auto field_typed_col = field_struct->field(1);  // "typed_value" sub-column
+
+      ARROW_ASSIGN_OR_RAISE(field_reconstructed_arrays[sf],
+                            ReconstructVariantColumn(metadata_array, field_value_col,
+                                                     field_typed_col, sub_schema));
+    }
+  }
+
+  // Cache for metadata reuse: in columnar data, all rows typically share the
+  // same metadata dictionary. By comparing metadata bytes across rows, we avoid
+  // redundant DecodeMetadata calls and VariantBuilder dictionary copies.
+  // Lifetime safety: cached_meta_bytes is a string_view into metadata_array's
+  // buffer, which is kept alive by the shared_ptr parameter for this function's
+  // entire duration. Arrow arrays never relocate their backing buffers.
+  std::string_view cached_meta_bytes;
+  VariantMetadata cached_meta;
+  // Cached builder: reused when consecutive rows share metadata. After
+  // BuildWithoutMeta(), the builder's buffer is cleared but its dictionary
+  // (dict_, dict_keys_) is preserved — exactly what we need for the next row.
+  std::unique_ptr<VariantBuilder> cached_builder;
+
+  for (int64_t i = 0; i < num_rows; ++i) {
+    bool value_present = value_array && value_array->IsValid(i);
+    bool typed_present = typed_value_array && typed_value_array->IsValid(i);
+
+    if (!value_present && !typed_present) {
+      // Both null → Variant null (see comment in primitive reconstruction
+      // about SQL NULL vs variant-null ambiguity)
+      uint8_t null_byte = 0x00;
+      ARROW_RETURN_NOT_OK(output_builder.Append(&null_byte, 1));
+      continue;
+    }
+
+    if (value_present && !typed_present) {
+      // Non-object value stored in residual
+      auto bytes = GetBinaryValue(*value_array, i);
+      ARROW_RETURN_NOT_OK(output_builder.Append(
+          reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+      continue;
+    }
+
+    // typed_present: reconstruct object from shredded fields + residual
+    auto meta_bytes = GetBinaryValue(*metadata_array, i);
+
+    // Reuse cached metadata and builder if bytes are identical (common case:
+    // all rows share the same metadata dictionary). This avoids O(n × k)
+    // dictionary copies from VariantBuilder construction per row.
+    if (meta_bytes != cached_meta_bytes) {
+      ARROW_ASSIGN_OR_RAISE(
+          cached_meta, DecodeMetadata(reinterpret_cast<const uint8_t*>(meta_bytes.data()),
+                                      static_cast<int64_t>(meta_bytes.size())));
+      cached_meta_bytes = meta_bytes;
+      cached_builder = std::make_unique<VariantBuilder>(cached_meta);
+      cached_builder->SetAllowDuplicates(true);
+    }
+
+    // Reuse the cached builder: BuildWithoutMeta() clears the buffer but
+    // preserves the dictionary, so NextField() can resolve keys without
+    // redundant hash map insertions.
+    VariantBuilder& vb = *cached_builder;
+    auto start = vb.Offset();
+    std::vector<VariantBuilder::FieldEntry> fields;
+
+    // Add shredded fields from typed_value struct
+    for (size_t sf = 0; sf < schema_fields.size(); ++sf) {
+      const auto& sub_schema = schema_fields[sf].second;
+
+      if (sub_schema.kind() == VariantShreddingSchema::Kind::kPrimitive &&
+          field_reconstructed_arrays[sf]) {
+        // Primitive sub-schema: use the pre-computed reconstructed array.
+        // Check the original sub-field struct to determine if the field was
+        // present (value or typed_value non-null) or absent (both null).
+        auto field_struct_col = typed_struct->field(static_cast<int>(sf));
+        auto* field_struct = static_cast<const StructArray*>(field_struct_col.get());
+        auto field_value_col = field_struct->field(0);
+        auto field_typed_col = field_struct->field(1);
+        bool field_present = field_value_col->IsValid(i) || field_typed_col->IsValid(i);
+
+        if (field_present) {
+          auto& recon_arr = field_reconstructed_arrays[sf];
+          auto recon_bytes = GetBinaryValue(*recon_arr, i);
+          if (!recon_bytes.empty()) {
+            fields.push_back(vb.NextField(start, schema_fields[sf].first));
+            vb.UnsafeAppendEncoded(reinterpret_cast<const uint8_t*>(recon_bytes.data()),
+                                   static_cast<int64_t>(recon_bytes.size()));
+          }
+        }
+      } else {
+        // Non-primitive or no reconstruction available: read from value sub-column
+        auto field_struct_col = typed_struct->field(static_cast<int>(sf));
+        auto* field_struct = static_cast<const StructArray*>(field_struct_col.get());
+        auto field_value_col = field_struct->field(0);  // "value" sub-column
+
+        if (field_value_col->IsValid(i)) {
+          auto field_bytes = GetBinaryValue(*field_value_col, i);
+          fields.push_back(vb.NextField(start, schema_fields[sf].first));
+          vb.UnsafeAppendEncoded(reinterpret_cast<const uint8_t*>(field_bytes.data()),
+                                 static_cast<int64_t>(field_bytes.size()));
+        }
+      }
+      // Both null → field is missing from this object, skip it
+    }
+
+    // Add residual fields (if value is present alongside typed_value)
+    if (value_present) {
+      auto residual_bytes = GetBinaryValue(*value_array, i);
+      auto* residual_data = reinterpret_cast<const uint8_t*>(residual_bytes.data());
+      auto residual_len = static_cast<int64_t>(residual_bytes.size());
+
+      if (residual_len > 0 && GetBasicType(residual_data[0]) == BasicType::kObject) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto residual_obj,
+            VariantObjectView::Make(cached_meta, residual_data, residual_len));
+        for (int32_t fi = 0; fi < residual_obj.num_fields(); ++fi) {
+          ARROW_ASSIGN_OR_RAISE(auto fname, residual_obj.field_name(fi));
+          ARROW_ASSIGN_OR_RAISE(auto fvalue, residual_obj.field_value(fi));
+          fields.push_back(vb.NextField(start, fname));
+          vb.UnsafeAppendEncoded(fvalue.data(), fvalue.size_bytes());
+        }
+      }
+    }
+
+    ARROW_RETURN_NOT_OK(vb.FinishObject(start, fields));
+    ARROW_ASSIGN_OR_RAISE(auto obj_bytes, vb.BuildWithoutMeta());
+    ARROW_RETURN_NOT_OK(
+        output_builder.Append(obj_bytes.data(), static_cast<int32_t>(obj_bytes.size())));
+  }
+
+  std::shared_ptr<Array> result;
+  ARROW_RETURN_NOT_OK(output_builder.Finish(&result));
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// ReconstructVariantColumn — dispatch by schema kind
+// ---------------------------------------------------------------------------
+
+Result<std::shared_ptr<Array>> ReconstructVariantColumn(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array,
+    const std::shared_ptr<Array>& typed_value_array, const VariantShreddingSchema& schema,
+    std::shared_ptr<Buffer>* out_null_bitmap) {
+  // Validate array lengths are consistent.
+  if (metadata_array->length() != value_array->length() ||
+      metadata_array->length() != typed_value_array->length()) {
+    return Status::Invalid("ReconstructVariantColumn: array length mismatch (metadata=",
+                           metadata_array->length(), ", value=", value_array->length(),
+                           ", typed_value=", typed_value_array->length(), ")");
+  }
+  // Validate input array types — GetBinaryValue silently returns empty for
+  // unsupported types, which would cause subtle data corruption.
+  if (metadata_array->type_id() != Type::BINARY &&
+      metadata_array->type_id() != Type::LARGE_BINARY &&
+      metadata_array->type_id() != Type::BINARY_VIEW) {
+    return Status::Invalid(
+        "ReconstructVariantColumn: metadata_array must be BINARY, LARGE_BINARY, or "
+        "BINARY_VIEW, got ",
+        metadata_array->type()->ToString());
+  }
+  if (value_array->type_id() != Type::BINARY &&
+      value_array->type_id() != Type::LARGE_BINARY &&
+      value_array->type_id() != Type::BINARY_VIEW) {
+    return Status::Invalid(
+        "ReconstructVariantColumn: value_array must be BINARY, LARGE_BINARY, or "
+        "BINARY_VIEW, got ",
+        value_array->type()->ToString());
+  }
+
+  if (schema.kind() == VariantShreddingSchema::Kind::kArray) {
+    auto result = ReconstructVariantColumnArray(metadata_array, value_array,
+                                                typed_value_array, schema);
+    if (result.ok() && out_null_bitmap) {
+      // Compute null bitmap: bit=0 where both value and typed_value are null
+      const int64_t num_rows = metadata_array->length();
+      ARROW_ASSIGN_OR_RAISE(auto bitmap, AllocateBitmap(num_rows, default_memory_pool()));
+      uint8_t* bitmap_data = bitmap->mutable_data();
+      for (int64_t i = 0; i < num_rows; ++i) {
+        bool valid = value_array->IsValid(i) || typed_value_array->IsValid(i);
+        bit_util::SetBitTo(bitmap_data, i, valid);
+      }
+      *out_null_bitmap = std::move(bitmap);
+    }
+    return result;
+  }
+
+  if (schema.kind() == VariantShreddingSchema::Kind::kObject) {
+    auto result = ReconstructVariantColumnObject(metadata_array, value_array,
+                                                 typed_value_array, schema);
+    if (result.ok() && out_null_bitmap) {
+      const int64_t num_rows = metadata_array->length();
+      ARROW_ASSIGN_OR_RAISE(auto bitmap, AllocateBitmap(num_rows, default_memory_pool()));
+      uint8_t* bitmap_data = bitmap->mutable_data();
+      for (int64_t i = 0; i < num_rows; ++i) {
+        bool valid = value_array->IsValid(i) || typed_value_array->IsValid(i);
+        bit_util::SetBitTo(bitmap_data, i, valid);
+      }
+      *out_null_bitmap = std::move(bitmap);
+    }
+    return result;
+  }
+
+  // Primitive reconstruction
+  const int64_t num_rows = metadata_array->length();
+  BinaryBuilder output_builder;
+  ARROW_RETURN_NOT_OK(output_builder.Reserve(num_rows));
+
+  // We need to re-encode native typed_value back to variant bytes.
+  // Reused across all rows — safe because primitive encoding never adds
+  // dictionary keys (only objects do). The dictionary stays empty.
+  VariantBuilder vb;
+
+  for (int64_t i = 0; i < num_rows; ++i) {
+    bool value_present = value_array && value_array->IsValid(i);
+    bool typed_present = typed_value_array && typed_value_array->IsValid(i);
+
+    if (!value_present && !typed_present) {
+      // Both null → Variant null (single byte: 0x00)
+      // NOTE: This is ambiguous — it could represent either:
+      //   1. "SQL NULL / missing" (the row itself is absent), or
+      //   2. "variant-typed null" (a Variant::Null that was stored in value)
+      // The Rust implementation disambiguates via a separate NullBuffer on the
+      // VariantArray struct. Since we don't receive a validity bitmap here,
+      // we conservatively emit Variant::Null (0x00). Callers that need to
+      // distinguish SQL NULL from variant-null should check the struct-level
+      // validity bitmap before calling ReconstructVariantColumn.
+      // TODO GH-45948 follow-up (Rust parity — NullBuffer): Accept an optional
+      // validity bitmap to propagate struct-level nulls into the output, matching
+      // Rust's `unshred_variant()` which returns a separate NullBuffer.
+      uint8_t null_byte = 0x00;
+      ARROW_RETURN_NOT_OK(output_builder.Append(&null_byte, 1));
+    } else if (value_present && !typed_present) {
+      // Value present, typed null → use residual value as-is
+      auto bytes = GetBinaryValue(*value_array, i);
+      ARROW_RETURN_NOT_OK(output_builder.Append(
+          reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size()));
+    } else if (!value_present && typed_present) {
+      // Typed present, value null → re-encode native value as variant.
+      // Dispatch on the *schema* type, not the physical array type, because
+      // some types (e.g., TIMESTAMP, TIME64) are stored as Int64 arrays
+      // but need to be re-encoded with their specific variant type.
+      switch (schema.type()->id()) {
+        case Type::INT64: {
+          auto& arr = static_cast<const Int64Array&>(*typed_value_array);
+          // Note: vb.Int() auto-sizes to smallest representation. This means
+          // Shred(Int64(42))→Reconstruct() produces Int8(42). The *value* is
+          // preserved but the encoding width may narrow. This matches Rust.
+          ARROW_RETURN_NOT_OK(vb.Int(arr.Value(i)));
+          break;
+        }
+        case Type::DOUBLE: {
+          auto& arr = static_cast<const DoubleArray&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.Double(arr.Value(i)));
+          break;
+        }
+        case Type::FLOAT: {
+          auto& arr = static_cast<const FloatArray&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.Float(arr.Value(i)));
+          break;
+        }
+        case Type::BOOL: {
+          auto& arr = static_cast<const BooleanArray&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.Bool(arr.Value(i)));
+          break;
+        }
+        case Type::STRING: {
+          auto& arr = static_cast<const StringArray&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.String(arr.GetView(i)));
+          break;
+        }
+        case Type::LARGE_STRING: {
+          auto& arr = static_cast<const LargeStringArray&>(*typed_value_array);
+          auto view = arr.GetView(i);
+          ARROW_RETURN_NOT_OK(vb.String(std::string_view(view.data(), view.size())));
+          break;
+        }
+        case Type::DATE32: {
+          auto& arr = static_cast<const Date32Array&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.Date(arr.Value(i)));
+          break;
+        }
+        case Type::TIMESTAMP: {
+          auto& arr = static_cast<const Int64Array&>(*typed_value_array);
+          // Determine the correct timestamp variant from the schema type.
+          // The schema carries TimeUnit and timezone, which tells us which
+          // variant encoding method to use for faithful round-trip.
+          auto& ts_type = static_cast<const TimestampType&>(*schema.type());
+          bool has_tz = !ts_type.timezone().empty();
+          if (ts_type.unit() == TimeUnit::NANO) {
+            if (has_tz) {
+              ARROW_RETURN_NOT_OK(vb.TimestampNanos(arr.Value(i)));
+            } else {
+              ARROW_RETURN_NOT_OK(vb.TimestampNanosNTZ(arr.Value(i)));
+            }
+          } else {
+            // MICRO unit (guaranteed by IsVariantCompatibleWithType which rejects
+            // SECOND/MILLI/other units during shredding)
+            if (has_tz) {
+              ARROW_RETURN_NOT_OK(vb.TimestampMicros(arr.Value(i)));
+            } else {
+              ARROW_RETURN_NOT_OK(vb.TimestampMicrosNTZ(arr.Value(i)));
+            }
+          }
+          break;
+        }
+        case Type::BINARY: {
+          auto& arr = static_cast<const BinaryArray&>(*typed_value_array);
+          auto view = arr.GetView(i);
+          ARROW_RETURN_NOT_OK(vb.Binary(
+              std::string_view(reinterpret_cast<const char*>(view.data()), view.size())));
+          break;
+        }
+        case Type::LARGE_BINARY: {
+          auto& arr = static_cast<const LargeBinaryArray&>(*typed_value_array);
+          auto view = arr.GetView(i);
+          ARROW_RETURN_NOT_OK(vb.Binary(
+              std::string_view(reinterpret_cast<const char*>(view.data()), view.size())));
+          break;
+        }
+        case Type::STRING_VIEW: {
+          auto& arr = static_cast<const StringViewArray&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.String(arr.GetView(i)));
+          break;
+        }
+        case Type::BINARY_VIEW: {
+          auto& arr = static_cast<const BinaryViewArray&>(*typed_value_array);
+          auto view = arr.GetView(i);
+          ARROW_RETURN_NOT_OK(vb.Binary(view));
+          break;
+        }
+        case Type::INT8: {
+          auto& arr = static_cast<const Int8Array&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.Int8(arr.Value(i)));
+          break;
+        }
+        case Type::INT16: {
+          auto& arr = static_cast<const Int16Array&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.Int16(arr.Value(i)));
+          break;
+        }
+        case Type::INT32: {
+          auto& arr = static_cast<const Int32Array&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.Int32(arr.Value(i)));
+          break;
+        }
+        case Type::TIME64: {
+          auto& arr = static_cast<const Int64Array&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.TimeNTZ(arr.Value(i)));
+          break;
+        }
+        case Type::FIXED_SIZE_BINARY: {
+          auto& arr = static_cast<const FixedSizeBinaryArray&>(*typed_value_array);
+          ARROW_RETURN_NOT_OK(vb.UUID(arr.GetValue(i)));
+          break;
+        }
+        case Type::DECIMAL128: {
+          auto& arr = static_cast<const Decimal128Array&>(*typed_value_array);
+          auto& dec_type = static_cast<const Decimal128Type&>(*typed_value_array->type());
+          Decimal128 val(arr.GetValue(i));
+          uint8_t scale = static_cast<uint8_t>(dec_type.scale());
+          // Preserve the smallest encoding width that can represent the value.
+          // This ensures round-trip byte identity: a Decimal4 variant stays Decimal4
+          // after shred→reconstruct rather than being widened to Decimal16.
+          //
+          // Use high_bits()/low_bits() accessors which are endian-safe (they
+          // return numeric values, not raw bytes). This avoids the ToBytes()+
+          // FromLittleEndian() pattern which is incorrect on big-endian.
+          int64_t high_word = val.high_bits();
+          int64_t low_word = static_cast<int64_t>(val.low_bits());
+          // Check if the value fits in 4 bytes (int32 range)
+          int32_t as_int32 = static_cast<int32_t>(low_word);
+          if (high_word == (as_int32 < 0 ? -1 : 0) &&
+              low_word == static_cast<int64_t>(as_int32)) {
+            // Fits in Decimal4 (4-byte unscaled value)
+            uint8_t d4_bytes[4];
+            int32_t val32 = bit_util::ToLittleEndian(as_int32);
+            std::memcpy(d4_bytes, &val32, 4);
+            ARROW_RETURN_NOT_OK(vb.Decimal4(scale, d4_bytes));
+          } else if (high_word == (low_word < 0 ? -1 : 0)) {
+            // Fits in Decimal8 (8-byte unscaled value)
+            uint8_t d8_bytes[8];
+            int64_t val64 = bit_util::ToLittleEndian(low_word);
+            std::memcpy(d8_bytes, &val64, 8);
+            ARROW_RETURN_NOT_OK(vb.Decimal8(scale, d8_bytes));
+          } else {
+            // Full Decimal16 — write low and high words in little-endian
+            uint8_t d16_bytes[16];
+            int64_t le_low = bit_util::ToLittleEndian(low_word);
+            int64_t le_high = bit_util::ToLittleEndian(high_word);
+            std::memcpy(d16_bytes, &le_low, 8);
+            std::memcpy(d16_bytes + 8, &le_high, 8);
+            ARROW_RETURN_NOT_OK(vb.Decimal16(scale, d16_bytes));
+          }
+          break;
+        }
+        // TODO GH-45948 follow-up: Add FixedSizeList and ListView
+        // reconstruction (LargeList is already supported above via the
+        // array reconstruction path).
+        // TODO GH-45948 follow-up (Rust parity — cast mode): Add Uint8/16/32/64,
+        // Float16, Decimal32/64, TimestampSecond/Millisecond reconstruction.
+        // See shredding switch for the full list.
+        default:
+          return Status::NotImplemented(
+              "ReconstructVariantColumn: unsupported typed_value type ",
+              typed_value_array->type()->ToString());
+      }
+      // Use BuildWithoutMeta() to avoid reconstructing the metadata dictionary
+      // on every row — primitives don't reference dictionary keys, so the
+      // metadata is irrelevant here. This avoids O(n) allocations.
+      ARROW_ASSIGN_OR_RAISE(auto value_bytes, vb.BuildWithoutMeta());
+      ARROW_RETURN_NOT_OK(output_builder.Append(
+          value_bytes.data(), static_cast<int32_t>(value_bytes.size())));
+    } else {
+      // Both present → partial object (not supported for primitive schemas)
+      return Status::Invalid(
+          "ReconstructVariantColumn: both value and typed_value are non-null "
+          "at row ",
+          i, " (partial objects not supported for primitive schemas)");
+    }
+  }
+
+  std::shared_ptr<Array> result;
+  ARROW_RETURN_NOT_OK(output_builder.Finish(&result));
+
+  // Compute null bitmap if requested
+  if (out_null_bitmap) {
+    ARROW_ASSIGN_OR_RAISE(auto bitmap, AllocateBitmap(num_rows, default_memory_pool()));
+    uint8_t* bitmap_data = bitmap->mutable_data();
+    for (int64_t i = 0; i < num_rows; ++i) {
+      bool valid = (value_array && value_array->IsValid(i)) ||
+                   (typed_value_array && typed_value_array->IsValid(i));
+      bit_util::SetBitTo(bitmap_data, i, valid);
+    }
+    *out_null_bitmap = std::move(bitmap);
+  }
+
+  return result;
+}
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_shredding.h
+++ b/cpp/src/arrow/extension/variant_shredding.h
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/array/array_nested.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/type_fwd.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow::extension::variant {
+
+// ---------------------------------------------------------------------------
+// Shredding Schema
+// ---------------------------------------------------------------------------
+
+/// \brief Defines which fields/types should be extracted from a Variant
+///        into typed Parquet columns.
+///
+/// A shredding schema is a tree that mirrors the structure of the Variant
+/// values to be shredded:
+/// - Primitive: shred the entire value as a specific Arrow type
+/// - Object: shred named fields, each with its own sub-schema
+/// - Array: shred array elements with a uniform element schema
+///
+/// This is the C++ equivalent of Rust's ShreddedSchemaBuilder.
+class ARROW_EXPORT VariantShreddingSchema {
+ public:
+  enum class Kind { kPrimitive, kObject, kArray };
+
+  /// \brief Create a primitive shredding schema.
+  ///
+  /// When applied, if the variant value's type is compatible with
+  /// the target DataType, it is cast and placed in typed_value.
+  /// Otherwise it remains in the value column as binary variant.
+  ///
+  /// \param[in] type The target Arrow DataType for the typed_value column
+  static VariantShreddingSchema Primitive(std::shared_ptr<DataType> type);
+
+  /// \brief Create an object shredding schema.
+  ///
+  /// When applied to an object variant, named fields are extracted
+  /// according to their individual sub-schemas. Remaining fields
+  /// go into the residual value column.
+  ///
+  /// \param[in] fields Vector of (field_name, sub_schema) pairs
+  static VariantShreddingSchema Object(
+      std::vector<std::pair<std::string, VariantShreddingSchema>> fields);
+
+  /// \brief Create an array shredding schema.
+  ///
+  /// When applied to an array variant, each element is shredded
+  /// according to the element_schema.
+  ///
+  /// \param[in] element_schema Schema for array elements
+  static VariantShreddingSchema Array(VariantShreddingSchema element_schema);
+
+  /// \brief Get the kind of this schema node.
+  Kind kind() const { return kind_; }
+
+  /// \brief Get the target type (only valid for Primitive kind).
+  const std::shared_ptr<DataType>& type() const { return type_; }
+
+  /// \brief Get the object fields (only valid for Object kind).
+  const std::vector<std::pair<std::string, VariantShreddingSchema>>& fields() const {
+    return fields_;
+  }
+
+  /// \brief Get the element schema (only valid for Array kind).
+  const VariantShreddingSchema& element_schema() const { return *element_schema_; }
+
+  /// \brief Convert this schema to the Arrow DataType for the typed_value column.
+  ///
+  /// - Primitive → the target DataType directly
+  /// - Object → struct type with fields named per the schema
+  /// - Array → list type with element struct {value?, typed_value?}
+  ///
+  /// NOTE: This returns the *logical* type. The actual shredded output for
+  /// TIMESTAMP and TIME64 schemas uses int64() as the physical field type
+  /// (since Arrow builds timestamps via Int64Builder). Callers comparing
+  /// ToArrowType() output against shredded array field types should account
+  /// for this TIMESTAMP/TIME64 → int64() mapping.
+  std::shared_ptr<DataType> ToArrowType() const;
+
+ private:
+  Kind kind_ = Kind::kPrimitive;
+  std::shared_ptr<DataType> type_;                                      // Primitive
+  std::vector<std::pair<std::string, VariantShreddingSchema>> fields_;  // Object
+  std::shared_ptr<VariantShreddingSchema> element_schema_;              // Array
+};
+
+// ---------------------------------------------------------------------------
+// Shredding Operations
+// ---------------------------------------------------------------------------
+
+/// \brief Determine if a Variant primitive type is compatible with a target
+///        Arrow DataType for shredding purposes.
+///
+/// Compatibility means the variant value can be losslessly represented
+/// in the target typed column without falling back to the binary value column.
+///
+/// \param[in] variant_data Pointer to the variant value buffer
+/// \param[in] variant_length Length of the variant value buffer
+/// \param[in] target_type The target Arrow DataType
+/// \return true if the variant value type is compatible with target_type
+ARROW_EXPORT bool IsVariantCompatibleWithType(const uint8_t* variant_data,
+                                              int64_t variant_length,
+                                              const DataType& target_type);
+
+// ---------------------------------------------------------------------------
+// Column-level Shredding / Reconstruction
+// ---------------------------------------------------------------------------
+
+/// \brief Shred a column of variant values according to a shredding schema.
+///
+/// Takes an unshredded VariantArray (a StructArray with {metadata, value})
+/// and produces a shredded StructArray with {metadata, value?, typed_value?}
+/// where matching values are routed to typed_value and non-matching values
+/// remain in value.
+///
+/// Type compatibility is strict: a variant value is only shredded if its
+/// encoded type matches the target type directly (with safe widening within
+/// the same family, e.g., Int8→Int64). Non-matching values always fall to
+/// the value column safely — no errors are produced for type mismatches.
+///
+/// This is the C++ equivalent of Rust's `shred_variant()`.
+///
+/// Known Rust parity gaps (planned follow-ups):
+/// - Recursive object/array sub-field shredding: Rust recursively shreds
+///   nested object and array sub-fields. C++ handles primitive sub-fields
+///   natively and recursively shreds array elements. Object/Array sub-schemas
+///   in object fields store values as variant binary (recursive nested
+///   shredding for those is a potential follow-up).
+/// - CastOptions: Rust supports cross-type coercion (e.g., Int32->Float64 via
+///   arrow::compute::cast); this function uses strict matching only.
+/// - Additional targets: Rust supports FixedSizeList and ListView as
+///   shredding output targets. Reconstruction accepts all list-like types.
+///
+/// \param[in] metadata_array The shared metadata column (binary array)
+/// \param[in] value_array The unshredded value column (binary array)
+/// \param[in] schema The shredding schema defining the typed_value target
+/// \return A struct with three fields: {metadata, value(nullable), typed_value(nullable)}
+ARROW_EXPORT Result<std::shared_ptr<StructArray>> ShredVariantColumn(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array, const VariantShreddingSchema& schema);
+
+/// \brief Reconstruct unshredded variant values from shredded columns.
+///
+/// Takes a shredded representation {metadata, value?, typed_value?} and
+/// produces a fully-materialized value column where all typed_value entries
+/// have been re-encoded as variant binary.
+///
+/// This is the C++ equivalent of Rust's `unshred_variant()`.
+///
+/// \param[in] metadata_array The shared metadata column (binary array)
+/// \param[in] value_array The residual value column (nullable binary array)
+/// \param[in] typed_value_array The shredded typed column (nullable)
+/// \param[in] schema The shredding schema (needed to interpret typed_value)
+/// \param[out] out_null_bitmap Optional. If non-null, receives a validity bitmap
+///             where bit i is 0 when both value[i] and typed_value[i] are null
+///             (indicating SQL NULL / missing row). This disambiguates SQL NULL
+///             from variant-null (0x00 byte). When null (default), all rows produce
+///             output (variant-null for both-null rows) matching prior behavior.
+/// \return A binary array of fully-reconstructed variant values.
+ARROW_EXPORT Result<std::shared_ptr<Array>> ReconstructVariantColumn(
+    const std::shared_ptr<Array>& metadata_array,
+    const std::shared_ptr<Array>& value_array,
+    const std::shared_ptr<Array>& typed_value_array, const VariantShreddingSchema& schema,
+    std::shared_ptr<Buffer>* out_null_bitmap = nullptr);
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_shredding_test.cc
+++ b/cpp/src/arrow/extension/variant_shredding_test.cc
@@ -1,0 +1,2224 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/extension/variant_shredding.h"
+
+#include <cstring>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/array/array_binary.h"
+#include "arrow/array/array_decimal.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_nested.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/buffer.h"
+#include "arrow/extension/variant.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/type.h"
+#include "arrow/util/decimal.h"
+
+namespace arrow::extension::variant {
+
+namespace {
+
+Result<int32_t> GetObjectFieldCount(const uint8_t* data, int64_t length) {
+  VariantMetadata empty_meta;
+  ARROW_ASSIGN_OR_RAISE(auto obj, VariantObjectView::Make(empty_meta, data, length));
+  return obj.num_fields();
+}
+
+Result<int32_t> GetArrayElementCount(const uint8_t* data, int64_t length) {
+  VariantMetadata empty_meta;
+  ARROW_ASSIGN_OR_RAISE(auto arr, VariantArrayView::Make(empty_meta, data, length));
+  return arr.num_elements();
+}
+
+}  // namespace
+
+namespace {
+
+// Test-local helper to extract variant bytes from a BinaryArray at index i.
+// Named to avoid confusion with BinaryViewArray::GetView().
+std::string_view GetBinaryView(const Array& array, int64_t i) {
+  if (array.type_id() == Type::BINARY) {
+    auto& bin = static_cast<const BinaryArray&>(array);
+    auto view = bin.GetView(i);
+    return {reinterpret_cast<const char*>(view.data()), static_cast<size_t>(view.size())};
+  }
+  return {};
+}
+
+}  // namespace
+
+// ===========================================================================
+// VariantShreddingSchema tests
+// ===========================================================================
+
+class VariantShreddingSchemaTest : public ::testing::Test {};
+
+TEST_F(VariantShreddingSchemaTest, PrimitiveSchema) {
+  auto schema = VariantShreddingSchema::Primitive(int64());
+  ASSERT_EQ(schema.kind(), VariantShreddingSchema::Kind::kPrimitive);
+  ASSERT_EQ(schema.type()->id(), Type::INT64);
+}
+
+TEST_F(VariantShreddingSchemaTest, PrimitiveToArrowType) {
+  auto schema = VariantShreddingSchema::Primitive(utf8());
+  auto arrow_type = schema.ToArrowType();
+  ASSERT_EQ(arrow_type->id(), Type::STRING);
+}
+
+TEST_F(VariantShreddingSchemaTest, ObjectSchema) {
+  auto schema = VariantShreddingSchema::Object({
+      {"name", VariantShreddingSchema::Primitive(utf8())},
+      {"age", VariantShreddingSchema::Primitive(int64())},
+  });
+  ASSERT_EQ(schema.kind(), VariantShreddingSchema::Kind::kObject);
+  ASSERT_EQ(schema.fields().size(), 2);
+  ASSERT_EQ(schema.fields()[0].first, "name");
+  ASSERT_EQ(schema.fields()[1].first, "age");
+}
+
+TEST_F(VariantShreddingSchemaTest, ObjectToArrowType) {
+  auto schema = VariantShreddingSchema::Object({
+      {"event_type", VariantShreddingSchema::Primitive(utf8())},
+      {"event_ts", VariantShreddingSchema::Primitive(timestamp(TimeUnit::MICRO, "UTC"))},
+  });
+  auto arrow_type = schema.ToArrowType();
+  ASSERT_EQ(arrow_type->id(), Type::STRUCT);
+  auto struct_type = std::static_pointer_cast<StructType>(arrow_type);
+  ASSERT_EQ(struct_type->num_fields(), 2);
+
+  // Each field should be a struct with {value, typed_value}
+  auto event_type_field = struct_type->field(0);
+  ASSERT_EQ(event_type_field->name(), "event_type");
+  ASSERT_EQ(event_type_field->type()->id(), Type::STRUCT);
+  auto inner = std::static_pointer_cast<StructType>(event_type_field->type());
+  ASSERT_EQ(inner->num_fields(), 2);
+  ASSERT_EQ(inner->field(0)->name(), "value");
+  ASSERT_EQ(inner->field(0)->type()->id(), Type::BINARY);
+  ASSERT_TRUE(inner->field(0)->nullable());
+  ASSERT_EQ(inner->field(1)->name(), "typed_value");
+  ASSERT_EQ(inner->field(1)->type()->id(), Type::STRING);
+  ASSERT_TRUE(inner->field(1)->nullable());
+}
+
+TEST_F(VariantShreddingSchemaTest, ArraySchema) {
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int32()));
+  ASSERT_EQ(schema.kind(), VariantShreddingSchema::Kind::kArray);
+  ASSERT_EQ(schema.element_schema().kind(), VariantShreddingSchema::Kind::kPrimitive);
+  ASSERT_EQ(schema.element_schema().type()->id(), Type::INT32);
+}
+
+TEST_F(VariantShreddingSchemaTest, ArrayToArrowType) {
+  auto schema =
+      VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(float64()));
+  auto arrow_type = schema.ToArrowType();
+  ASSERT_EQ(arrow_type->id(), Type::LIST);
+  auto list_type = std::static_pointer_cast<ListType>(arrow_type);
+  auto elem_type = list_type->value_type();
+  ASSERT_EQ(elem_type->id(), Type::STRUCT);
+}
+
+TEST_F(VariantShreddingSchemaTest, NestedObjectSchema) {
+  // Schema for shredding: {"location": {"lat": double, "lon": double}}
+  auto schema = VariantShreddingSchema::Object({
+      {"location", VariantShreddingSchema::Object({
+                       {"lat", VariantShreddingSchema::Primitive(float64())},
+                       {"lon", VariantShreddingSchema::Primitive(float64())},
+                   })},
+  });
+  ASSERT_EQ(schema.kind(), VariantShreddingSchema::Kind::kObject);
+  ASSERT_EQ(schema.fields().size(), 1);
+  ASSERT_EQ(schema.fields()[0].first, "location");
+  ASSERT_EQ(schema.fields()[0].second.kind(), VariantShreddingSchema::Kind::kObject);
+}
+
+// ===========================================================================
+// Type compatibility tests
+// ===========================================================================
+
+class VariantTypeCompatibilityTest : public ::testing::Test {
+ protected:
+  // Helper to build a variant value and check compatibility
+  bool CheckCompatibility(std::function<Status(VariantBuilder&)> build_fn,
+                          const DataType& target) {
+    VariantBuilder b;
+    build_fn(b).ok();
+    auto result = b.Finish().ValueOrDie();
+    return IsVariantCompatibleWithType(result.value.data(),
+                                       static_cast<int64_t>(result.value.size()), target);
+  }
+};
+
+TEST_F(VariantTypeCompatibilityTest, Int8CompatibleWithInt8) {
+  ASSERT_TRUE(CheckCompatibility([](VariantBuilder& b) { return b.Int8(42); }, *int8()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, Int8CompatibleWithInt64) {
+  // Int8 can be widened to Int64
+  ASSERT_TRUE(CheckCompatibility([](VariantBuilder& b) { return b.Int8(42); }, *int64()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, Int64NotCompatibleWithInt32) {
+  // Int64 cannot be narrowed to Int32
+  ASSERT_FALSE(CheckCompatibility([](VariantBuilder& b) { return b.Int64(5000000000LL); },
+                                  *int32()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, StringCompatibleWithUtf8) {
+  ASSERT_TRUE(
+      CheckCompatibility([](VariantBuilder& b) { return b.String("hello"); }, *utf8()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, ShortStringCompatibleWithUtf8) {
+  ASSERT_TRUE(
+      CheckCompatibility([](VariantBuilder& b) { return b.String("hi"); }, *utf8()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, BoolCompatibleWithBool) {
+  ASSERT_TRUE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Bool(true); }, *boolean()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, BoolNotCompatibleWithInt32) {
+  ASSERT_FALSE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Bool(true); }, *int32()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, DoubleCompatibleWithFloat64) {
+  ASSERT_TRUE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Double(3.14); }, *float64()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, FloatCompatibleWithFloat64ViaWidening) {
+  // Float can be widened to Double — value precision preserved, type tag changes
+  ASSERT_TRUE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Float(3.14f); }, *float64()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, FloatCompatibleWithFloat32) {
+  // Float is directly compatible with its own type
+  ASSERT_TRUE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Float(3.14f); }, *float32()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, DoubleNotCompatibleWithFloat32) {
+  // Double cannot be narrowed to Float
+  ASSERT_FALSE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Double(3.14); }, *float32()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, DateCompatibleWithDate32) {
+  ASSERT_TRUE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Date(19000); }, *date32()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, TimestampMicrosCompatibleWithTimestamp) {
+  ASSERT_TRUE(CheckCompatibility(
+      [](VariantBuilder& b) { return b.TimestampMicros(1654041600000000LL); },
+      *timestamp(TimeUnit::MICRO, "UTC")));
+}
+
+TEST_F(VariantTypeCompatibilityTest, TimestampMicrosNotCompatibleWithNanos) {
+  // TimestampMicros should NOT be compatible with NANO resolution target
+  ASSERT_FALSE(CheckCompatibility(
+      [](VariantBuilder& b) { return b.TimestampMicros(1654041600000000LL); },
+      *timestamp(TimeUnit::NANO, "UTC")));
+}
+
+TEST_F(VariantTypeCompatibilityTest, TimestampMicrosNotCompatibleWithNTZ) {
+  // TimestampMicros (with timezone) should NOT be compatible with NTZ target
+  ASSERT_FALSE(CheckCompatibility(
+      [](VariantBuilder& b) { return b.TimestampMicros(1654041600000000LL); },
+      *timestamp(TimeUnit::MICRO)));
+}
+
+TEST_F(VariantTypeCompatibilityTest, TimestampNanosNTZCompatibleWithNanosNTZ) {
+  ASSERT_TRUE(CheckCompatibility(
+      [](VariantBuilder& b) { return b.TimestampNanosNTZ(1654041600000000000LL); },
+      *timestamp(TimeUnit::NANO)));
+}
+
+TEST_F(VariantTypeCompatibilityTest, DecimalScaleMismatchNotCompatible) {
+  // Decimal4 with scale=3 should NOT be compatible with Decimal128(10,2)
+  ASSERT_FALSE(CheckCompatibility(
+      [](VariantBuilder& b) {
+        uint8_t bytes[4] = {0x39, 0x30, 0x00, 0x00};
+        return b.Decimal4(3, bytes);
+      },
+      *decimal128(10, 2)));
+}
+
+TEST_F(VariantTypeCompatibilityTest, DecimalScaleMatchCompatible) {
+  // Decimal4 with scale=2 should be compatible with Decimal128(10,2)
+  ASSERT_TRUE(CheckCompatibility(
+      [](VariantBuilder& b) {
+        uint8_t bytes[4] = {0x39, 0x30, 0x00, 0x00};
+        return b.Decimal4(2, bytes);
+      },
+      *decimal128(10, 2)));
+}
+
+TEST_F(VariantTypeCompatibilityTest, NullNotCompatibleWithTypedColumns) {
+  // Per Rust/spec: Variant::Null is NOT compatible with any typed column.
+  // It remains in the value column to distinguish "variant null" from "missing".
+  ASSERT_FALSE(CheckCompatibility([](VariantBuilder& b) { return b.Null(); }, *int64()));
+  ASSERT_FALSE(CheckCompatibility([](VariantBuilder& b) { return b.Null(); }, *utf8()));
+  ASSERT_FALSE(
+      CheckCompatibility([](VariantBuilder& b) { return b.Null(); }, *boolean()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, StringNotCompatibleWithInt64) {
+  ASSERT_FALSE(
+      CheckCompatibility([](VariantBuilder& b) { return b.String("hello"); }, *int64()));
+}
+
+TEST_F(VariantTypeCompatibilityTest, UUIDCompatibleWithFixedSizeBinary16) {
+  uint8_t uuid[16] = {};
+  ASSERT_TRUE(CheckCompatibility([&uuid](VariantBuilder& b) { return b.UUID(uuid); },
+                                 *fixed_size_binary(16)));
+}
+
+TEST_F(VariantTypeCompatibilityTest, UUIDNotCompatibleWithFixedSizeBinary32) {
+  uint8_t uuid[16] = {};
+  ASSERT_FALSE(CheckCompatibility([&uuid](VariantBuilder& b) { return b.UUID(uuid); },
+                                  *fixed_size_binary(32)));
+}
+
+TEST_F(VariantTypeCompatibilityTest, Time64MicroCompatibleWithTime64Micro) {
+  ASSERT_TRUE(CheckCompatibility([](VariantBuilder& b) { return b.TimeNTZ(1234567); },
+                                 *time64(TimeUnit::MICRO)));
+}
+
+TEST_F(VariantTypeCompatibilityTest, Time64NanoNotCompatibleWithTime64Micro) {
+  // The variant spec's kTimeNTZ stores microseconds. A time64(NANO) target
+  // would cause misinterpretation of the values in the typed_value column.
+  ASSERT_FALSE(CheckCompatibility([](VariantBuilder& b) { return b.TimeNTZ(1234567); },
+                                  *time64(TimeUnit::NANO)));
+}
+
+// ===========================================================================
+// ShredVariantColumn / ReconstructVariantColumn round-trip tests
+// ===========================================================================
+
+class VariantShredRoundTripTest : public ::testing::Test {
+ protected:
+  // Helper: build a binary array of encoded variant values.
+  // Note: Uses .ok()/.ValueOrDie() because ASSERT_OK_AND_ASSIGN cannot be used
+  // in non-void functions. Test-only; will crash with a descriptive message
+  // on failure rather than producing a clean test failure.
+  std::shared_ptr<Array> BuildVariantColumn(
+      const std::vector<std::function<Status(VariantBuilder&)>>& builders) {
+    // Use a single shared builder to produce consistent metadata
+    BinaryBuilder array_builder;
+    for (const auto& build_fn : builders) {
+      VariantBuilder vb;
+      build_fn(vb).ok();
+      auto encoded = vb.Finish().ValueOrDie();
+      array_builder
+          .Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+          .ok();
+    }
+    std::shared_ptr<Array> result;
+    array_builder.Finish(&result).ok();
+    return result;
+  }
+
+  // Helper: build a metadata array (all same metadata)
+  std::shared_ptr<Array> BuildMetadataColumn(int64_t num_rows) {
+    // Empty metadata (no dictionary keys needed for primitives)
+    VariantBuilder vb;
+    vb.Null().ok();
+    auto encoded = vb.Finish().ValueOrDie();
+
+    BinaryBuilder builder;
+    for (int64_t i = 0; i < num_rows; ++i) {
+      builder
+          .Append(encoded.metadata.data(), static_cast<int32_t>(encoded.metadata.size()))
+          .ok();
+    }
+    std::shared_ptr<Array> result;
+    builder.Finish(&result).ok();
+    return result;
+  }
+};
+
+TEST_F(VariantShredRoundTripTest, PrimitiveInt64AllMatch) {
+  // All values are integers — should all go to typed_value
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) { return b.Int(42); },
+      [](VariantBuilder& b) { return b.Int(100); },
+      [](VariantBuilder& b) { return b.Int(-7); },
+  });
+  auto metadata = BuildMetadataColumn(3);
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  // All values should be in typed_value (value column all null)
+  auto value_col = shredded->field(1);    // "value"
+  ASSERT_EQ(value_col->null_count(), 3);  // all null
+
+  auto typed_col = shredded->field(2);  // "typed_value"
+  ASSERT_EQ(typed_col->type_id(), Type::INT64);
+  ASSERT_EQ(typed_col->null_count(), 0);  // all present
+
+  // Verify native values
+  auto& int_arr = static_cast<const Int64Array&>(*typed_col);
+  ASSERT_EQ(int_arr.Value(0), 42);
+  ASSERT_EQ(int_arr.Value(1), 100);
+  ASSERT_EQ(int_arr.Value(2), -7);
+
+  // Reconstruct and verify round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 3);
+  // Verify the reconstructed variant bytes are valid
+  for (int64_t i = 0; i < 3; ++i) {
+    ASSERT_TRUE(reconstructed->IsValid(i));
+  }
+}
+
+TEST_F(VariantShredRoundTripTest, PrimitiveMixedTypes) {
+  // Mix of matching and non-matching types
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) { return b.Int(42); },       // matches int64
+      [](VariantBuilder& b) { return b.String("hi"); },  // doesn't match
+      [](VariantBuilder& b) { return b.Int(99); },       // matches
+      [](VariantBuilder& b) { return b.Bool(true); },    // doesn't match
+  });
+  auto metadata = BuildMetadataColumn(4);
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Rows 0,2 → typed_value; Rows 1,3 → value
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_TRUE(value_col->IsValid(1));
+  ASSERT_TRUE(value_col->IsNull(2));
+  ASSERT_TRUE(value_col->IsValid(3));
+
+  ASSERT_TRUE(typed_col->IsValid(0));
+  ASSERT_TRUE(typed_col->IsNull(1));
+  ASSERT_TRUE(typed_col->IsValid(2));
+  ASSERT_TRUE(typed_col->IsNull(3));
+
+  // Verify native int values
+  auto& int_arr = static_cast<const Int64Array&>(*typed_col);
+  ASSERT_EQ(int_arr.Value(0), 42);
+  ASSERT_EQ(int_arr.Value(2), 99);
+
+  // Round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 4);
+}
+
+TEST_F(VariantShredRoundTripTest, PrimitiveAllMismatch) {
+  // No values match the target type — all stay in value column
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) { return b.String("a"); },
+      [](VariantBuilder& b) { return b.String("b"); },
+  });
+  auto metadata = BuildMetadataColumn(2);
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // All in value, none in typed_value
+  ASSERT_EQ(value_col->null_count(), 0);
+  ASSERT_EQ(typed_col->null_count(), 2);
+
+  // Round-trip: since typed_value is all null, everything comes from value
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  for (int64_t i = 0; i < 2; ++i) {
+    ASSERT_EQ(GetBinaryView(*values, i), GetBinaryView(*reconstructed, i));
+  }
+}
+
+TEST_F(VariantShredRoundTripTest, NullVariantIsRouted) {
+  // Per Rust/spec: Variant::Null is NOT shredded into typed columns.
+  // It goes to the value column as raw bytes (0x00). This distinguishes
+  // "variant-typed null" from "SQL NULL / missing" (both columns null).
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) { return b.Null(); },
+      [](VariantBuilder& b) { return b.Int(5); },
+  });
+  auto metadata = BuildMetadataColumn(2);
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+  // Variant Null → value column has content (0x00 byte), typed_value is null
+  ASSERT_TRUE(value_col->IsValid(0));
+  ASSERT_TRUE(typed_col->IsNull(0));
+  // Int(5) → typed_value is present, value is null
+  ASSERT_TRUE(value_col->IsNull(1));
+  ASSERT_TRUE(typed_col->IsValid(1));
+}
+
+TEST_F(VariantShredRoundTripTest, ZeroRowInput) {
+  // Empty arrays (zero rows) should be handled gracefully without errors.
+  auto values = BuildVariantColumn({});
+  auto metadata = BuildMetadataColumn(0);
+
+  // Primitive schema with zero rows
+  auto prim_schema = VariantShreddingSchema::Primitive(int64());
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, prim_schema));
+  ASSERT_EQ(shredded->length(), 0);
+  ASSERT_EQ(shredded->num_fields(), 3);
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+  ASSERT_EQ(value_col->length(), 0);
+  ASSERT_EQ(typed_col->length(), 0);
+
+  // Round-trip on empty arrays
+  ASSERT_OK_AND_ASSIGN(
+      auto reconstructed,
+      ReconstructVariantColumn(metadata, value_col, typed_col, prim_schema));
+  ASSERT_EQ(reconstructed->length(), 0);
+
+  // Object schema with zero rows
+  auto obj_schema = VariantShreddingSchema::Object({
+      {"a", VariantShreddingSchema::Primitive(int64())},
+  });
+  ASSERT_OK_AND_ASSIGN(auto obj_shredded,
+                       ShredVariantColumn(metadata, values, obj_schema));
+  ASSERT_EQ(obj_shredded->length(), 0);
+
+  // Array schema with zero rows
+  auto arr_schema =
+      VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+  ASSERT_OK_AND_ASSIGN(auto arr_shredded,
+                       ShredVariantColumn(metadata, values, arr_schema));
+  ASSERT_EQ(arr_shredded->length(), 0);
+}
+
+// ===========================================================================
+// Object shredding round-trip tests
+// ===========================================================================
+
+class VariantShredObjectTest : public ::testing::Test {
+ protected:
+  // Helper: build a variant column with object values
+  struct ObjectRow {
+    std::vector<std::pair<std::string, std::function<Status(VariantBuilder&)>>> fields;
+  };
+
+  std::shared_ptr<Array> BuildObjectColumn(const std::vector<ObjectRow>& rows) {
+    BinaryBuilder array_builder;
+    for (const auto& row : rows) {
+      VariantBuilder vb;
+      auto start = vb.Offset();
+      std::vector<VariantBuilder::FieldEntry> fields;
+      for (const auto& [key, value_fn] : row.fields) {
+        fields.push_back(vb.NextField(start, key));
+        value_fn(vb).ok();
+      }
+      vb.FinishObject(start, fields).ok();
+      auto encoded = vb.Finish().ValueOrDie();
+      array_builder
+          .Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+          .ok();
+    }
+    std::shared_ptr<Array> result;
+    array_builder.Finish(&result).ok();
+    return result;
+  }
+
+  std::shared_ptr<Array> BuildMetadataForObjects(const std::vector<ObjectRow>& rows) {
+    BinaryBuilder builder;
+    for (const auto& row : rows) {
+      VariantBuilder vb;
+      auto start = vb.Offset();
+      std::vector<VariantBuilder::FieldEntry> fields;
+      for (const auto& [key, value_fn] : row.fields) {
+        fields.push_back(vb.NextField(start, key));
+        value_fn(vb).ok();
+      }
+      vb.FinishObject(start, fields).ok();
+      auto encoded = vb.Finish().ValueOrDie();
+      builder
+          .Append(encoded.metadata.data(), static_cast<int32_t>(encoded.metadata.size()))
+          .ok();
+    }
+    std::shared_ptr<Array> result;
+    builder.Finish(&result).ok();
+    return result;
+  }
+};
+
+TEST_F(VariantShredObjectTest, FullyShredded) {
+  // Object {"name": "Alice", "age": 30} shredded with schema {name, age}
+  std::vector<ObjectRow> rows = {
+      {{{"name", [](VariantBuilder& b) { return b.String("Alice"); }},
+        {"age", [](VariantBuilder& b) { return b.Int(30); }}}},
+      {{{"name", [](VariantBuilder& b) { return b.String("Bob"); }},
+        {"age", [](VariantBuilder& b) { return b.Int(25); }}}},
+  };
+
+  auto values = BuildObjectColumn(rows);
+  auto metadata = BuildMetadataForObjects(rows);
+
+  auto schema = VariantShreddingSchema::Object({
+      {"name", VariantShreddingSchema::Primitive(utf8())},
+      {"age", VariantShreddingSchema::Primitive(int64())},
+  });
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  // When fully shredded, residual value should be all null
+  auto value_col = shredded->field(1);
+  ASSERT_EQ(value_col->null_count(), 2);
+
+  // typed_value is a struct with "name" and "age" fields
+  auto typed_col = shredded->field(2);
+  ASSERT_EQ(typed_col->type_id(), Type::STRUCT);
+
+  // Verify native extraction: each field's struct should have typed_value populated
+  auto& typed_struct = static_cast<const StructArray&>(*typed_col);
+
+  // "name" field: sub-struct {value: binary, typed_value: string}
+  auto name_field_struct = static_cast<const StructArray*>(typed_struct.field(0).get());
+  auto name_value_col = name_field_struct->field(0);  // fallback value
+  auto name_typed_col = name_field_struct->field(1);  // native typed_value
+
+  // Both names should be in typed_value (string compatible with utf8 target)
+  ASSERT_EQ(name_value_col->null_count(), 2);  // no fallback needed
+  ASSERT_EQ(name_typed_col->null_count(), 0);  // both present
+  auto& name_arr = static_cast<const StringArray&>(*name_typed_col);
+  ASSERT_EQ(name_arr.GetView(0), "Alice");
+  ASSERT_EQ(name_arr.GetView(1), "Bob");
+
+  // "age" field: sub-struct {value: binary, typed_value: int64}
+  auto age_field_struct = static_cast<const StructArray*>(typed_struct.field(1).get());
+  auto age_value_col = age_field_struct->field(0);
+  auto age_typed_col = age_field_struct->field(1);
+
+  ASSERT_EQ(age_value_col->null_count(), 2);  // no fallback needed
+  ASSERT_EQ(age_typed_col->null_count(), 0);  // both present
+  auto& age_arr = static_cast<const Int64Array&>(*age_typed_col);
+  ASSERT_EQ(age_arr.Value(0), 30);
+  ASSERT_EQ(age_arr.Value(1), 25);
+
+  // Reconstruct and verify round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 2);
+  // Verify the reconstructed values decode correctly
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+}
+
+TEST_F(VariantShredObjectTest, MissingFieldNativeExtraction) {
+  // Object with missing field — verifies native extraction handles absent fields.
+  // Row 0: {name: "Alice", age: 30} — both fields present
+  // Row 1: {name: "Bob"} — "age" field missing
+  // Row 2: {age: 42} — "name" field missing
+  std::vector<ObjectRow> rows = {
+      {{{"name", [](VariantBuilder& b) { return b.String("Alice"); }},
+        {"age", [](VariantBuilder& b) { return b.Int(30); }}}},
+      {{{"name", [](VariantBuilder& b) { return b.String("Bob"); }}}},
+      {{{"age", [](VariantBuilder& b) { return b.Int(42); }}}},
+  };
+
+  auto values = BuildObjectColumn(rows);
+  auto metadata = BuildMetadataForObjects(rows);
+
+  auto schema = VariantShreddingSchema::Object({
+      {"name", VariantShreddingSchema::Primitive(utf8())},
+      {"age", VariantShreddingSchema::Primitive(int64())},
+  });
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+  auto& typed_struct = static_cast<const StructArray&>(*typed_col);
+
+  // "name" field: rows 0,1 present, row 2 absent
+  auto name_struct = static_cast<const StructArray*>(typed_struct.field(0).get());
+  auto name_typed = name_struct->field(1);
+  ASSERT_TRUE(name_typed->IsValid(0));  // "Alice"
+  ASSERT_TRUE(name_typed->IsValid(1));  // "Bob"
+  ASSERT_TRUE(name_typed->IsNull(2));   // missing
+  auto& name_arr = static_cast<const StringArray&>(*name_typed);
+  ASSERT_EQ(name_arr.GetView(0), "Alice");
+  ASSERT_EQ(name_arr.GetView(1), "Bob");
+
+  // "age" field: rows 0,2 present, row 1 absent
+  auto age_struct = static_cast<const StructArray*>(typed_struct.field(1).get());
+  auto age_typed = age_struct->field(1);
+  ASSERT_TRUE(age_typed->IsValid(0));  // 30
+  ASSERT_TRUE(age_typed->IsNull(1));   // missing
+  ASSERT_TRUE(age_typed->IsValid(2));  // 42
+  auto& age_arr = static_cast<const Int64Array&>(*age_typed);
+  ASSERT_EQ(age_arr.Value(0), 30);
+  ASSERT_EQ(age_arr.Value(2), 42);
+
+  // Reconstruct and verify round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 3);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+  ASSERT_TRUE(reconstructed->IsValid(2));
+}
+
+TEST_F(VariantShredObjectTest, PartiallyShredded) {
+  // Object {"name": "Alice", "age": 30, "score": 95.5}
+  // Schema only shreds "name" — "age" and "score" go to residual
+  std::vector<ObjectRow> rows = {
+      {{{"name", [](VariantBuilder& b) { return b.String("Alice"); }},
+        {"age", [](VariantBuilder& b) { return b.Int(30); }},
+        {"score", [](VariantBuilder& b) { return b.Double(95.5); }}}},
+  };
+
+  auto values = BuildObjectColumn(rows);
+  auto metadata = BuildMetadataForObjects(rows);
+
+  auto schema = VariantShreddingSchema::Object({
+      {"name", VariantShreddingSchema::Primitive(utf8())},
+  });
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  // Residual should have content (the "age" and "score" fields)
+  auto value_col = shredded->field(1);
+  ASSERT_TRUE(value_col->IsValid(0));  // has residual
+
+  // Reconstruct
+  auto typed_col = shredded->field(2);
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+}
+
+TEST_F(VariantShredObjectTest, NonObjectFallback) {
+  // A string value (not an object) with an object schema → goes to residual
+  BinaryBuilder array_builder;
+  {
+    VariantBuilder vb;
+    vb.String("not an object").ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    array_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  array_builder.Finish(&values).ok();
+
+  BinaryBuilder meta_builder;
+  {
+    VariantBuilder vb;
+    vb.String("x").ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    meta_builder
+        .Append(encoded.metadata.data(), static_cast<int32_t>(encoded.metadata.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> metadata;
+  meta_builder.Finish(&metadata).ok();
+
+  auto schema = VariantShreddingSchema::Object({
+      {"name", VariantShreddingSchema::Primitive(utf8())},
+  });
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  // Non-object → residual has the value, typed fields are null
+  auto value_col = shredded->field(1);
+  ASSERT_TRUE(value_col->IsValid(0));
+}
+
+// ===========================================================================
+// Array shredding round-trip tests
+// ===========================================================================
+
+class VariantShredArrayTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<Array> BuildMetadata(int64_t num_rows) {
+    VariantBuilder vb;
+    vb.Null().ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    BinaryBuilder builder;
+    for (int64_t i = 0; i < num_rows; ++i) {
+      builder
+          .Append(encoded.metadata.data(), static_cast<int32_t>(encoded.metadata.size()))
+          .ok();
+    }
+    std::shared_ptr<Array> result;
+    builder.Finish(&result).ok();
+    return result;
+  }
+};
+
+TEST_F(VariantShredArrayTest, SimpleArrayShred) {
+  // Build a variant array value: [1, 2, 3]
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    auto start = vb.Offset();
+    std::vector<int64_t> offsets;
+    offsets.push_back(vb.NextElement(start));
+    vb.Int(1).ok();
+    offsets.push_back(vb.NextElement(start));
+    vb.Int(2).ok();
+    offsets.push_back(vb.NextElement(start));
+    vb.Int(3).ok();
+    vb.FinishArray(start, offsets).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadata(1);
+
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  // Array goes to typed_value (a list), value is null
+  auto value_col = shredded->field(1);
+  ASSERT_TRUE(value_col->IsNull(0));
+
+  auto typed_col = shredded->field(2);
+  ASSERT_EQ(typed_col->type_id(), Type::LIST);
+  auto& list = static_cast<const ListArray&>(*typed_col);
+  ASSERT_EQ(list.value_length(0), 3);  // 3 elements
+
+  // With recursive element shredding, elements are struct{value, typed_value}
+  // where compatible int values go to typed_value and value is null.
+  auto elem_type = list.value_type();
+  ASSERT_EQ(elem_type->id(), Type::STRUCT);
+  auto* elem_struct_type = static_cast<const StructType*>(elem_type.get());
+  ASSERT_EQ(elem_struct_type->num_fields(), 2);
+  ASSERT_EQ(elem_struct_type->field(0)->name(), "value");
+  ASSERT_EQ(elem_struct_type->field(1)->name(), "typed_value");
+
+  // Verify native int64 values in the element typed_value column
+  auto* elem_struct = static_cast<const StructArray*>(list.values().get());
+  auto elem_value_col = elem_struct->field(0);  // per-element residual
+  auto elem_typed_col = elem_struct->field(1);  // per-element typed_value
+  // All 3 ints should be in typed_value
+  ASSERT_EQ(elem_value_col->null_count(), 3);
+  ASSERT_EQ(elem_typed_col->null_count(), 0);
+  auto& elem_int_arr = static_cast<const Int64Array&>(*elem_typed_col);
+  ASSERT_EQ(elem_int_arr.Value(0), 1);
+  ASSERT_EQ(elem_int_arr.Value(1), 2);
+  ASSERT_EQ(elem_int_arr.Value(2), 3);
+
+  // Round-trip reconstruction
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+}
+
+TEST_F(VariantShredArrayTest, ArrayShredMixedElements) {
+  // Build a variant array value: [1, "hello", 3] — mixed types with int64 schema.
+  // Int elements should go to typed_value, string element to per-element value.
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    auto start = vb.Offset();
+    std::vector<int64_t> offsets;
+    offsets.push_back(vb.NextElement(start));
+    vb.Int(1).ok();
+    offsets.push_back(vb.NextElement(start));
+    vb.String("hello").ok();
+    offsets.push_back(vb.NextElement(start));
+    vb.Int(3).ok();
+    vb.FinishArray(start, offsets).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadata(1);
+
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // The array is shredded — residual value is null, typed_value has the list
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_EQ(typed_col->type_id(), Type::LIST);
+
+  auto& list = static_cast<const ListArray&>(*typed_col);
+  auto* elem_struct = static_cast<const StructArray*>(list.values().get());
+  auto elem_value_col = elem_struct->field(0);
+  auto elem_typed_col = elem_struct->field(1);
+
+  // Element 0 (Int(1)) → typed_value=1, value=null
+  ASSERT_TRUE(elem_value_col->IsNull(0));
+  ASSERT_TRUE(elem_typed_col->IsValid(0));
+  auto& elem_ints = static_cast<const Int64Array&>(*elem_typed_col);
+  ASSERT_EQ(elem_ints.Value(0), 1);
+
+  // Element 1 (String("hello")) → typed_value=null, value=variant bytes
+  ASSERT_TRUE(elem_value_col->IsValid(1));
+  ASSERT_TRUE(elem_typed_col->IsNull(1));
+
+  // Element 2 (Int(3)) → typed_value=3, value=null
+  ASSERT_TRUE(elem_value_col->IsNull(2));
+  ASSERT_TRUE(elem_typed_col->IsValid(2));
+  ASSERT_EQ(elem_ints.Value(2), 3);
+
+  // Round-trip reconstruction
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify the reconstructed value decodes to an array with the expected elements
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  auto* data = reinterpret_cast<const uint8_t*>(recon_bytes.data());
+  auto len = static_cast<int64_t>(recon_bytes.size());
+  ASSERT_GE(len, 1);
+  ASSERT_EQ(GetBasicType(data[0]), BasicType::kArray);
+  ASSERT_OK_AND_ASSIGN(auto elem_count, GetArrayElementCount(data, len));
+  ASSERT_EQ(elem_count, 3);
+}
+
+TEST_F(VariantShredArrayTest, NonArrayFallback) {
+  // A string value with an array schema → goes to residual
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.String("not an array").ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadata(1);
+
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  // Non-array → residual has the value, typed_value is null
+  auto value_col = shredded->field(1);
+  ASSERT_TRUE(value_col->IsValid(0));
+
+  auto typed_col = shredded->field(2);
+  ASSERT_TRUE(typed_col->IsNull(0));
+}
+
+// ===========================================================================
+// Additional round-trip tests for specific types (Decimal128, UUID, Timestamps)
+// ===========================================================================
+
+class VariantShredTypedRoundTripTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<Array> BuildMetadataColumn(int64_t num_rows) {
+    VariantBuilder vb;
+    vb.Null().ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    BinaryBuilder builder;
+    for (int64_t i = 0; i < num_rows; ++i) {
+      builder
+          .Append(encoded.metadata.data(), static_cast<int32_t>(encoded.metadata.size()))
+          .ok();
+    }
+    std::shared_ptr<Array> result;
+    builder.Finish(&result).ok();
+    return result;
+  }
+};
+
+TEST_F(VariantShredTypedRoundTripTest, Decimal128RoundTrip) {
+  // Build variant column with decimal values (scale=2)
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    // Encode 123.45 as decimal4 with scale 2 → unscaled 12345
+    uint8_t scale = 2;
+    int32_t unscaled = 12345;
+    uint8_t bytes[4];
+    std::memcpy(bytes, &unscaled, 4);
+    vb.Decimal4(scale, bytes).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    VariantBuilder vb;
+    // Encode -999.99 as decimal4 with scale 2 → unscaled -99999
+    uint8_t scale = 2;
+    int32_t unscaled = -99999;
+    uint8_t bytes[4];
+    std::memcpy(bytes, &unscaled, 4);
+    vb.Decimal4(scale, bytes).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(2);
+
+  // Schema: Decimal128(10, 2)
+  auto schema = VariantShreddingSchema::Primitive(decimal128(10, 2));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Both values should match (scale=2 matches schema)
+  ASSERT_EQ(value_col->null_count(), 2);  // all in typed
+  ASSERT_EQ(typed_col->null_count(), 0);  // all present
+
+  // Verify native decimal values
+  auto& dec_arr = static_cast<const Decimal128Array&>(*typed_col);
+  Decimal128 val0(dec_arr.GetValue(0));
+  Decimal128 val1(dec_arr.GetValue(1));
+  ASSERT_EQ(val0, Decimal128(12345));
+  ASSERT_EQ(val1, Decimal128(-99999));
+
+  // Round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 2);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+}
+
+TEST_F(VariantShredTypedRoundTripTest, Decimal128ScaleMismatch) {
+  // Build variant column with decimal scale=3, but schema wants scale=2
+  // Should NOT be shredded (scale mismatch → goes to residual)
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    uint8_t scale = 3;
+    int32_t unscaled = 12345;
+    uint8_t bytes[4];
+    std::memcpy(bytes, &unscaled, 4);
+    vb.Decimal4(scale, bytes).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(1);
+
+  auto schema = VariantShreddingSchema::Primitive(decimal128(10, 2));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Scale mismatch → value has content, typed is null
+  ASSERT_TRUE(value_col->IsValid(0));
+  ASSERT_TRUE(typed_col->IsNull(0));
+}
+
+TEST_F(VariantShredTypedRoundTripTest, UUIDRoundTrip) {
+  // Build variant column with UUID values
+  BinaryBuilder value_builder;
+  uint8_t uuid1[16] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+                       0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10};
+  uint8_t uuid2[16] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  {
+    VariantBuilder vb;
+    vb.UUID(uuid1).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    VariantBuilder vb;
+    vb.UUID(uuid2).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(2);
+
+  auto schema = VariantShreddingSchema::Primitive(fixed_size_binary(16));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Both UUIDs should be in typed_value
+  ASSERT_EQ(value_col->null_count(), 2);
+  ASSERT_EQ(typed_col->null_count(), 0);
+
+  // Verify bytes
+  auto& fsb_arr = static_cast<const FixedSizeBinaryArray&>(*typed_col);
+  ASSERT_EQ(std::memcmp(fsb_arr.GetValue(0), uuid1, 16), 0);
+  ASSERT_EQ(std::memcmp(fsb_arr.GetValue(1), uuid2, 16), 0);
+
+  // Round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 2);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+}
+
+TEST_F(VariantShredTypedRoundTripTest, TimestampMicrosRoundTrip) {
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.TimestampMicros(1654041600000000LL).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(1);
+
+  auto schema = VariantShreddingSchema::Primitive(timestamp(TimeUnit::MICRO, "UTC"));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  ASSERT_EQ(value_col->null_count(), 1);
+  ASSERT_EQ(typed_col->null_count(), 0);
+
+  // Verify int64 value stored
+  auto& int_arr = static_cast<const Int64Array&>(*typed_col);
+  ASSERT_EQ(int_arr.Value(0), 1654041600000000LL);
+
+  // Round-trip: should reconstruct as TimestampMicros (not NTZ or Nanos)
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify the variant bytes encode as TimestampMicros (header byte check)
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  ASSERT_GE(recon_bytes.size(), 1);
+  uint8_t header = static_cast<uint8_t>(recon_bytes[0]);
+  // PrimitiveType::kTimestampMicros = 12, encoded as (12 << 2) | 0 = 0x30
+  ASSERT_EQ(header, 0x30);
+}
+
+TEST_F(VariantShredTypedRoundTripTest, TimestampNanosRoundTrip) {
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.TimestampNanos(1654041600000000000LL).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(1);
+
+  // Schema says NANO resolution with timezone
+  auto schema = VariantShreddingSchema::Primitive(timestamp(TimeUnit::NANO, "UTC"));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  ASSERT_EQ(value_col->null_count(), 1);
+  ASSERT_EQ(typed_col->null_count(), 0);
+
+  // Round-trip: should reconstruct as TimestampNanos (not Micros)
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify the variant bytes encode as TimestampNanos
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  ASSERT_GE(recon_bytes.size(), 1);
+  uint8_t header = static_cast<uint8_t>(recon_bytes[0]);
+  // PrimitiveType::kTimestampNanos = 18, encoded as (18 << 2) | 0 = 0x48
+  ASSERT_EQ(header, 0x48);
+}
+
+TEST_F(VariantShredTypedRoundTripTest, TimestampMicrosNTZRoundTrip) {
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.TimestampMicrosNTZ(1654041600000000LL).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(1);
+
+  // No timezone → NTZ
+  auto schema = VariantShreddingSchema::Primitive(timestamp(TimeUnit::MICRO));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  ASSERT_EQ(value_col->null_count(), 1);
+  ASSERT_EQ(typed_col->null_count(), 0);
+
+  // Round-trip: should reconstruct as TimestampMicrosNTZ
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify: PrimitiveType::kTimestampMicrosNTZ = 13, encoded as (13 << 2) | 0 = 0x34
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  ASSERT_GE(recon_bytes.size(), 1);
+  uint8_t header = static_cast<uint8_t>(recon_bytes[0]);
+  ASSERT_EQ(header, 0x34);
+}
+
+TEST_F(VariantShredTypedRoundTripTest, TimestampNanosNTZRoundTrip) {
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.TimestampNanosNTZ(1654041600000000000LL).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(1);
+
+  // Nano resolution, no timezone → NanosNTZ
+  auto schema = VariantShreddingSchema::Primitive(timestamp(TimeUnit::NANO));
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  ASSERT_EQ(value_col->null_count(), 1);
+  ASSERT_EQ(typed_col->null_count(), 0);
+
+  // Round-trip: should reconstruct as TimestampNanosNTZ
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify: PrimitiveType::kTimestampNanosNTZ = 19, encoded as (19 << 2) | 0 = 0x4C
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  ASSERT_GE(recon_bytes.size(), 1);
+  uint8_t header = static_cast<uint8_t>(recon_bytes[0]);
+  ASSERT_EQ(header, 0x4C);
+}
+
+TEST_F(VariantShredTypedRoundTripTest, FloatWidenedToDoubleRoundTrip) {
+  // Float variant shredded into a Double column — exercises Float→Double widening.
+  // The value precision is preserved (float→double is lossless for the numeric value),
+  // but the variant type tag changes: Float→Double on reconstruction.
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.Float(3.14f).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(1);
+
+  // Target is Double — Float should be compatible (widening)
+  auto schema = VariantShreddingSchema::Primitive(float64());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Float should be shredded into the Double typed_value column
+  ASSERT_EQ(value_col->null_count(), 1);  // value is null (shredded)
+  ASSERT_EQ(typed_col->null_count(), 0);  // typed_value is present
+
+  // Verify the stored double value matches the original float value
+  auto& dbl_arr = static_cast<const DoubleArray&>(*typed_col);
+  ASSERT_DOUBLE_EQ(dbl_arr.Value(0), static_cast<double>(3.14f));
+
+  // Round-trip: reconstructed variant will be Double, not Float
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify: PrimitiveType::kDouble = 7, encoded as (7 << 2) | 0 = 0x1C
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  ASSERT_GE(recon_bytes.size(), 1);
+  uint8_t header = static_cast<uint8_t>(recon_bytes[0]);
+  ASSERT_EQ(header, 0x1C);  // Double, not Float (0x38)
+}
+
+TEST_F(VariantShredTypedRoundTripTest, Int8ShredTargetRoundTrip) {
+  // Int8 variant shredded into an Int8 column
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.Int8(42).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    // Int16 variant should NOT match Int8 target (no narrowing)
+    VariantBuilder vb;
+    vb.Int16(300).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(2);
+
+  auto schema = VariantShreddingSchema::Primitive(int8());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Row 0 (Int8(42)) → typed_value; Row 1 (Int16(300)) → value (no narrowing)
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_TRUE(typed_col->IsValid(0));
+  ASSERT_TRUE(value_col->IsValid(1));
+  ASSERT_TRUE(typed_col->IsNull(1));
+
+  // Verify native value
+  auto& int_arr = static_cast<const Int8Array&>(*typed_col);
+  ASSERT_EQ(int_arr.Value(0), 42);
+
+  // Round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 2);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+}
+
+TEST_F(VariantShredTypedRoundTripTest, Int16ShredTargetRoundTrip) {
+  // Int8 and Int16 variants shredded into an Int16 column
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.Int8(42).ok();  // Int8 → compatible with Int16
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    VariantBuilder vb;
+    vb.Int16(300).ok();  // Int16 → compatible with Int16
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    VariantBuilder vb;
+    vb.Int32(100000).ok();  // Int32 → NOT compatible with Int16 (no narrowing)
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(3);
+
+  auto schema = VariantShreddingSchema::Primitive(int16());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Rows 0,1 → typed; Row 2 → value
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_TRUE(typed_col->IsValid(0));
+  ASSERT_TRUE(value_col->IsNull(1));
+  ASSERT_TRUE(typed_col->IsValid(1));
+  ASSERT_TRUE(value_col->IsValid(2));
+  ASSERT_TRUE(typed_col->IsNull(2));
+
+  auto& int_arr = static_cast<const Int16Array&>(*typed_col);
+  ASSERT_EQ(int_arr.Value(0), 42);
+  ASSERT_EQ(int_arr.Value(1), 300);
+
+  // Round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 3);
+}
+
+TEST_F(VariantShredTypedRoundTripTest, LargeStringShredRoundTrip) {
+  // String variant shredded into a LARGE_STRING column
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.String("hello world").ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    // Non-string should NOT match LARGE_STRING target
+    VariantBuilder vb;
+    vb.Int(42).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(2);
+
+  auto schema = VariantShreddingSchema::Primitive(large_utf8());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Row 0 (String) → typed_value; Row 1 (Int) → value
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_TRUE(typed_col->IsValid(0));
+  ASSERT_TRUE(value_col->IsValid(1));
+  ASSERT_TRUE(typed_col->IsNull(1));
+
+  // Verify native value
+  auto& str_arr = static_cast<const LargeStringArray&>(*typed_col);
+  ASSERT_EQ(str_arr.GetView(0), "hello world");
+
+  // Round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 2);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+
+  // Verify reconstructed string has correct variant header (short string: length in
+  // header)
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  ASSERT_GE(recon_bytes.size(), 1);
+  uint8_t header = static_cast<uint8_t>(recon_bytes[0]);
+  // "hello world" = 11 bytes, short string header = (11 << 2) | 1 = 0x2D
+  ASSERT_EQ(header, 0x2D);
+}
+
+TEST_F(VariantShredTypedRoundTripTest, LargeBinaryShredRoundTrip) {
+  // Binary variant shredded into a LARGE_BINARY column
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.Binary(std::string_view("\x00\x01\x02\x03", 4)).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    // Non-binary should NOT match LARGE_BINARY target
+    VariantBuilder vb;
+    vb.String("not binary").ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(2);
+
+  auto schema = VariantShreddingSchema::Primitive(large_binary());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Row 0 (Binary) → typed_value; Row 1 (String) → value
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_TRUE(typed_col->IsValid(0));
+  ASSERT_TRUE(value_col->IsValid(1));
+  ASSERT_TRUE(typed_col->IsNull(1));
+
+  // Verify native value
+  auto& bin_arr = static_cast<const LargeBinaryArray&>(*typed_col);
+  auto bin_view = bin_arr.GetView(0);
+  ASSERT_EQ(bin_view.size(), 4);
+  ASSERT_EQ(std::memcmp(bin_view.data(), "\x00\x01\x02\x03", 4), 0);
+
+  // Round-trip
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 2);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+}
+
+// ===========================================================================
+// Error handling / invalid input tests
+// ===========================================================================
+
+class VariantShredErrorTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<Array> BuildMetadataColumn(int64_t num_rows) {
+    VariantBuilder vb;
+    vb.Null().ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    BinaryBuilder builder;
+    for (int64_t i = 0; i < num_rows; ++i) {
+      builder
+          .Append(encoded.metadata.data(), static_cast<int32_t>(encoded.metadata.size()))
+          .ok();
+    }
+    std::shared_ptr<Array> result;
+    builder.Finish(&result).ok();
+    return result;
+  }
+};
+
+TEST_F(VariantShredErrorTest, ReconstructBothNonNullPrimitiveSchema) {
+  // Reconstruction should error if both value and typed_value are non-null
+  // for a primitive schema (this is an invalid shredded state).
+  auto metadata = BuildMetadataColumn(1);
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  // Build a value column with a valid value
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.Int(42).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> value_col;
+  value_builder.Finish(&value_col).ok();
+
+  // Build a typed_value column that is also non-null
+  Int64Builder typed_builder;
+  typed_builder.Append(99).ok();
+  std::shared_ptr<Array> typed_col;
+  typed_builder.Finish(&typed_col).ok();
+
+  // Should return Status::Invalid (both non-null is invalid for primitives)
+  auto result = ReconstructVariantColumn(metadata, value_col, typed_col, schema);
+  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsInvalid());
+}
+
+TEST_F(VariantShredErrorTest, ShredUnsupportedTargetType) {
+  // Shredding with an unsupported target type should return NotImplemented
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.Int(42).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+  auto metadata = BuildMetadataColumn(1);
+
+  // duration() is not a valid shredding target
+  auto schema = VariantShreddingSchema::Primitive(duration(TimeUnit::MICRO));
+  auto result = ShredVariantColumn(metadata, values, schema);
+  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsNotImplemented());
+}
+
+TEST_F(VariantShredErrorTest, ShredInvalidMetadataArrayType) {
+  // metadata_array must be BINARY, LARGE_BINARY, or BINARY_VIEW
+  Int64Builder int_builder;
+  int_builder.Append(42).ok();
+  std::shared_ptr<Array> bad_metadata;
+  int_builder.Finish(&bad_metadata).ok();
+
+  BinaryBuilder value_builder;
+  {
+    VariantBuilder vb;
+    vb.Int(1).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+
+  auto schema = VariantShreddingSchema::Primitive(int64());
+  auto result = ShredVariantColumn(bad_metadata, values, schema);
+  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsInvalid());
+}
+
+TEST_F(VariantShredErrorTest, ReconstructInvalidValueArrayType) {
+  // value_array must be BINARY, LARGE_BINARY, or BINARY_VIEW for reconstruction
+  auto metadata = BuildMetadataColumn(1);
+
+  Int64Builder int_builder;
+  int_builder.Append(99).ok();
+  std::shared_ptr<Array> bad_value;
+  int_builder.Finish(&bad_value).ok();
+
+  Int64Builder typed_builder;
+  typed_builder.AppendNull().ok();
+  std::shared_ptr<Array> typed_col;
+  typed_builder.Finish(&typed_col).ok();
+
+  auto schema = VariantShreddingSchema::Primitive(int64());
+  auto result = ReconstructVariantColumn(metadata, bad_value, typed_col, schema);
+  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsInvalid());
+}
+
+TEST_F(VariantShredErrorTest, ReconstructArrayTypedValueNotList) {
+  // For array schemas, typed_value must be a LIST or LARGE_LIST
+  auto metadata = BuildMetadataColumn(1);
+
+  BinaryBuilder value_builder;
+  value_builder.AppendNull().ok();
+  std::shared_ptr<Array> value_col;
+  value_builder.Finish(&value_col).ok();
+
+  // Pass an Int64Array instead of a ListArray
+  Int64Builder typed_builder;
+  typed_builder.Append(42).ok();
+  std::shared_ptr<Array> typed_col;
+  typed_builder.Finish(&typed_col).ok();
+
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+  auto result = ReconstructVariantColumn(metadata, value_col, typed_col, schema);
+  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsInvalid());
+}
+
+TEST_F(VariantShredErrorTest, ReconstructObjectTypedValueNotStruct) {
+  // For object schemas, typed_value must be a StructArray
+  auto metadata = BuildMetadataColumn(1);
+
+  BinaryBuilder value_builder;
+  value_builder.AppendNull().ok();
+  std::shared_ptr<Array> value_col;
+  value_builder.Finish(&value_col).ok();
+
+  // Pass an Int64Array instead of a StructArray
+  Int64Builder typed_builder;
+  typed_builder.Append(42).ok();
+  std::shared_ptr<Array> typed_col;
+  typed_builder.Finish(&typed_col).ok();
+
+  auto schema = VariantShreddingSchema::Object({
+      {"name", VariantShreddingSchema::Primitive(utf8())},
+  });
+  auto result = ReconstructVariantColumn(metadata, value_col, typed_col, schema);
+  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsInvalid());
+}
+
+TEST_F(VariantShredErrorTest, ReconstructObjectFieldCountMismatch) {
+  // typed_value struct has fewer fields than the schema expects
+  auto metadata = BuildMetadataColumn(1);
+
+  BinaryBuilder value_builder;
+  value_builder.AppendNull().ok();
+  std::shared_ptr<Array> value_col;
+  value_builder.Finish(&value_col).ok();
+
+  // Build a struct with only 1 field, but schema expects 2
+  BinaryBuilder inner_value_builder;
+  inner_value_builder.AppendNull().ok();
+  std::shared_ptr<Array> inner_value;
+  inner_value_builder.Finish(&inner_value).ok();
+
+  Int64Builder inner_typed_builder;
+  inner_typed_builder.AppendNull().ok();
+  std::shared_ptr<Array> inner_typed;
+  inner_typed_builder.Finish(&inner_typed).ok();
+
+  auto inner_fields = std::vector<std::shared_ptr<Field>>{
+      field("value", binary(), true),
+      field("typed_value", int64(), true),
+  };
+  ASSERT_OK_AND_ASSIGN(auto single_field_struct,
+                       StructArray::Make({inner_value, inner_typed}, inner_fields));
+
+  // Wrap into outer struct with only 1 field ("name")
+  auto outer_fields = std::vector<std::shared_ptr<Field>>{
+      field("name", single_field_struct->type(), false),
+  };
+  ASSERT_OK_AND_ASSIGN(auto typed_col,
+                       StructArray::Make({single_field_struct}, outer_fields));
+
+  // Schema expects 2 fields: name + age
+  auto schema = VariantShreddingSchema::Object({
+      {"name", VariantShreddingSchema::Primitive(utf8())},
+      {"age", VariantShreddingSchema::Primitive(int64())},
+  });
+  auto result = ReconstructVariantColumn(metadata, value_col, typed_col, schema);
+  ASSERT_FALSE(result.ok());
+  ASSERT_TRUE(result.status().IsInvalid());
+}
+
+// ===========================================================================
+// StringView / BinaryView shredding tests
+// ===========================================================================
+
+TEST_F(VariantShredRoundTripTest, StringViewShredRoundTrip) {
+  // String variant values shredded into StringView typed column
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) { return b.String("hello"); },
+      [](VariantBuilder& b) { return b.Int(42); },  // doesn't match
+      [](VariantBuilder& b) { return b.String("world"); },
+  });
+  auto metadata = BuildMetadataColumn(3);
+  auto schema = VariantShreddingSchema::Primitive(utf8_view());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Rows 0,2 match (strings); Row 1 doesn't (int)
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_TRUE(value_col->IsValid(1));
+  ASSERT_TRUE(value_col->IsNull(2));
+
+  ASSERT_TRUE(typed_col->IsValid(0));
+  ASSERT_TRUE(typed_col->IsNull(1));
+  ASSERT_TRUE(typed_col->IsValid(2));
+
+  // Verify typed column is StringViewArray
+  ASSERT_EQ(typed_col->type_id(), Type::STRING_VIEW);
+  auto& sv_arr = static_cast<const StringViewArray&>(*typed_col);
+  ASSERT_EQ(sv_arr.GetView(0), "hello");
+  ASSERT_EQ(sv_arr.GetView(2), "world");
+
+  // Round-trip via reconstruction
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 3);
+  // Verify reconstructed strings have correct short-string header byte
+  auto recon_bytes0 = GetBinaryView(*reconstructed, 0);
+  // Short string "hello" (5 chars): header = (5 << 2) | 0x01 = 0x15
+  ASSERT_EQ(recon_bytes0.size(), 6);
+  ASSERT_EQ(static_cast<uint8_t>(recon_bytes0[0]), 0x15);
+}
+
+TEST_F(VariantShredRoundTripTest, BinaryViewShredRoundTrip) {
+  // Binary variant values shredded into BinaryView typed column
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) { return b.Binary(std::string_view("\x01\x02\x03", 3)); },
+      [](VariantBuilder& b) { return b.String("text"); },  // doesn't match binary
+      [](VariantBuilder& b) { return b.Binary(std::string_view("\xAA\xBB", 2)); },
+  });
+  auto metadata = BuildMetadataColumn(3);
+  auto schema = VariantShreddingSchema::Primitive(binary_view());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Rows 0,2 match (binary); Row 1 doesn't (string)
+  ASSERT_TRUE(value_col->IsNull(0));
+  ASSERT_TRUE(value_col->IsValid(1));
+  ASSERT_TRUE(value_col->IsNull(2));
+
+  ASSERT_TRUE(typed_col->IsValid(0));
+  ASSERT_TRUE(typed_col->IsNull(1));
+  ASSERT_TRUE(typed_col->IsValid(2));
+
+  // Verify typed column is BinaryViewArray
+  ASSERT_EQ(typed_col->type_id(), Type::BINARY_VIEW);
+  auto& bv_arr = static_cast<const BinaryViewArray&>(*typed_col);
+  auto v0 = bv_arr.GetView(0);
+  ASSERT_EQ(v0.size(), 3);
+  ASSERT_EQ(v0[0], '\x01');
+  ASSERT_EQ(v0[1], '\x02');
+  ASSERT_EQ(v0[2], '\x03');
+
+  // Round-trip via reconstruction
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 3);
+}
+
+TEST_F(VariantShredRoundTripTest, ShortStringToStringView) {
+  // Short strings (≤63 bytes) should be compatible with StringView target
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) { return b.String("hi"); },  // short string
+  });
+  auto metadata = BuildMetadataColumn(1);
+  auto schema = VariantShreddingSchema::Primitive(utf8_view());
+
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+
+  auto typed_col = shredded->field(2);
+  ASSERT_EQ(typed_col->type_id(), Type::STRING_VIEW);
+  ASSERT_TRUE(typed_col->IsValid(0));
+  auto& sv_arr = static_cast<const StringViewArray&>(*typed_col);
+  ASSERT_EQ(sv_arr.GetView(0), "hi");
+}
+
+// ===========================================================================
+// LargeList reconstruction tests
+// ===========================================================================
+
+TEST_F(VariantShredRoundTripTest, LargeListReconstructRoundTrip) {
+  // Shred an array, then construct a LargeListArray with equivalent data
+  // and verify reconstruction works with 64-bit offsets.
+  auto values = BuildVariantColumn({
+      [](VariantBuilder& b) {
+        auto s = b.Offset();
+        std::vector<int64_t> offsets;
+        offsets.push_back(b.NextElement(s));
+        b.Int(10).ok();
+        offsets.push_back(b.NextElement(s));
+        b.Int(20).ok();
+        return b.FinishArray(s, offsets);
+      },
+  });
+  auto metadata = BuildMetadataColumn(1);
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+
+  // First shred normally (produces ListArray with struct elements)
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+  auto value_col = shredded->field(1);  // residual (null for arrays)
+  auto typed_col = shredded->field(2);  // ListArray<struct{value, typed_value}>
+
+  ASSERT_EQ(typed_col->type_id(), Type::LIST);
+
+  // Reconstruct from the normal ListArray (sanity check)
+  ASSERT_OK_AND_ASSIGN(auto recon1,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(recon1->length(), 1);
+
+  // Now build a LargeListArray with the same element struct data.
+  // The elements are struct{value: binary, typed_value: int64}.
+  const auto* list_arr = static_cast<const ListArray*>(typed_col.get());
+  auto elem_struct = list_arr->values();  // StructArray
+
+  // Construct a LargeList with same struct elements using 64-bit offsets.
+  auto large_offsets = Buffer::FromVector(std::vector<int64_t>{0, 2});
+  auto large_list_arr = std::make_shared<LargeListArray>(
+      large_list(field("element", elem_struct->type(), false)), 1, large_offsets,
+      elem_struct);
+  ASSERT_EQ(large_list_arr->type_id(), Type::LARGE_LIST);
+
+  // Reconstruct from LargeListArray
+  ASSERT_OK_AND_ASSIGN(
+      auto recon2, ReconstructVariantColumn(metadata, value_col, large_list_arr, schema));
+  ASSERT_EQ(recon2->length(), 1);
+
+  // Verify both reconstructions produce identical output
+  auto bytes1 = GetBinaryView(*recon1, 0);
+  auto bytes2 = GetBinaryView(*recon2, 0);
+  ASSERT_EQ(bytes1, bytes2);
+}
+
+TEST_F(VariantShredRoundTripTest, ReconstructArrayTypedValueLargeListAccepted) {
+  // Verify that LargeList is accepted alongside List for array reconstruction.
+  // This tests the validation path.
+  auto metadata = BuildMetadataColumn(0);
+  BinaryBuilder vb;
+  std::shared_ptr<Array> value_col;
+  vb.Finish(&value_col).ok();
+
+  // Empty LargeList of binary
+  auto large_list_builder = std::make_shared<LargeListBuilder>(
+      default_memory_pool(), std::make_shared<BinaryBuilder>());
+  std::shared_ptr<Array> typed_col;
+  large_list_builder->Finish(&typed_col).ok();
+
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+
+  // Should succeed (empty arrays, no actual reconstruction needed)
+  auto result = ReconstructVariantColumn(metadata, value_col, typed_col, schema);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(VariantShredRoundTripTest, ReconstructArrayFixedSizeListAccepted) {
+  // Verify that FixedSizeList is accepted for array reconstruction.
+  // Build a FixedSizeList(2) of binary variant bytes and reconstruct.
+  auto metadata = BuildMetadataColumn(1);
+
+  // value_col is null (array went to typed_value)
+  BinaryBuilder value_builder;
+  value_builder.AppendNull().ok();
+  std::shared_ptr<Array> value_col;
+  value_builder.Finish(&value_col).ok();
+
+  // Build element binary values: Int(10), Int(20)
+  BinaryBuilder elem_builder;
+  {
+    VariantBuilder vb;
+    vb.Int(10).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    elem_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  {
+    VariantBuilder vb;
+    vb.Int(20).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    elem_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> elem_arr;
+  elem_builder.Finish(&elem_arr).ok();
+
+  // Build FixedSizeList(2) containing the 2 elements
+  auto typed_col = std::make_shared<FixedSizeListArray>(
+      fixed_size_list(field("item", binary()), 2), 1, elem_arr);
+
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+
+  // Should succeed
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify reconstructed is a variant array with 2 elements
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  auto* data = reinterpret_cast<const uint8_t*>(recon_bytes.data());
+  auto len = static_cast<int64_t>(recon_bytes.size());
+  ASSERT_GE(len, 1);
+  ASSERT_EQ(GetBasicType(data[0]), BasicType::kArray);
+  ASSERT_OK_AND_ASSIGN(auto elem_count, GetArrayElementCount(data, len));
+  ASSERT_EQ(elem_count, 2);
+}
+
+TEST_F(VariantShredRoundTripTest, ReconstructArrayListViewAccepted) {
+  // Verify that ListView is accepted for array reconstruction.
+  auto metadata = BuildMetadataColumn(1);
+
+  // value_col is null
+  BinaryBuilder value_builder;
+  value_builder.AppendNull().ok();
+  std::shared_ptr<Array> value_col;
+  value_builder.Finish(&value_col).ok();
+
+  // Build element binary values: Int(5), Int(6), Int(7)
+  BinaryBuilder elem_builder;
+  for (int val : {5, 6, 7}) {
+    VariantBuilder vb;
+    vb.Int(val).ok();
+    auto encoded = vb.Finish().ValueOrDie();
+    elem_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+        .ok();
+  }
+  std::shared_ptr<Array> elem_arr;
+  elem_builder.Finish(&elem_arr).ok();
+
+  // Build a ListView array: 1 row pointing to elements [0, 3) (all 3 elements)
+  // ListView needs offsets buffer + sizes buffer
+  auto offsets_buf = Buffer::FromVector<int32_t>({0});
+  auto sizes_buf = Buffer::FromVector<int32_t>({3});
+  auto list_view_type = list_view(field("item", binary()));
+  auto typed_col = std::make_shared<ListViewArray>(list_view_type, 1, offsets_buf,
+                                                   sizes_buf, elem_arr);
+
+  auto schema = VariantShreddingSchema::Array(VariantShreddingSchema::Primitive(int64()));
+
+  // Should succeed
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+
+  // Verify reconstructed is a variant array with 3 elements
+  auto recon_bytes = GetBinaryView(*reconstructed, 0);
+  auto* data = reinterpret_cast<const uint8_t*>(recon_bytes.data());
+  auto len = static_cast<int64_t>(recon_bytes.size());
+  ASSERT_GE(len, 1);
+  ASSERT_EQ(GetBasicType(data[0]), BasicType::kArray);
+  ASSERT_OK_AND_ASSIGN(auto elem_count, GetArrayElementCount(data, len));
+  ASSERT_EQ(elem_count, 3);
+}
+
+TEST_F(VariantShredRoundTripTest, StringViewMetadataArrayInput) {
+  // Verify that STRING_VIEW metadata arrays are accepted by ShredVariantColumn.
+  // Arrow's BinaryViewArray/StringViewArray are valid metadata containers.
+  VariantBuilder vb;
+  vb.Int(42).ok();
+  auto encoded = vb.Finish().ValueOrDie();
+
+  // Build a BinaryView metadata array (STRING_VIEW has the same binary layout
+  // and is accepted by GetBinaryValue)
+  BinaryViewBuilder meta_builder;
+  meta_builder
+      .Append(encoded.metadata.data(), static_cast<int64_t>(encoded.metadata.size()))
+      .ok();
+  std::shared_ptr<Array> metadata;
+  meta_builder.Finish(&metadata).ok();
+  ASSERT_EQ(metadata->type_id(), Type::BINARY_VIEW);
+
+  // Build value array as regular binary
+  BinaryBuilder value_builder;
+  value_builder.Append(encoded.value.data(), static_cast<int32_t>(encoded.value.size()))
+      .ok();
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  // Shredding should work with BinaryView metadata
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+  auto typed_col = shredded->field(2);
+  ASSERT_EQ(typed_col->null_count(), 0);
+  auto& int_arr = static_cast<const Int64Array&>(*typed_col);
+  ASSERT_EQ(int_arr.Value(0), 42);
+}
+
+TEST_F(VariantShredRoundTripTest, BinaryViewMetadataReconstructionRoundTrip) {
+  // Verify that BINARY_VIEW metadata arrays work in reconstruction path.
+  VariantBuilder vb;
+  vb.Int(99).ok();
+  auto encoded = vb.Finish().ValueOrDie();
+
+  // Build metadata as BinaryView
+  BinaryViewBuilder meta_builder;
+  meta_builder
+      .Append(encoded.metadata.data(), static_cast<int64_t>(encoded.metadata.size()))
+      .ok();
+  std::shared_ptr<Array> metadata;
+  meta_builder.Finish(&metadata).ok();
+  ASSERT_EQ(metadata->type_id(), Type::BINARY_VIEW);
+
+  // value_col is null (value goes to typed)
+  BinaryBuilder value_builder;
+  value_builder.AppendNull().ok();
+  std::shared_ptr<Array> value_col;
+  value_builder.Finish(&value_col).ok();
+
+  // typed_value has the int64
+  Int64Builder typed_builder;
+  typed_builder.Append(99).ok();
+  std::shared_ptr<Array> typed_col;
+  typed_builder.Finish(&typed_col).ok();
+
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  // Reconstruction should succeed with BinaryView metadata
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 1);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+}
+
+TEST_F(VariantShredRoundTripTest, ObjectShredDifferentMetadataDictionaries) {
+  // Test object shredding with rows that have different metadata dictionaries.
+  // This exercises the cached_meta_bytes comparison in ReconstructVariantColumnObject.
+  auto schema = VariantShreddingSchema::Object({
+      {"x", VariantShreddingSchema::Primitive(int64())},
+  });
+
+  // Row 0: object {"x": 10} with metadata containing "x"
+  VariantBuilder vb1;
+  auto start1 = vb1.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields1;
+  fields1.push_back(vb1.NextField(start1, "x"));
+  vb1.Int(10).ok();
+  vb1.FinishObject(start1, fields1).ok();
+  auto encoded1 = vb1.Finish().ValueOrDie();
+
+  // Row 1: object {"x": 20, "y": 30} with metadata containing "x" AND "y"
+  VariantBuilder vb2;
+  auto start2 = vb2.Offset();
+  std::vector<VariantBuilder::FieldEntry> fields2;
+  fields2.push_back(vb2.NextField(start2, "x"));
+  vb2.Int(20).ok();
+  fields2.push_back(vb2.NextField(start2, "y"));
+  vb2.Int(30).ok();
+  vb2.FinishObject(start2, fields2).ok();
+  auto encoded2 = vb2.Finish().ValueOrDie();
+
+  // Build metadata array (different metadata per row)
+  BinaryBuilder meta_builder;
+  meta_builder
+      .Append(encoded1.metadata.data(), static_cast<int32_t>(encoded1.metadata.size()))
+      .ok();
+  meta_builder
+      .Append(encoded2.metadata.data(), static_cast<int32_t>(encoded2.metadata.size()))
+      .ok();
+  std::shared_ptr<Array> metadata;
+  meta_builder.Finish(&metadata).ok();
+
+  // Build value array
+  BinaryBuilder value_builder;
+  value_builder.Append(encoded1.value.data(), static_cast<int32_t>(encoded1.value.size()))
+      .ok();
+  value_builder.Append(encoded2.value.data(), static_cast<int32_t>(encoded2.value.size()))
+      .ok();
+  std::shared_ptr<Array> values;
+  value_builder.Finish(&values).ok();
+
+  // Shred
+  ASSERT_OK_AND_ASSIGN(auto shredded, ShredVariantColumn(metadata, values, schema));
+  auto value_col = shredded->field(1);
+  auto typed_col = shredded->field(2);
+
+  // Row 0: "x" is shredded, no residual (single field)
+  // Row 1: "x" is shredded, "y" goes to residual
+  ASSERT_TRUE(value_col->IsNull(0));   // no residual for row 0
+  ASSERT_TRUE(value_col->IsValid(1));  // residual with "y" for row 1
+
+  // Reconstruct — must handle different metadata dictionaries correctly
+  ASSERT_OK_AND_ASSIGN(auto reconstructed,
+                       ReconstructVariantColumn(metadata, value_col, typed_col, schema));
+  ASSERT_EQ(reconstructed->length(), 2);
+  ASSERT_TRUE(reconstructed->IsValid(0));
+  ASSERT_TRUE(reconstructed->IsValid(1));
+
+  // Verify row 1 reconstructed has both fields by checking it's a valid object
+  auto recon_bytes = GetBinaryView(*reconstructed, 1);
+  auto* data = reinterpret_cast<const uint8_t*>(recon_bytes.data());
+  auto len = static_cast<int64_t>(recon_bytes.size());
+  ASSERT_GE(len, 1);
+  ASSERT_EQ(GetBasicType(data[0]), BasicType::kObject);
+  ASSERT_OK_AND_ASSIGN(auto field_count, GetObjectFieldCount(data, len));
+  ASSERT_EQ(field_count, 2);  // Both "x" and "y" reconstructed
+}
+
+// ===========================================================================
+// NullBuffer output from ReconstructVariantColumn
+// ===========================================================================
+
+class VariantReconstructNullBitmapTest : public ::testing::Test {};
+
+TEST_F(VariantReconstructNullBitmapTest, PrimitiveSchemaProducesNullBitmap) {
+  // Build: row 0 = Int64(42), row 1 = both null (SQL NULL), row 2 = Int64(99)
+  // Shred them so row 1 results in both value=null and typed_value=null.
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  // Build variant values
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int(42));
+  ASSERT_OK_AND_ASSIGN(auto enc0, builder.Finish());
+  builder.Reset();
+  ASSERT_OK(builder.Int(99));
+  ASSERT_OK_AND_ASSIGN(auto enc2, builder.Finish());
+
+  // Construct the shredded representation manually:
+  // metadata: 3 rows (same metadata for all)
+  // value: [null, null, null] (all values go to typed_value)
+  // typed_value: [42, null, 99]
+  BinaryBuilder meta_builder;
+  ASSERT_OK(meta_builder.Append(enc0.metadata.data(), enc0.metadata.size()));
+  ASSERT_OK(meta_builder.Append(enc0.metadata.data(), enc0.metadata.size()));
+  ASSERT_OK(meta_builder.Append(enc0.metadata.data(), enc0.metadata.size()));
+  std::shared_ptr<Array> meta_arr;
+  ASSERT_OK(meta_builder.Finish(&meta_arr));
+
+  BinaryBuilder value_builder;
+  ASSERT_OK(value_builder.AppendNull());
+  ASSERT_OK(value_builder.AppendNull());
+  ASSERT_OK(value_builder.AppendNull());
+  std::shared_ptr<Array> value_arr;
+  ASSERT_OK(value_builder.Finish(&value_arr));
+
+  Int64Builder typed_builder;
+  ASSERT_OK(typed_builder.Append(42));
+  ASSERT_OK(typed_builder.AppendNull());  // row 1: SQL NULL
+  ASSERT_OK(typed_builder.Append(99));
+  std::shared_ptr<Array> typed_arr;
+  ASSERT_OK(typed_builder.Finish(&typed_arr));
+
+  // Reconstruct WITH null bitmap output
+  std::shared_ptr<Buffer> null_bitmap;
+  ASSERT_OK_AND_ASSIGN(
+      auto result,
+      ReconstructVariantColumn(meta_arr, value_arr, typed_arr, schema, &null_bitmap));
+
+  // Verify results
+  ASSERT_EQ(result->length(), 3);
+  ASSERT_NE(null_bitmap, nullptr);
+
+  // Row 0: typed_value present → valid (bit=1)
+  ASSERT_TRUE(bit_util::GetBit(null_bitmap->data(), 0));
+  // Row 1: both null → SQL NULL (bit=0)
+  ASSERT_FALSE(bit_util::GetBit(null_bitmap->data(), 1));
+  // Row 2: typed_value present → valid (bit=1)
+  ASSERT_TRUE(bit_util::GetBit(null_bitmap->data(), 2));
+}
+
+TEST_F(VariantReconstructNullBitmapTest, NullBitmapNotRequestedByDefault) {
+  auto schema = VariantShreddingSchema::Primitive(int64());
+
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int(42));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+
+  BinaryBuilder meta_builder;
+  ASSERT_OK(meta_builder.Append(enc.metadata.data(), enc.metadata.size()));
+  std::shared_ptr<Array> meta_arr;
+  ASSERT_OK(meta_builder.Finish(&meta_arr));
+
+  BinaryBuilder value_builder;
+  ASSERT_OK(value_builder.AppendNull());
+  std::shared_ptr<Array> value_arr;
+  ASSERT_OK(value_builder.Finish(&value_arr));
+
+  Int64Builder typed_builder;
+  ASSERT_OK(typed_builder.Append(42));
+  std::shared_ptr<Array> typed_arr;
+  ASSERT_OK(typed_builder.Finish(&typed_arr));
+
+  // Call WITHOUT null bitmap (default parameter)
+  ASSERT_OK_AND_ASSIGN(auto result,
+                       ReconstructVariantColumn(meta_arr, value_arr, typed_arr, schema));
+  ASSERT_EQ(result->length(), 1);
+}
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_test.cc
+++ b/cpp/src/arrow/extension/variant_test.cc
@@ -1,0 +1,2412 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/extension/variant.h"
+#include "arrow/extension/variant_internal_test_util.h"
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow::extension::variant {
+
+// ===========================================================================
+// Test helpers
+// ===========================================================================
+
+namespace {
+
+/// \brief Decode and visit a variant value (convenience wrapper for tests).
+/// Replaces the old DecodeVariantValue free function.
+Status DecodeAndVisit(const VariantMetadata& metadata, const uint8_t* data,
+                      int64_t length, VariantVisitor* visitor) {
+  ARROW_ASSIGN_OR_RAISE(auto view, VariantView::Make(metadata, data, length));
+  return view.Visit(visitor);
+}
+
+/// \brief Get the basic type of a value (convenience for tests).
+Result<BasicType> GetValueBasicType(const uint8_t* data, int64_t length) {
+  if (data == nullptr || length < 1) {
+    return Status::Invalid("buffer is null or empty");
+  }
+  return GetBasicType(data[0]);
+}
+
+/// \brief Get object field count (convenience for tests).
+Result<int32_t> GetObjectFieldCount(const uint8_t* data, int64_t length) {
+  VariantMetadata empty_meta;
+  ARROW_ASSIGN_OR_RAISE(auto obj, VariantObjectView::Make(empty_meta, data, length));
+  return obj.num_fields();
+}
+
+/// \brief Get array element count (convenience for tests).
+Result<int32_t> GetArrayElementCount(const uint8_t* data, int64_t length) {
+  VariantMetadata empty_meta;
+  ARROW_ASSIGN_OR_RAISE(auto arr, VariantArrayView::Make(empty_meta, data, length));
+  return arr.num_elements();
+}
+
+/// \brief Find object field by name (convenience for tests).
+Status FindObjectField(const VariantMetadata& metadata, const uint8_t* data,
+                       int64_t length, std::string_view field_name, int64_t* field_offset,
+                       int64_t* field_size) {
+  *field_offset = -1;
+  *field_size = 0;
+  ARROW_ASSIGN_OR_RAISE(auto obj, VariantObjectView::Make(metadata, data, length));
+  auto result = obj.get(field_name);
+  if (result.has_value()) {
+    *field_offset = result->data() - data;
+    *field_size = result->size_bytes();
+  }
+  return Status::OK();
+}
+
+/// \brief Get array element by index (convenience for tests).
+Status GetArrayElement(const uint8_t* data, int64_t length, int32_t index,
+                       int64_t* element_offset, int64_t* element_size) {
+  VariantMetadata empty_meta;
+  ARROW_ASSIGN_OR_RAISE(auto arr, VariantArrayView::Make(empty_meta, data, length));
+  ARROW_ASSIGN_OR_RAISE(auto elem, arr.get(index));
+  *element_offset = elem.data() - data;
+  *element_size = elem.size_bytes();
+  return Status::OK();
+}
+
+/// \brief Get object field at index (convenience for tests).
+Status GetObjectFieldAt(const VariantMetadata& metadata, const uint8_t* data,
+                        int64_t length, int32_t index, std::string_view* field_name,
+                        int64_t* field_offset, int64_t* field_size) {
+  ARROW_ASSIGN_OR_RAISE(auto obj, VariantObjectView::Make(metadata, data, length));
+  ARROW_ASSIGN_OR_RAISE(*field_name, obj.field_name(index));
+  ARROW_ASSIGN_OR_RAISE(auto value, obj.field_value(index));
+  *field_offset = value.data() - data;
+  *field_size = value.size_bytes();
+  return Status::OK();
+}
+
+/// \brief Build a metadata buffer from a list of strings.
+///
+/// Uses offset_size=1, version=1, sorted flag as specified.
+std::vector<uint8_t> BuildMetadataBuffer(const std::vector<std::string>& strings,
+                                         bool sorted = false, int32_t offset_size = 1) {
+  std::vector<uint8_t> buffer;
+
+  // Header byte: version=1, sorted flag, offset_size
+  uint8_t header = kVariantVersion;
+  if (sorted) {
+    header |= (1 << 4);
+  }
+  header |= static_cast<uint8_t>((offset_size - 1) << 6);
+  buffer.push_back(header);
+
+  // Dictionary size
+  auto dict_size = static_cast<uint32_t>(strings.size());
+  for (int32_t b = 0; b < offset_size; ++b) {
+    buffer.push_back(static_cast<uint8_t>((dict_size >> (b * 8)) & 0xFF));
+  }
+
+  // Compute string offsets
+  std::vector<uint32_t> offsets(dict_size + 1);
+  offsets[0] = 0;
+  for (uint32_t i = 0; i < dict_size; ++i) {
+    offsets[i + 1] = offsets[i] + static_cast<uint32_t>(strings[i].size());
+  }
+
+  // Write offsets
+  for (uint32_t i = 0; i <= dict_size; ++i) {
+    for (int32_t b = 0; b < offset_size; ++b) {
+      buffer.push_back(static_cast<uint8_t>((offsets[i] >> (b * 8)) & 0xFF));
+    }
+  }
+
+  // Write string data
+  for (const auto& s : strings) {
+    buffer.insert(buffer.end(), s.begin(), s.end());
+  }
+
+  return buffer;
+}
+
+/// \brief Build a primitive value header byte.
+uint8_t PrimitiveHeader(PrimitiveType type) {
+  return static_cast<uint8_t>(BasicType::kPrimitive) | (static_cast<uint8_t>(type) << 2);
+}
+
+/// \brief Build a short string value buffer.
+std::vector<uint8_t> BuildShortString(const std::string& s) {
+  std::vector<uint8_t> buffer;
+  auto len = static_cast<uint8_t>(s.size());
+  uint8_t header = static_cast<uint8_t>(BasicType::kShortString) | (len << 2);
+  buffer.push_back(header);
+  buffer.insert(buffer.end(), s.begin(), s.end());
+  return buffer;
+}
+
+/// \brief Build an object value buffer.
+///
+/// \param field_ids Dictionary indices for each field name
+/// \param field_values Serialized variant values for each field
+/// \param field_id_size Bytes per field ID (1-4)
+/// \param field_offset_size Bytes per offset (1-4)
+std::vector<uint8_t> BuildObject(const std::vector<uint32_t>& field_ids,
+                                 const std::vector<std::vector<uint8_t>>& field_values,
+                                 int32_t field_id_size = 1,
+                                 int32_t field_offset_size = 1) {
+  auto num_fields = static_cast<uint32_t>(field_ids.size());
+  bool is_large = (num_fields > 255);
+
+  std::vector<uint8_t> buffer;
+
+  // Header per spec: basic_type=2 in bits 0-1,
+  //   bits 2-3: field_offset_size-1
+  //   bits 4-5: field_id_size-1
+  //   bit 6: is_large
+  uint8_t header = static_cast<uint8_t>(BasicType::kObject);
+  header |= static_cast<uint8_t>((field_offset_size - 1) << 2);
+  header |= static_cast<uint8_t>((field_id_size - 1) << 4);
+  if (is_large) {
+    header |= (1 << 6);
+  }
+  buffer.push_back(header);
+
+  // num_fields: 1 byte or 4 bytes depending on is_large
+  int32_t num_fields_size = is_large ? 4 : 1;
+  for (int32_t b = 0; b < num_fields_size; ++b) {
+    buffer.push_back(static_cast<uint8_t>((num_fields >> (b * 8)) & 0xFF));
+  }
+
+  // field_ids
+  for (auto fid : field_ids) {
+    for (int32_t b = 0; b < field_id_size; ++b) {
+      buffer.push_back(static_cast<uint8_t>((fid >> (b * 8)) & 0xFF));
+    }
+  }
+
+  // Compute offsets
+  std::vector<uint32_t> offsets(num_fields + 1);
+  offsets[0] = 0;
+  for (uint32_t i = 0; i < num_fields; ++i) {
+    offsets[i + 1] = offsets[i] + static_cast<uint32_t>(field_values[i].size());
+  }
+
+  // Write offsets
+  for (uint32_t i = 0; i <= num_fields; ++i) {
+    for (int32_t b = 0; b < field_offset_size; ++b) {
+      buffer.push_back(static_cast<uint8_t>((offsets[i] >> (b * 8)) & 0xFF));
+    }
+  }
+
+  // Write field value data
+  for (const auto& fv : field_values) {
+    buffer.insert(buffer.end(), fv.begin(), fv.end());
+  }
+
+  return buffer;
+}
+
+/// \brief Build an array value buffer.
+///
+/// \param elements Serialized variant values for each element
+/// \param field_offset_size Bytes per offset (1-4)
+std::vector<uint8_t> BuildArray(const std::vector<std::vector<uint8_t>>& elements,
+                                int32_t field_offset_size = 1) {
+  auto num_elements = static_cast<uint32_t>(elements.size());
+  bool is_large = (num_elements > 255);
+
+  std::vector<uint8_t> buffer;
+
+  // Header per spec: basic_type=3 in bits 0-1,
+  //   bits 2-3: field_offset_size-1
+  //   bit 4: is_large
+  uint8_t header = static_cast<uint8_t>(BasicType::kArray);
+  header |= static_cast<uint8_t>((field_offset_size - 1) << 2);
+  if (is_large) {
+    header |= (1 << 4);
+  }
+  buffer.push_back(header);
+
+  // num_elements: 1 byte or 4 bytes depending on is_large
+  int32_t num_elements_size = is_large ? 4 : 1;
+  for (int32_t b = 0; b < num_elements_size; ++b) {
+    buffer.push_back(static_cast<uint8_t>((num_elements >> (b * 8)) & 0xFF));
+  }
+
+  // Compute offsets
+  std::vector<uint32_t> offsets(num_elements + 1);
+  offsets[0] = 0;
+  for (uint32_t i = 0; i < num_elements; ++i) {
+    offsets[i + 1] = offsets[i] + static_cast<uint32_t>(elements[i].size());
+  }
+
+  // Write offsets
+  for (uint32_t i = 0; i <= num_elements; ++i) {
+    for (int32_t b = 0; b < field_offset_size; ++b) {
+      buffer.push_back(static_cast<uint8_t>((offsets[i] >> (b * 8)) & 0xFF));
+    }
+  }
+
+  // Write element data
+  for (const auto& elem : elements) {
+    buffer.insert(buffer.end(), elem.begin(), elem.end());
+  }
+
+  return buffer;
+}
+
+}  // namespace
+
+// ===========================================================================
+// Metadata decoding tests
+// ===========================================================================
+
+class VariantMetadataTest : public ::testing::Test {};
+
+TEST_F(VariantMetadataTest, EmptyDictionary) {
+  auto buf = BuildMetadataBuffer({});
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.version, 1);
+  ASSERT_FALSE(metadata.is_sorted);
+  ASSERT_EQ(metadata.offset_size, 1);
+  ASSERT_EQ(metadata.strings.size(), 0);
+}
+
+TEST_F(VariantMetadataTest, SingleString) {
+  auto buf = BuildMetadataBuffer({"hello"});
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.strings.size(), 1);
+  ASSERT_EQ(metadata.strings[0], "hello");
+}
+
+TEST_F(VariantMetadataTest, MultipleStrings) {
+  auto buf = BuildMetadataBuffer({"name", "age", "scores"});
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.strings.size(), 3);
+  ASSERT_EQ(metadata.strings[0], "name");
+  ASSERT_EQ(metadata.strings[1], "age");
+  ASSERT_EQ(metadata.strings[2], "scores");
+}
+
+TEST_F(VariantMetadataTest, SortedFlag) {
+  auto buf = BuildMetadataBuffer({"age", "name", "score"}, true);
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_TRUE(metadata.is_sorted);
+}
+
+TEST_F(VariantMetadataTest, OffsetSize2) {
+  auto buf = BuildMetadataBuffer({"key1", "key2"}, false, 2);
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.offset_size, 2);
+  ASSERT_EQ(metadata.strings.size(), 2);
+  ASSERT_EQ(metadata.strings[0], "key1");
+  ASSERT_EQ(metadata.strings[1], "key2");
+}
+
+TEST_F(VariantMetadataTest, OffsetSize4) {
+  auto buf = BuildMetadataBuffer({"a", "bb", "ccc"}, false, 4);
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.offset_size, 4);
+  ASSERT_EQ(metadata.strings.size(), 3);
+  ASSERT_EQ(metadata.strings[0], "a");
+  ASSERT_EQ(metadata.strings[1], "bb");
+  ASSERT_EQ(metadata.strings[2], "ccc");
+}
+
+TEST_F(VariantMetadataTest, EmptyStrings) {
+  auto buf = BuildMetadataBuffer({"", "nonempty", ""});
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.strings.size(), 3);
+  ASSERT_EQ(metadata.strings[0], "");
+  ASSERT_EQ(metadata.strings[1], "nonempty");
+  ASSERT_EQ(metadata.strings[2], "");
+}
+
+// Error cases
+
+TEST_F(VariantMetadataTest, NullBuffer) {
+  ASSERT_RAISES(Invalid, DecodeMetadata(nullptr, 0));
+}
+
+TEST_F(VariantMetadataTest, EmptyBuffer) {
+  uint8_t data = 0;
+  ASSERT_RAISES(Invalid, DecodeMetadata(&data, 0));
+}
+
+TEST_F(VariantMetadataTest, UnsupportedVersion) {
+  // Version 2 (unsupported)
+  uint8_t data[] = {0x02, 0x00};
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
+TEST_F(VariantMetadataTest, TruncatedDictionarySize) {
+  // Header says offset_size=2 (bits 6-7 = 01), but only 1 byte follows
+  uint8_t data[] = {0x41, 0x00};  // version=1, offset_size=2
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
+TEST_F(VariantMetadataTest, TruncatedStringOffsets) {
+  // Claims dict_size=5 but buffer is too short for offsets
+  uint8_t data[] = {0x01, 0x05, 0x00};
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
+TEST_F(VariantMetadataTest, OffsetSize3) {
+  auto buf = BuildMetadataBuffer({"foo", "bar"}, false, 3);
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.offset_size, 3);
+  ASSERT_EQ(metadata.strings.size(), 2);
+  ASSERT_EQ(metadata.strings[0], "foo");
+  ASSERT_EQ(metadata.strings[1], "bar");
+}
+
+TEST_F(VariantMetadataTest, ReservedBit5Set) {
+  // Header with bit 5 set: 0x21 = version=1, bit5=1
+  uint8_t data[] = {0x21, 0x00, 0x00};
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
+TEST_F(VariantMetadataTest, NonMonotonicStringOffsets) {
+  // Manually construct metadata where string offsets are NOT monotonically
+  // non-decreasing. ValidateOffsets should reject this.
+  // Header: version=1, offset_size=1
+  // dict_size=2, offsets=[0, 5, 3] — 3 < 5, non-monotonic
+  // String data: "helloabc" (8 bytes, but offsets claim 3 as last)
+  uint8_t data[] = {0x01,              // header: version=1, offset_size=1
+                    0x02,              // dict_size = 2
+                    0x00, 0x05, 0x03,  // offsets: [0, 5, 3] — non-monotonic
+                    'h',  'e',  'l',  'l', 'o', 'a', 'b', 'c'};
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
+// ===========================================================================
+// Primitive value decoding tests
+// ===========================================================================
+
+class VariantPrimitiveTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+  }
+};
+
+TEST_F(VariantPrimitiveTest, DecodeNull) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kNull)};
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events.size(), 1);
+  ASSERT_EQ(visitor.events[0], "Null");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeTrue) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kTrue)};
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events.size(), 1);
+  ASSERT_EQ(visitor.events[0], "Bool(true)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeFalse) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kFalse)};
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events.size(), 1);
+  ASSERT_EQ(visitor.events[0], "Bool(false)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeInt8) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt8), 0x2A};
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int8(42)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeInt8Negative) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt8), 0xD6};
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int8(-42)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeInt16) {
+  // 300 = 0x012C in little-endian: 0x2C, 0x01
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt16), 0x2C, 0x01};
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int16(300)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeInt32) {
+  // 100000 = 0x000186A0 in LE: A0 86 01 00
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt32), 0xA0, 0x86, 0x01, 0x00};
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int32(100000)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeInt32Max) {
+  int32_t val = std::numeric_limits<int32_t>::max();
+  uint8_t data[5];
+  data[0] = PrimitiveHeader(PrimitiveType::kInt32);
+  std::memcpy(data + 1, &val, 4);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int32(" + std::to_string(val) + ")");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeInt64) {
+  int64_t val = 1234567890123LL;
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kInt64);
+  std::memcpy(data + 1, &val, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int64(" + std::to_string(val) + ")");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeFloat) {
+  float val = 3.14f;
+  uint8_t data[5];
+  data[0] = PrimitiveHeader(PrimitiveType::kFloat);
+  std::memcpy(data + 1, &val, 4);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  // Float string representation may vary; just check it starts with Float(
+  ASSERT_TRUE(visitor.events[0].find("Float(") == 0);
+}
+
+TEST_F(VariantPrimitiveTest, DecodeDouble) {
+  double val = 2.718281828459045;
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kDouble);
+  std::memcpy(data + 1, &val, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_TRUE(visitor.events[0].find("Double(") == 0);
+}
+
+TEST_F(VariantPrimitiveTest, DecodeDate) {
+  // Days since epoch: 19000 (approximately 2022-01-01)
+  int32_t days = 19000;
+  uint8_t data[5];
+  data[0] = PrimitiveHeader(PrimitiveType::kDate);
+  std::memcpy(data + 1, &days, 4);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Date(19000)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeTimestampMicros) {
+  int64_t micros = 1654041600000000LL;  // some timestamp
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kTimestampMicros);
+  std::memcpy(data + 1, &micros, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "TimestampMicros(" + std::to_string(micros) + ")");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeTimestampMicrosNTZ) {
+  int64_t micros = 1654041600000000LL;
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kTimestampMicrosNTZ);
+  std::memcpy(data + 1, &micros, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "TimestampMicrosNTZ(" + std::to_string(micros) + ")");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeDecimal4) {
+  // Spec layout: 1 byte scale, then 4 bytes LE unscaled value
+  uint8_t data[6];
+  data[0] = PrimitiveHeader(PrimitiveType::kDecimal4);
+  data[1] = 2;  // scale = 2
+  int32_t val = 12345;
+  std::memcpy(data + 2, &val, 4);  // unscaled value
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Decimal4(scale=2)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeDecimal4MaxScale) {
+  // Scale at maximum per spec: 38
+  uint8_t data[6];
+  data[0] = PrimitiveHeader(PrimitiveType::kDecimal4);
+  data[1] = 38;  // scale = 38 (maximum per spec)
+  int32_t val = 12345;
+  std::memcpy(data + 2, &val, 4);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Decimal4(scale=38)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeDecimal8) {
+  // Spec layout: 1 byte scale, then 8 bytes LE unscaled value
+  uint8_t data[10];
+  data[0] = PrimitiveHeader(PrimitiveType::kDecimal8);
+  data[1] = 5;  // scale = 5
+  int64_t val = 123456789012345LL;
+  std::memcpy(data + 2, &val, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Decimal8(scale=5)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeDecimal16) {
+  // Spec layout: 1 byte scale, then 16 bytes LE unscaled value
+  uint8_t data[18];
+  data[0] = PrimitiveHeader(PrimitiveType::kDecimal16);
+  data[1] = 10;  // scale = 10
+  std::memset(data + 2, 0, 16);
+  data[2] = 0x01;  // low byte = 1
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Decimal16(scale=10)");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeLongString) {
+  // Long string: primitive type kString with 4-byte length prefix
+  std::string test_str = "hello world, this is a long string";
+  auto str_len = static_cast<uint32_t>(test_str.size());
+
+  std::vector<uint8_t> data;
+  data.push_back(PrimitiveHeader(PrimitiveType::kString));
+  // 4-byte little-endian length
+  for (int b = 0; b < 4; ++b) {
+    data.push_back(static_cast<uint8_t>((str_len >> (b * 8)) & 0xFF));
+  }
+  data.insert(data.end(), test_str.begin(), test_str.end());
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "String(\"hello world, this is a long string\")");
+}
+
+TEST_F(VariantPrimitiveTest, DecodeBinary) {
+  std::vector<uint8_t> bin_bytes = {0x00, 0x01, 0x02, 0x03};
+  auto bin_len = static_cast<uint32_t>(bin_bytes.size());
+
+  std::vector<uint8_t> data;
+  data.push_back(PrimitiveHeader(PrimitiveType::kBinary));
+  for (int b = 0; b < 4; ++b) {
+    data.push_back(static_cast<uint8_t>((bin_len >> (b * 8)) & 0xFF));
+  }
+  data.insert(data.end(), bin_bytes.begin(), bin_bytes.end());
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "Binary(len=4)");
+}
+
+// Truncation errors
+
+TEST_F(VariantPrimitiveTest, TruncatedInt32) {
+  // Only 2 bytes after header, but Int32 needs 4
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt32), 0x00, 0x00};
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+}
+
+TEST_F(VariantPrimitiveTest, EmptyValueBuffer) {
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(empty_metadata_, nullptr, 0, &visitor));
+}
+
+// ===========================================================================
+// Short string tests
+// ===========================================================================
+
+class VariantShortStringTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+  }
+};
+
+TEST_F(VariantShortStringTest, EmptyShortString) {
+  auto data = BuildShortString("");
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "String(\"\")");
+}
+
+TEST_F(VariantShortStringTest, SimpleShortString) {
+  auto data = BuildShortString("hi");
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "String(\"hi\")");
+}
+
+TEST_F(VariantShortStringTest, MaxLengthShortString) {
+  // Maximum short string is 63 bytes
+  std::string max_str(63, 'x');
+  auto data = BuildShortString(max_str);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "String(\"" + max_str + "\")");
+}
+
+TEST_F(VariantShortStringTest, TruncatedShortString) {
+  // Header says length=10 but buffer only has 3 bytes total
+  uint8_t data[] = {static_cast<uint8_t>(BasicType::kShortString) | (10 << 2), 'a', 'b'};
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+}
+
+// ===========================================================================
+// Object decoding tests
+// ===========================================================================
+
+class VariantObjectTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = false;
+    metadata_.offset_size = 1;
+    metadata_.strings = {"name", "age", "scores"};
+  }
+};
+
+TEST_F(VariantObjectTest, EmptyObject) {
+  auto data = BuildObject({}, {});
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+  ASSERT_EQ(visitor.events.size(), 2);
+  ASSERT_EQ(visitor.events[0], "StartObject(0)");
+  ASSERT_EQ(visitor.events[1], "EndObject");
+}
+
+TEST_F(VariantObjectTest, SingleField) {
+  // Object with one field: name -> "Alice" (short string)
+  auto value = BuildShortString("Alice");
+  auto data = BuildObject({0}, {value});
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+  ASSERT_EQ(visitor.events.size(), 4);
+  ASSERT_EQ(visitor.events[0], "StartObject(1)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[2], "String(\"Alice\")");
+  ASSERT_EQ(visitor.events[3], "EndObject");
+}
+
+TEST_F(VariantObjectTest, MultipleFields) {
+  // Object: {name: "Bob", age: 30}
+  auto name_val = BuildShortString("Bob");
+  // age: Int32(30)
+  std::vector<uint8_t> age_val = {PrimitiveHeader(PrimitiveType::kInt32), 30, 0, 0, 0};
+
+  auto data = BuildObject({0, 1}, {name_val, age_val});
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+  ASSERT_EQ(visitor.events.size(), 6);
+  ASSERT_EQ(visitor.events[0], "StartObject(2)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[2], "String(\"Bob\")");
+  ASSERT_EQ(visitor.events[3], "FieldName(\"age\")");
+  ASSERT_EQ(visitor.events[4], "Int32(30)");
+  ASSERT_EQ(visitor.events[5], "EndObject");
+}
+
+TEST_F(VariantObjectTest, InvalidFieldId) {
+  // field_id=99 exceeds dictionary size of 3
+  auto value = BuildShortString("oops");
+  auto data = BuildObject({99}, {value});
+
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(metadata_, data.data(),
+                                        static_cast<int64_t>(data.size()), &visitor));
+}
+
+TEST_F(VariantObjectTest, ThreeByteOffsetSize) {
+  // Exercises value decoding with 3-byte field_offset_size and field_id_size.
+  // Object with 2 fields: {name: "test", age: 42}
+  auto name_val = BuildShortString("test");
+  std::vector<uint8_t> age_val = {PrimitiveHeader(PrimitiveType::kInt32), 42, 0, 0, 0};
+  auto data = BuildObject({0, 1}, {name_val, age_val},
+                          /*field_id_size=*/3, /*field_offset_size=*/3);
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+  ASSERT_EQ(visitor.events.size(), 6);
+  ASSERT_EQ(visitor.events[0], "StartObject(2)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[2], "String(\"test\")");
+  ASSERT_EQ(visitor.events[3], "FieldName(\"age\")");
+  ASSERT_EQ(visitor.events[4], "Int32(42)");
+  ASSERT_EQ(visitor.events[5], "EndObject");
+}
+
+// ===========================================================================
+// Array decoding tests
+// ===========================================================================
+
+class VariantArrayTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+  }
+};
+
+TEST_F(VariantArrayTest, EmptyArray) {
+  auto data = BuildArray({});
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events.size(), 2);
+  ASSERT_EQ(visitor.events[0], "StartArray(0)");
+  ASSERT_EQ(visitor.events[1], "EndArray");
+}
+
+TEST_F(VariantArrayTest, SingleElement) {
+  std::vector<uint8_t> elem = {PrimitiveHeader(PrimitiveType::kInt32), 42, 0, 0, 0};
+  auto data = BuildArray({elem});
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events.size(), 3);
+  ASSERT_EQ(visitor.events[0], "StartArray(1)");
+  ASSERT_EQ(visitor.events[1], "Int32(42)");
+  ASSERT_EQ(visitor.events[2], "EndArray");
+}
+
+TEST_F(VariantArrayTest, HeterogeneousElements) {
+  // Array with mixed types: [42, "hello", true]
+  std::vector<uint8_t> int_elem = {PrimitiveHeader(PrimitiveType::kInt32), 42, 0, 0, 0};
+  auto str_elem = BuildShortString("hello");
+  std::vector<uint8_t> bool_elem = {PrimitiveHeader(PrimitiveType::kTrue)};
+
+  auto data = BuildArray({int_elem, str_elem, bool_elem});
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events.size(), 5);
+  ASSERT_EQ(visitor.events[0], "StartArray(3)");
+  ASSERT_EQ(visitor.events[1], "Int32(42)");
+  ASSERT_EQ(visitor.events[2], "String(\"hello\")");
+  ASSERT_EQ(visitor.events[3], "Bool(true)");
+  ASSERT_EQ(visitor.events[4], "EndArray");
+}
+
+TEST_F(VariantArrayTest, LargeArrayIsLargeFlag) {
+  // Build an array with 256 elements to exercise is_large=true (4-byte
+  // num_elements). Each element is a Null primitive (1 byte each).
+  // Use field_offset_size=2 since total data (256 bytes) exceeds 1-byte max.
+  std::vector<std::vector<uint8_t>> elements;
+  elements.reserve(256);
+  for (int i = 0; i < 256; ++i) {
+    elements.push_back({PrimitiveHeader(PrimitiveType::kNull)});
+  }
+  auto data = BuildArray(elements, /*field_offset_size=*/2);
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  // StartArray(256) + 256 Nulls + EndArray = 258 events
+  ASSERT_EQ(visitor.events.size(), 258);
+  ASSERT_EQ(visitor.events[0], "StartArray(256)");
+  ASSERT_EQ(visitor.events[1], "Null");
+  ASSERT_EQ(visitor.events[256], "Null");
+  ASSERT_EQ(visitor.events[257], "EndArray");
+}
+
+// ===========================================================================
+// Nested structure tests
+// ===========================================================================
+
+class VariantNestedTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = false;
+    metadata_.offset_size = 1;
+    metadata_.strings = {"name", "scores", "inner"};
+  }
+};
+
+TEST_F(VariantNestedTest, ObjectWithNestedArray) {
+  // {name: "Alice", scores: [95, 87]}
+  auto name_val = BuildShortString("Alice");
+
+  // scores array: [Int32(95), Int32(87)]
+  std::vector<uint8_t> score1 = {PrimitiveHeader(PrimitiveType::kInt32), 95, 0, 0, 0};
+  std::vector<uint8_t> score2 = {PrimitiveHeader(PrimitiveType::kInt32), 87, 0, 0, 0};
+  auto scores_val = BuildArray({score1, score2});
+
+  auto data = BuildObject({0, 1}, {name_val, scores_val});
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+
+  // Expected events:
+  // StartObject(2), FieldName("name"), String("Alice"),
+  // FieldName("scores"), StartArray(2), Int32(95), Int32(87), EndArray,
+  // EndObject
+  ASSERT_EQ(visitor.events.size(), 9);
+  ASSERT_EQ(visitor.events[0], "StartObject(2)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[2], "String(\"Alice\")");
+  ASSERT_EQ(visitor.events[3], "FieldName(\"scores\")");
+  ASSERT_EQ(visitor.events[4], "StartArray(2)");
+  ASSERT_EQ(visitor.events[5], "Int32(95)");
+  ASSERT_EQ(visitor.events[6], "Int32(87)");
+  ASSERT_EQ(visitor.events[7], "EndArray");
+  ASSERT_EQ(visitor.events[8], "EndObject");
+}
+
+TEST_F(VariantNestedTest, NestedObjects) {
+  // {inner: {name: "deep"}}
+  auto deep_name = BuildShortString("deep");
+  auto inner_obj = BuildObject({0}, {deep_name});
+  auto data = BuildObject({2}, {inner_obj});
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+
+  ASSERT_EQ(visitor.events.size(), 7);
+  ASSERT_EQ(visitor.events[0], "StartObject(1)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"inner\")");
+  ASSERT_EQ(visitor.events[2], "StartObject(1)");
+  ASSERT_EQ(visitor.events[3], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[4], "String(\"deep\")");
+  ASSERT_EQ(visitor.events[5], "EndObject");
+  ASSERT_EQ(visitor.events[6], "EndObject");
+}
+
+TEST_F(VariantNestedTest, ArrayOfObjects) {
+  // [{name: "a"}, {name: "b"}]
+  auto val_a = BuildShortString("a");
+  auto obj_a = BuildObject({0}, {val_a});
+
+  auto val_b = BuildShortString("b");
+  auto obj_b = BuildObject({0}, {val_b});
+
+  auto data = BuildArray({obj_a, obj_b});
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+
+  ASSERT_EQ(visitor.events.size(), 10);
+  ASSERT_EQ(visitor.events[0], "StartArray(2)");
+  ASSERT_EQ(visitor.events[1], "StartObject(1)");
+  ASSERT_EQ(visitor.events[2], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[3], "String(\"a\")");
+  ASSERT_EQ(visitor.events[4], "EndObject");
+  ASSERT_EQ(visitor.events[5], "StartObject(1)");
+  ASSERT_EQ(visitor.events[6], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[7], "String(\"b\")");
+  ASSERT_EQ(visitor.events[8], "EndObject");
+  ASSERT_EQ(visitor.events[9], "EndArray");
+}
+
+// ===========================================================================
+// Recursion depth limit test
+// ===========================================================================
+
+class VariantDepthTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = false;
+    metadata_.offset_size = 1;
+    metadata_.strings = {"x"};
+  }
+};
+
+TEST_F(VariantDepthTest, ExceedsMaxNestingDepth) {
+  // Build a deeply nested array: [[[[...]]]]
+  // Each level wraps the inner in a 1-element array with offset_size=2
+  // to allow buffers larger than 255 bytes.
+  std::vector<uint8_t> inner = {PrimitiveHeader(PrimitiveType::kNull)};
+
+  // Wrap 130 times (exceeds kMaxNestingDepth=128)
+  for (int i = 0; i < 130; ++i) {
+    inner = BuildArray({inner}, /*field_offset_size=*/2);
+  }
+
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(metadata_, inner.data(),
+                                        static_cast<int64_t>(inner.size()), &visitor));
+}
+
+TEST_F(VariantDepthTest, AtMaxNestingDepthSucceeds) {
+  // Build 50 levels of nesting — well within kMaxNestingDepth=128
+  // and within offset_size=1 limits (each level adds ~4 bytes).
+  std::vector<uint8_t> inner = {PrimitiveHeader(PrimitiveType::kNull)};
+
+  for (int i = 0; i < 50; ++i) {
+    inner = BuildArray({inner});
+  }
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, inner.data(), static_cast<int64_t>(inner.size()),
+                           &visitor));
+}
+
+// ===========================================================================
+// Utility function tests
+// ===========================================================================
+
+class VariantUtilTest : public ::testing::Test {};
+
+TEST_F(VariantUtilTest, GetValueBasicTypePrimitive) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt32), 0, 0, 0, 0};
+  ASSERT_OK_AND_ASSIGN(auto bt, GetValueBasicType(data, sizeof(data)));
+  ASSERT_EQ(bt, BasicType::kPrimitive);
+}
+
+TEST_F(VariantUtilTest, GetValueBasicTypeShortString) {
+  auto data = BuildShortString("test");
+  ASSERT_OK_AND_ASSIGN(auto bt,
+                       GetValueBasicType(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(bt, BasicType::kShortString);
+}
+
+TEST_F(VariantUtilTest, GetValueBasicTypeObject) {
+  VariantMetadata meta;
+  meta.version = 1;
+  meta.strings = {"key"};
+  auto val = BuildShortString("val");
+  auto data = BuildObject({0}, {val});
+  ASSERT_OK_AND_ASSIGN(auto bt,
+                       GetValueBasicType(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(bt, BasicType::kObject);
+}
+
+TEST_F(VariantUtilTest, GetValueBasicTypeArray) {
+  auto data = BuildArray({});
+  ASSERT_OK_AND_ASSIGN(auto bt,
+                       GetValueBasicType(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(bt, BasicType::kArray);
+}
+
+TEST_F(VariantUtilTest, GetValueBasicTypeEmptyBuffer) {
+  ASSERT_RAISES(Invalid, GetValueBasicType(nullptr, 0));
+}
+
+TEST_F(VariantUtilTest, GetObjectFieldCount) {
+  VariantMetadata meta;
+  meta.version = 1;
+  meta.strings = {"a", "b", "c"};
+  auto v1 = BuildShortString("x");
+  auto v2 = BuildShortString("y");
+  auto data = BuildObject({0, 1}, {v1, v2});
+  ASSERT_OK_AND_ASSIGN(
+      auto count, GetObjectFieldCount(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(count, 2);
+}
+
+TEST_F(VariantUtilTest, GetArrayElementCount) {
+  std::vector<uint8_t> e1 = {PrimitiveHeader(PrimitiveType::kNull)};
+  std::vector<uint8_t> e2 = {PrimitiveHeader(PrimitiveType::kTrue)};
+  std::vector<uint8_t> e3 = {PrimitiveHeader(PrimitiveType::kFalse)};
+  auto data = BuildArray({e1, e2, e3});
+  ASSERT_OK_AND_ASSIGN(
+      auto count, GetArrayElementCount(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(count, 3);
+}
+
+TEST_F(VariantUtilTest, PrimitiveValueSizes) {
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kNull), 0);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kTrue), 0);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kFalse), 0);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kInt8), 1);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kInt16), 2);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kInt32), 4);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kInt64), 8);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kFloat), 4);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kDouble), 8);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kDate), 4);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kTimestampMicros), 8);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kTimestampMicrosNTZ), 8);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kTimeNTZ), 8);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kTimestampNanos), 8);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kTimestampNanosNTZ), 8);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kUUID), 16);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kDecimal4), 5);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kDecimal8), 9);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kDecimal16), 17);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kBinary), -1);
+  ASSERT_EQ(PrimitiveValueSize(PrimitiveType::kString), -1);
+}
+
+// ===========================================================================
+// Integration: Metadata + Value decoding together
+// ===========================================================================
+
+class VariantIntegrationTest : public ::testing::Test {};
+
+TEST_F(VariantIntegrationTest, FullRoundTrip) {
+  // Build a complete variant: {name: "Alice", age: 30, scores: [95, 87]}
+  auto meta_buf = BuildMetadataBuffer({"name", "age", "scores"});
+
+  auto name_val = BuildShortString("Alice");
+  std::vector<uint8_t> age_val = {PrimitiveHeader(PrimitiveType::kInt32), 30, 0, 0, 0};
+  std::vector<uint8_t> s1 = {PrimitiveHeader(PrimitiveType::kInt32), 95, 0, 0, 0};
+  std::vector<uint8_t> s2 = {PrimitiveHeader(PrimitiveType::kInt32), 87, 0, 0, 0};
+  auto scores_val = BuildArray({s1, s2});
+
+  auto value_buf = BuildObject({0, 1, 2}, {name_val, age_val, scores_val});
+
+  // Decode metadata
+  ASSERT_OK_AND_ASSIGN(
+      auto metadata,
+      DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+  ASSERT_EQ(metadata.strings.size(), 3);
+
+  // Decode value
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata, value_buf.data(),
+                           static_cast<int64_t>(value_buf.size()), &visitor));
+
+  // Verify full event sequence
+  ASSERT_EQ(visitor.events.size(), 11);
+  ASSERT_EQ(visitor.events[0], "StartObject(3)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"name\")");
+  ASSERT_EQ(visitor.events[2], "String(\"Alice\")");
+  ASSERT_EQ(visitor.events[3], "FieldName(\"age\")");
+  ASSERT_EQ(visitor.events[4], "Int32(30)");
+  ASSERT_EQ(visitor.events[5], "FieldName(\"scores\")");
+  ASSERT_EQ(visitor.events[6], "StartArray(2)");
+  ASSERT_EQ(visitor.events[7], "Int32(95)");
+  ASSERT_EQ(visitor.events[8], "Int32(87)");
+  ASSERT_EQ(visitor.events[9], "EndArray");
+  ASSERT_EQ(visitor.events[10], "EndObject");
+}
+
+// ===========================================================================
+// Visitor early abort test
+// ===========================================================================
+
+/// \brief A visitor that aborts after receiving a specific number of events.
+class AbortingVisitor : public VariantVisitor {
+ public:
+  int32_t abort_after;
+  int32_t count = 0;
+
+  explicit AbortingVisitor(int32_t abort_after) : abort_after(abort_after) {}
+
+  Status MaybeAbort() {
+    ++count;
+    if (count >= abort_after) {
+      return Status::Cancelled("Visitor aborted after ", count, " events");
+    }
+    return Status::OK();
+  }
+
+  Status Null() override { return MaybeAbort(); }
+  Status Bool(bool /*value*/) override { return MaybeAbort(); }
+  Status Int8(int8_t /*value*/) override { return MaybeAbort(); }
+  Status Int16(int16_t /*value*/) override { return MaybeAbort(); }
+  Status Int32(int32_t /*value*/) override { return MaybeAbort(); }
+  Status Int64(int64_t /*value*/) override { return MaybeAbort(); }
+  Status Float(float /*value*/) override { return MaybeAbort(); }
+  Status Double(double /*value*/) override { return MaybeAbort(); }
+  Status Decimal4(const uint8_t* /*bytes*/, int32_t /*s*/) override {
+    return MaybeAbort();
+  }
+  Status Decimal8(const uint8_t* /*bytes*/, int32_t /*s*/) override {
+    return MaybeAbort();
+  }
+  Status Decimal16(const uint8_t* /*bytes*/, int32_t /*s*/) override {
+    return MaybeAbort();
+  }
+  Status Date(int32_t /*days*/) override { return MaybeAbort(); }
+  Status TimestampMicros(int64_t /*micros*/) override { return MaybeAbort(); }
+  Status TimestampMicrosNTZ(int64_t /*micros*/) override { return MaybeAbort(); }
+  Status String(std::string_view /*value*/) override { return MaybeAbort(); }
+  Status Binary(std::string_view /*value*/) override { return MaybeAbort(); }
+  Status TimeNTZ(int64_t /*micros*/) override { return MaybeAbort(); }
+  Status TimestampNanos(int64_t /*nanos*/) override { return MaybeAbort(); }
+  Status TimestampNanosNTZ(int64_t /*nanos*/) override { return MaybeAbort(); }
+  Status UUID(const uint8_t* /*bytes*/) override { return MaybeAbort(); }
+  Status StartObject(int32_t /*num_fields*/) override { return MaybeAbort(); }
+  Status FieldName(std::string_view /*name*/) override { return MaybeAbort(); }
+  Status EndObject() override { return MaybeAbort(); }
+  Status StartArray(int32_t /*num_elements*/) override { return MaybeAbort(); }
+  Status EndArray() override { return MaybeAbort(); }
+};
+
+class VariantAbortTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = false;
+    metadata_.offset_size = 1;
+    metadata_.strings = {"name", "age"};
+  }
+};
+
+TEST_F(VariantAbortTest, VisitorAbortsEarly) {
+  // Object: {name: "Alice", age: 30}
+  auto name_val = BuildShortString("Alice");
+  std::vector<uint8_t> age_val = {PrimitiveHeader(PrimitiveType::kInt32), 30, 0, 0, 0};
+  auto data = BuildObject({0, 1}, {name_val, age_val});
+
+  // Abort after 3 events (StartObject, FieldName, String)
+  // Should NOT reach the second field
+  AbortingVisitor visitor(3);
+  auto status =
+      DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()), &visitor);
+  ASSERT_TRUE(status.IsCancelled());
+  ASSERT_EQ(visitor.count, 3);
+}
+
+TEST_F(VariantAbortTest, VisitorAbortsOnFirstEvent) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kNull)};
+  AbortingVisitor visitor(1);
+  auto status = DecodeAndVisit(metadata_, data, sizeof(data), &visitor);
+  ASSERT_TRUE(status.IsCancelled());
+}
+
+// ===========================================================================
+// Spec-conformance test with hardcoded byte sequences
+// ===========================================================================
+
+class VariantSpecTest : public ::testing::Test {};
+
+TEST_F(VariantSpecTest, HandcraftedNullValue) {
+  // Variant Encoding Spec: Null is basic_type=0, primitive_type=0
+  // Header byte: 0x00 (bits 0-1=00 for primitive, bits 2-7=000000 for null)
+  uint8_t metadata_bytes[] = {0x01, 0x00, 0x00};  // v1, 0 strings, offset[0]=0
+  uint8_t value_bytes[] = {0x00};                 // null
+
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(metadata_bytes, sizeof(metadata_bytes)));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata, value_bytes, sizeof(value_bytes), &visitor));
+  ASSERT_EQ(visitor.events.size(), 1);
+  ASSERT_EQ(visitor.events[0], "Null");
+}
+
+TEST_F(VariantSpecTest, HandcraftedInt32Value) {
+  // Int32(42): basic_type=0, primitive_type=5
+  // Header: (5 << 2) | 0 = 0x14
+  // Value: 42 as LE int32 = 2A 00 00 00
+  uint8_t metadata_bytes[] = {0x01, 0x00, 0x00};
+  uint8_t value_bytes[] = {0x14, 0x2A, 0x00, 0x00, 0x00};
+
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(metadata_bytes, sizeof(metadata_bytes)));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata, value_bytes, sizeof(value_bytes), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int32(42)");
+}
+
+TEST_F(VariantSpecTest, HandcraftedShortString) {
+  // Short string "hello": basic_type=1, length=5
+  // Header: (5 << 2) | 1 = 0x15
+  // Followed by 5 bytes of UTF-8 "hello"
+  uint8_t metadata_bytes[] = {0x01, 0x00, 0x00};
+  uint8_t value_bytes[] = {0x15, 'h', 'e', 'l', 'l', 'o'};
+
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(metadata_bytes, sizeof(metadata_bytes)));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata, value_bytes, sizeof(value_bytes), &visitor));
+  ASSERT_EQ(visitor.events[0], "String(\"hello\")");
+}
+
+TEST_F(VariantSpecTest, HandcraftedSimpleObject) {
+  // Object {"a": 1} with metadata dictionary ["a"]
+  //
+  // Metadata: version=1, sorted=false, offset_size=1
+  //   header=0x01, dict_size=0x01, offsets=[0x00, 0x01], data="a"
+  uint8_t metadata_bytes[] = {0x01, 0x01, 0x00, 0x01, 'a'};
+  //
+  // Value: object with 1 field
+  //   header: basic_type=2, field_id_size=1(bits2-3=00),
+  //           offset_size=1(bits4-5=00), num_fields_size=1(bits6-7=00)
+  //           = 0x02
+  //   num_fields: 0x01
+  //   field_ids: [0x00] (index into metadata for "a")
+  //   offsets: [0x00, 0x05] (field 0 at offset 0, total size 5)
+  //   field value: Int32(1) = header 0x14 + LE bytes 01 00 00 00
+  uint8_t value_bytes[] = {
+      0x02,                         // object header
+      0x01,                         // num_fields = 1
+      0x00,                         // field_id[0] = 0
+      0x00, 0x05,                   // offsets: [0, 5]
+      0x14, 0x01, 0x00, 0x00, 0x00  // Int32(1)
+  };
+
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(metadata_bytes, sizeof(metadata_bytes)));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata, value_bytes, sizeof(value_bytes), &visitor));
+  ASSERT_EQ(visitor.events.size(), 4);
+  ASSERT_EQ(visitor.events[0], "StartObject(1)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"a\")");
+  ASSERT_EQ(visitor.events[2], "Int32(1)");
+  ASSERT_EQ(visitor.events[3], "EndObject");
+}
+
+TEST_F(VariantSpecTest, HandcraftedTrueAndFalse) {
+  // True: basic_type=0, primitive_type=1 → header = (1<<2)|0 = 0x04
+  // False: basic_type=0, primitive_type=2 → header = (2<<2)|0 = 0x08
+  uint8_t metadata_bytes[] = {0x01, 0x00, 0x00};
+
+  uint8_t true_bytes[] = {0x04};
+  uint8_t false_bytes[] = {0x08};
+
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(metadata_bytes, sizeof(metadata_bytes)));
+
+  RecordingVisitor v1;
+  ASSERT_OK(DecodeAndVisit(metadata, true_bytes, sizeof(true_bytes), &v1));
+  ASSERT_EQ(v1.events[0], "Bool(true)");
+
+  RecordingVisitor v2;
+  ASSERT_OK(DecodeAndVisit(metadata, false_bytes, sizeof(false_bytes), &v2));
+  ASSERT_EQ(v2.events[0], "Bool(false)");
+}
+
+TEST_F(VariantSpecTest, HandcraftedDouble) {
+  // Double: basic_type=0, primitive_type=7 → header = (7<<2)|0 = 0x1C
+  // Value: 3.14 as IEEE 754 double LE
+  uint8_t metadata_bytes[] = {0x01, 0x00, 0x00};
+  uint8_t value_bytes[9];
+  value_bytes[0] = 0x1C;
+  double val = 3.14;
+  std::memcpy(value_bytes + 1, &val, 8);
+
+  ASSERT_OK_AND_ASSIGN(auto metadata,
+                       DecodeMetadata(metadata_bytes, sizeof(metadata_bytes)));
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata, value_bytes, sizeof(value_bytes), &visitor));
+  ASSERT_TRUE(visitor.events[0].find("Double(") == 0);
+}
+
+// ===========================================================================
+// ValueSize tests
+// ===========================================================================
+
+class VariantValueSizeTest : public ::testing::Test {};
+
+TEST_F(VariantValueSizeTest, NullSize) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kNull)};
+  ASSERT_OK_AND_ASSIGN(auto size, ValueSize(data, sizeof(data)));
+  ASSERT_EQ(size, 1);
+}
+
+TEST_F(VariantValueSizeTest, Int32Size) {
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt32), 0, 0, 0, 0};
+  ASSERT_OK_AND_ASSIGN(auto size, ValueSize(data, sizeof(data)));
+  ASSERT_EQ(size, 5);
+}
+
+TEST_F(VariantValueSizeTest, ShortStringSize) {
+  auto data = BuildShortString("hello");
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, 6);  // 1 header + 5 chars
+}
+
+TEST_F(VariantValueSizeTest, ObjectSize) {
+  VariantMetadata meta;
+  meta.version = 1;
+  meta.strings = {"key"};
+  auto val = BuildShortString("val");
+  auto data = BuildObject({0}, {val});
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(data.size()));
+}
+
+TEST_F(VariantValueSizeTest, ArraySize) {
+  std::vector<uint8_t> e1 = {PrimitiveHeader(PrimitiveType::kNull)};
+  std::vector<uint8_t> e2 = {PrimitiveHeader(PrimitiveType::kTrue)};
+  auto data = BuildArray({e1, e2});
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(data.size()));
+}
+
+TEST_F(VariantValueSizeTest, UUIDSize) {
+  uint8_t data[17];
+  data[0] = PrimitiveHeader(PrimitiveType::kUUID);
+  std::memset(data + 1, 0, 16);
+  ASSERT_OK_AND_ASSIGN(auto size, ValueSize(data, sizeof(data)));
+  ASSERT_EQ(size, 17);
+}
+
+// ===========================================================================
+// Random access tests
+// ===========================================================================
+
+class VariantRandomAccessTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = true;
+    metadata_.offset_size = 1;
+    // Sorted lexicographically for binary search
+    metadata_.strings = {"age", "name", "score"};
+  }
+};
+
+TEST_F(VariantRandomAccessTest, FindObjectFieldExists) {
+  // Object: {age: 30, name: "Alice", score: 95}
+  // field_ids must be in lex order of keys: age=0, name=1, score=2
+  std::vector<uint8_t> age_val = {PrimitiveHeader(PrimitiveType::kInt32), 30, 0, 0, 0};
+  auto name_val = BuildShortString("Alice");
+  std::vector<uint8_t> score_val = {PrimitiveHeader(PrimitiveType::kInt32), 95, 0, 0, 0};
+  auto data = BuildObject({0, 1, 2}, {age_val, name_val, score_val});
+
+  int64_t offset = -1, size = 0;
+  ASSERT_OK(FindObjectField(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                            "name", &offset, &size));
+  ASSERT_GT(offset, 0);
+  ASSERT_EQ(size, 6);  // short string "Alice" = 1 + 5
+
+  // Verify we can decode just that field
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data() + offset, size, &visitor));
+  ASSERT_EQ(visitor.events[0], "String(\"Alice\")");
+}
+
+TEST_F(VariantRandomAccessTest, FindObjectFieldNotFound) {
+  auto val = BuildShortString("x");
+  auto data = BuildObject({0}, {val});
+
+  int64_t offset = -1, size = 0;
+  ASSERT_OK(FindObjectField(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                            "nonexistent", &offset, &size));
+  ASSERT_EQ(offset, -1);
+  ASSERT_EQ(size, 0);
+}
+
+TEST_F(VariantRandomAccessTest, GetArrayElementFirst) {
+  std::vector<uint8_t> e0 = {PrimitiveHeader(PrimitiveType::kInt32), 42, 0, 0, 0};
+  std::vector<uint8_t> e1 = {PrimitiveHeader(PrimitiveType::kNull)};
+  auto data = BuildArray({e0, e1});
+
+  int64_t offset = 0, size = 0;
+  ASSERT_OK(
+      GetArrayElement(data.data(), static_cast<int64_t>(data.size()), 0, &offset, &size));
+  ASSERT_EQ(size, 5);  // Int32 = 5 bytes
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data() + offset, size, &visitor));
+  ASSERT_EQ(visitor.events[0], "Int32(42)");
+}
+
+TEST_F(VariantRandomAccessTest, GetArrayElementLast) {
+  std::vector<uint8_t> e0 = {PrimitiveHeader(PrimitiveType::kInt32), 42, 0, 0, 0};
+  std::vector<uint8_t> e1 = {PrimitiveHeader(PrimitiveType::kNull)};
+  auto data = BuildArray({e0, e1});
+
+  int64_t offset = 0, size = 0;
+  ASSERT_OK(
+      GetArrayElement(data.data(), static_cast<int64_t>(data.size()), 1, &offset, &size));
+  ASSERT_EQ(size, 1);  // Null = 1 byte
+}
+
+TEST_F(VariantRandomAccessTest, GetArrayElementOutOfRange) {
+  std::vector<uint8_t> e0 = {PrimitiveHeader(PrimitiveType::kNull)};
+  auto data = BuildArray({e0});
+
+  int64_t offset = 0, size = 0;
+  ASSERT_RAISES(Invalid, GetArrayElement(data.data(), static_cast<int64_t>(data.size()),
+                                         5, &offset, &size));
+}
+
+TEST_F(VariantRandomAccessTest, GetObjectFieldAtByIndex) {
+  std::vector<uint8_t> age_val = {PrimitiveHeader(PrimitiveType::kInt32), 30, 0, 0, 0};
+  auto name_val = BuildShortString("Bob");
+  auto data = BuildObject({0, 1}, {age_val, name_val});
+
+  std::string_view name;
+  int64_t offset = 0, size = 0;
+  ASSERT_OK(GetObjectFieldAt(metadata_, data.data(), static_cast<int64_t>(data.size()), 1,
+                             &name, &offset, &size));
+  ASSERT_EQ(name, "name");
+  ASSERT_EQ(size, 4);  // short string "Bob" = 1 + 3
+}
+
+TEST_F(VariantRandomAccessTest, GetObjectFieldAtOutOfRange) {
+  auto val = BuildShortString("x");
+  auto data = BuildObject({0}, {val});
+
+  std::string_view name;
+  int64_t offset = 0, size = 0;
+  ASSERT_RAISES(
+      Invalid, GetObjectFieldAt(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                                99, &name, &offset, &size));
+}
+
+// ===========================================================================
+// FindMetadataKey tests
+// ===========================================================================
+
+class VariantFindMetadataKeyTest : public ::testing::Test {};
+
+TEST_F(VariantFindMetadataKeyTest, SortedFound) {
+  VariantMetadata meta;
+  meta.is_sorted = true;
+  meta.strings = {"age", "name", "score"};
+  ASSERT_EQ(FindMetadataKey(meta, "name"), 1);
+  ASSERT_EQ(FindMetadataKey(meta, "age"), 0);
+  ASSERT_EQ(FindMetadataKey(meta, "score"), 2);
+}
+
+TEST_F(VariantFindMetadataKeyTest, SortedNotFound) {
+  VariantMetadata meta;
+  meta.is_sorted = true;
+  meta.strings = {"age", "name", "score"};
+  ASSERT_EQ(FindMetadataKey(meta, "missing"), -1);
+}
+
+TEST_F(VariantFindMetadataKeyTest, UnsortedFound) {
+  VariantMetadata meta;
+  meta.is_sorted = false;
+  meta.strings = {"name", "age", "score"};
+  ASSERT_EQ(FindMetadataKey(meta, "age"), 1);
+}
+
+TEST_F(VariantFindMetadataKeyTest, UnsortedNotFound) {
+  VariantMetadata meta;
+  meta.is_sorted = false;
+  meta.strings = {"name", "age"};
+  ASSERT_EQ(FindMetadataKey(meta, "missing"), -1);
+}
+
+// ===========================================================================
+// ValueSize regression tests (Go bug: array is_large bit position)
+// ===========================================================================
+
+class VariantValueSizeRegressionTest : public ::testing::Test {};
+
+TEST_F(VariantValueSizeRegressionTest, LargeArrayIsLargeBit) {
+  // Build a large array with 300 elements (>255) to trigger is_large=true.
+  // This verifies the is_large bit is read at bit 2 of type_info (bit 4 of
+  // full byte), NOT bit 4 of type_info (bit 6 of full byte) which was the
+  // Go bug (apache/arrow-go#839).
+  std::vector<std::vector<uint8_t>> elements;
+  elements.reserve(300);
+  for (int i = 0; i < 300; ++i) {
+    elements.push_back({PrimitiveHeader(PrimitiveType::kNull)});
+  }
+  auto data = BuildArray(elements, /*field_offset_size=*/2);
+
+  // Verify the header byte is correctly structured
+  uint8_t header = data[0];
+  ASSERT_EQ(GetBasicType(header), BasicType::kArray);
+  // is_large should be set at bit 4 of the full header byte
+  ASSERT_TRUE(((header >> 4) & 0x01) != 0);
+
+  // ValueSize must return the total size of the buffer
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(data.size()));
+}
+
+TEST_F(VariantValueSizeRegressionTest, SmallArrayIsLargeFalse) {
+  // Array with 3 elements — is_large=false
+  std::vector<uint8_t> e1 = {PrimitiveHeader(PrimitiveType::kNull)};
+  std::vector<uint8_t> e2 = {PrimitiveHeader(PrimitiveType::kTrue)};
+  std::vector<uint8_t> e3 = {PrimitiveHeader(PrimitiveType::kFalse)};
+  auto data = BuildArray({e1, e2, e3});
+
+  // Verify is_large is NOT set
+  uint8_t header = data[0];
+  ASSERT_FALSE(((header >> 4) & 0x01) != 0);
+
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(data.size()));
+}
+
+TEST_F(VariantValueSizeRegressionTest, LargeObjectIsLargeBit) {
+  // Object with 300 fields to trigger is_large=true (bit 6 of full byte)
+  std::vector<uint32_t> field_ids;
+  std::vector<std::vector<uint8_t>> values;
+  for (int i = 0; i < 300; ++i) {
+    field_ids.push_back(static_cast<uint32_t>(i));
+    values.push_back({PrimitiveHeader(PrimitiveType::kNull)});
+  }
+  auto data =
+      BuildObject(field_ids, values, /*field_id_size=*/2, /*field_offset_size=*/2);
+
+  // Verify is_large is set at bit 6 of the full header byte
+  uint8_t header = data[0];
+  ASSERT_EQ(GetBasicType(header), BasicType::kObject);
+  ASSERT_TRUE(((header >> 6) & 0x01) != 0);
+
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, static_cast<int64_t>(data.size()));
+}
+
+// ===========================================================================
+// Additional primitive decoding tests
+// ===========================================================================
+
+class VariantPrimitiveExtraTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+  }
+};
+
+TEST_F(VariantPrimitiveExtraTest, DecodeTimeNTZ) {
+  int64_t micros = 43200000000LL;  // 12:00:00 in microseconds
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kTimeNTZ);
+  std::memcpy(data + 1, &micros, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "TimeNTZ(" + std::to_string(micros) + ")");
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeTimestampNanos) {
+  int64_t nanos = 1654041600000000000LL;
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kTimestampNanos);
+  std::memcpy(data + 1, &nanos, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "TimestampNanos(" + std::to_string(nanos) + ")");
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeTimestampNanosNTZ) {
+  int64_t nanos = 1654041600000000000LL;
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kTimestampNanosNTZ);
+  std::memcpy(data + 1, &nanos, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "TimestampNanosNTZ(" + std::to_string(nanos) + ")");
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeUUID) {
+  uint8_t data[17];
+  data[0] = PrimitiveHeader(PrimitiveType::kUUID);
+  // Fill UUID with recognizable pattern (big-endian per spec)
+  for (int i = 0; i < 16; ++i) {
+    data[1 + i] = static_cast<uint8_t>(i + 1);
+  }
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "UUID");
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeInt8Boundaries) {
+  // INT8_MIN = -128
+  {
+    uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt8), 0x80};
+    RecordingVisitor visitor;
+    ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+    ASSERT_EQ(visitor.events[0], "Int8(-128)");
+  }
+  // INT8_MAX = 127
+  {
+    uint8_t data[] = {PrimitiveHeader(PrimitiveType::kInt8), 0x7F};
+    RecordingVisitor visitor;
+    ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+    ASSERT_EQ(visitor.events[0], "Int8(127)");
+  }
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeInt16Boundaries) {
+  // INT16_MIN = -32768
+  {
+    int16_t val = std::numeric_limits<int16_t>::min();
+    uint8_t data[3];
+    data[0] = PrimitiveHeader(PrimitiveType::kInt16);
+    std::memcpy(data + 1, &val, 2);
+    RecordingVisitor visitor;
+    ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+    ASSERT_EQ(visitor.events[0], "Int16(-32768)");
+  }
+  // INT16_MAX = 32767
+  {
+    int16_t val = std::numeric_limits<int16_t>::max();
+    uint8_t data[3];
+    data[0] = PrimitiveHeader(PrimitiveType::kInt16);
+    std::memcpy(data + 1, &val, 2);
+    RecordingVisitor visitor;
+    ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+    ASSERT_EQ(visitor.events[0], "Int16(32767)");
+  }
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeInt64Min) {
+  int64_t val = std::numeric_limits<int64_t>::min();
+  uint8_t data[9];
+  data[0] = PrimitiveHeader(PrimitiveType::kInt64);
+  std::memcpy(data + 1, &val, 8);
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+  ASSERT_EQ(visitor.events[0], "Int64(" + std::to_string(val) + ")");
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeEmptyBinary) {
+  // Binary with zero length
+  std::vector<uint8_t> data;
+  data.push_back(PrimitiveHeader(PrimitiveType::kBinary));
+  uint32_t len = 0;
+  for (int b = 0; b < 4; ++b) {
+    data.push_back(static_cast<uint8_t>((len >> (b * 8)) & 0xFF));
+  }
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "Binary(len=0)");
+}
+
+TEST_F(VariantPrimitiveExtraTest, DecodeEmptyLongString) {
+  // Long string with zero length
+  std::vector<uint8_t> data;
+  data.push_back(PrimitiveHeader(PrimitiveType::kString));
+  uint32_t len = 0;
+  for (int b = 0; b < 4; ++b) {
+    data.push_back(static_cast<uint8_t>((len >> (b * 8)) & 0xFF));
+  }
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(empty_metadata_, data.data(),
+                           static_cast<int64_t>(data.size()), &visitor));
+  ASSERT_EQ(visitor.events[0], "String(\"\")");
+}
+
+// ===========================================================================
+// Object with non-monotonic offsets (spec-compliant)
+// ===========================================================================
+
+class VariantObjectNonMonotonicTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = true;
+    metadata_.offset_size = 1;
+    // Sorted lexicographically
+    metadata_.strings = {"a", "b", "c"};
+  }
+};
+
+TEST_F(VariantObjectNonMonotonicTest, NonMonotonicObjectOffsets) {
+  // Per spec: "field IDs and offsets must be listed in the order of the
+  // corresponding field names, sorted lexicographically" but "the actual
+  // value entries do not need to be in any particular order" and "the
+  // field_offset values may not be monotonically increasing."
+  //
+  // Construct: {a: 1, b: 2, c: 3} where values are stored as [3, 1, 2]
+  // in the data area but offsets point to them in key-sorted order.
+  std::vector<uint8_t> val_a = {PrimitiveHeader(PrimitiveType::kInt8), 1};
+  std::vector<uint8_t> val_b = {PrimitiveHeader(PrimitiveType::kInt8), 2};
+  std::vector<uint8_t> val_c = {PrimitiveHeader(PrimitiveType::kInt8), 3};
+
+  // Data area stores: val_c (2 bytes) | val_a (2 bytes) | val_b (2 bytes)
+  // Offsets: a->2, b->4, c->0, end->6
+  uint8_t header = static_cast<uint8_t>(BasicType::kObject);  // offset_size=1, id_size=1
+  std::vector<uint8_t> data;
+  data.push_back(header);
+  data.push_back(3);  // num_fields = 3
+  data.push_back(0);  // field_id[0] = 0 ("a")
+  data.push_back(1);  // field_id[1] = 1 ("b")
+  data.push_back(2);  // field_id[2] = 2 ("c")
+  data.push_back(2);  // offset[0] = 2 (val_a starts at byte 2)
+  data.push_back(4);  // offset[1] = 4 (val_b starts at byte 4)
+  data.push_back(0);  // offset[2] = 0 (val_c starts at byte 0)
+  data.push_back(6);  // offset[3] = 6 (total data size)
+  // Data area: val_c, val_a, val_b
+  data.insert(data.end(), val_c.begin(), val_c.end());
+  data.insert(data.end(), val_a.begin(), val_a.end());
+  data.insert(data.end(), val_b.begin(), val_b.end());
+
+  RecordingVisitor visitor;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                           &visitor));
+  // Field iteration order follows field_ids (sorted by key): a, b, c
+  ASSERT_EQ(visitor.events.size(), 8);
+  ASSERT_EQ(visitor.events[0], "StartObject(3)");
+  ASSERT_EQ(visitor.events[1], "FieldName(\"a\")");
+  ASSERT_EQ(visitor.events[2], "Int8(1)");
+  ASSERT_EQ(visitor.events[3], "FieldName(\"b\")");
+  ASSERT_EQ(visitor.events[4], "Int8(2)");
+  ASSERT_EQ(visitor.events[5], "FieldName(\"c\")");
+  ASSERT_EQ(visitor.events[6], "Int8(3)");
+  ASSERT_EQ(visitor.events[7], "EndObject");
+}
+
+TEST_F(VariantObjectNonMonotonicTest, FindFieldWithNonMonotonicOffsets) {
+  // Same layout as above: values stored out-of-order
+  uint8_t header = static_cast<uint8_t>(BasicType::kObject);
+  std::vector<uint8_t> data;
+  data.push_back(header);
+  data.push_back(3);
+  data.push_back(0);
+  data.push_back(1);
+  data.push_back(2);
+  data.push_back(2);  // a -> offset 2
+  data.push_back(4);  // b -> offset 4
+  data.push_back(0);  // c -> offset 0
+  data.push_back(6);  // end = 6
+  // Data: [Int8(3), Int8(1), Int8(2)]
+  data.push_back(PrimitiveHeader(PrimitiveType::kInt8));
+  data.push_back(3);
+  data.push_back(PrimitiveHeader(PrimitiveType::kInt8));
+  data.push_back(1);
+  data.push_back(PrimitiveHeader(PrimitiveType::kInt8));
+  data.push_back(2);
+
+  // FindObjectField should find "c" at offset 0 of data area
+  int64_t field_offset = -1, field_size = 0;
+  ASSERT_OK(FindObjectField(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                            "c", &field_offset, &field_size));
+  ASSERT_GT(field_offset, 0);
+  ASSERT_EQ(field_size, 2);  // Int8 = 2 bytes
+
+  // Decode the value at that offset and verify it's 3 (val_c)
+  RecordingVisitor v;
+  ASSERT_OK(DecodeAndVisit(metadata_, data.data() + field_offset, field_size, &v));
+  ASSERT_EQ(v.events[0], "Int8(3)");
+}
+
+// ===========================================================================
+// ValueSize for variable-length primitives
+// ===========================================================================
+
+class VariantValueSizeVarLenTest : public ::testing::Test {};
+
+TEST_F(VariantValueSizeVarLenTest, LongStringSize) {
+  // Long string "hello" (5 chars): header(1) + length(4) + data(5) = 10
+  std::string s = "hello";
+  std::vector<uint8_t> data;
+  data.push_back(PrimitiveHeader(PrimitiveType::kString));
+  auto len = static_cast<uint32_t>(s.size());
+  for (int b = 0; b < 4; ++b) {
+    data.push_back(static_cast<uint8_t>((len >> (b * 8)) & 0xFF));
+  }
+  data.insert(data.end(), s.begin(), s.end());
+
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, 10);
+}
+
+TEST_F(VariantValueSizeVarLenTest, BinarySize) {
+  // Binary with 4 bytes: header(1) + length(4) + data(4) = 9
+  std::vector<uint8_t> data;
+  data.push_back(PrimitiveHeader(PrimitiveType::kBinary));
+  uint32_t len = 4;
+  for (int b = 0; b < 4; ++b) {
+    data.push_back(static_cast<uint8_t>((len >> (b * 8)) & 0xFF));
+  }
+  data.push_back(0x00);
+  data.push_back(0x01);
+  data.push_back(0x02);
+  data.push_back(0x03);
+
+  ASSERT_OK_AND_ASSIGN(auto size,
+                       ValueSize(data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(size, 9);
+}
+
+TEST_F(VariantValueSizeVarLenTest, TruncatedLongString) {
+  // Only header byte, no length field
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kString)};
+  ASSERT_RAISES(Invalid, ValueSize(data, sizeof(data)));
+}
+
+// ===========================================================================
+// Unknown/invalid type tests
+// ===========================================================================
+
+class VariantUnknownTypeTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+  }
+};
+
+TEST_F(VariantUnknownTypeTest, UnknownPrimitiveType) {
+  // Primitive type ID 25 (beyond kUUID=20) should produce an error.
+  // Header: (25 << 2) | 0 = 0x64
+  uint8_t data[] = {0x64};
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+}
+
+TEST_F(VariantUnknownTypeTest, UnknownPrimitiveTypeValueSize) {
+  // ValueSize on an unknown primitive type should still return a value
+  // (PrimitiveValueSize returns -1, triggering variable-length path).
+  // With only 1 byte, variable-length path requires 5 bytes → truncated.
+  uint8_t data[] = {0x64};
+  ASSERT_RAISES(Invalid, ValueSize(data, sizeof(data)));
+}
+
+// ===========================================================================
+// Array non-monotonic offset rejection test
+// ===========================================================================
+
+class VariantArrayNonMonotonicTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+  }
+};
+
+TEST_F(VariantArrayNonMonotonicTest, RejectsNonMonotonicOffsets) {
+  // Manually craft an array with 2 elements where offsets go [0, 3, 1]
+  // (non-monotonic: 1 < 3). This should be rejected.
+  // header: basic_type=3, offset_size=1, is_large=false → 0x03
+  // num_elements: 2
+  // offsets: [0, 3, 1] — non-monotonic
+  // data: 3 bytes of nulls
+  uint8_t data[] = {
+      0x03,  // array header: basic_type=3, offset_size=1, is_large=false
+      0x02,  // num_elements = 2
+      0x00,
+      0x03,
+      0x01,  // offsets: [0, 3, 1] — non-monotonic!
+      PrimitiveHeader(PrimitiveType::kNull),
+      PrimitiveHeader(PrimitiveType::kNull),
+      PrimitiveHeader(PrimitiveType::kNull),
+  };
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+}
+
+// ===========================================================================
+// Object field offset out-of-bounds test
+// ===========================================================================
+
+class VariantObjectOffsetBoundsTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = false;
+    metadata_.offset_size = 1;
+    metadata_.strings = {"key"};
+  }
+};
+
+TEST_F(VariantObjectOffsetBoundsTest, FieldOffsetExceedsDataSize) {
+  // Object with 1 field where field_offset[0] = 99 (beyond total_data_size).
+  // header: basic_type=2, offset_size=1, id_size=1, is_large=false → 0x02
+  // num_fields: 1
+  // field_ids: [0]
+  // offsets: [99, 2] — field 0 at offset 99, total=2
+  // data: 2 bytes (Null)
+  uint8_t data[] = {
+      0x02,  // object header
+      0x01,  // num_fields = 1
+      0x00,  // field_id[0] = 0
+      0x63,
+      0x02,  // offsets: [99, 2] — 99 > total_data_size(2)
+      PrimitiveHeader(PrimitiveType::kNull),
+      PrimitiveHeader(PrimitiveType::kNull),
+  };
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(metadata_, data, sizeof(data), &visitor));
+}
+
+// ===========================================================================
+// Empty metadata with various offset sizes
+// ===========================================================================
+
+class VariantMetadataOffsetSizeTest : public ::testing::Test {};
+
+TEST_F(VariantMetadataOffsetSizeTest, EmptyDictionaryOffsetSize4) {
+  // Valid metadata with 0 strings but offset_size=4.
+  auto buf = BuildMetadataBuffer({}, false, 4);
+  ASSERT_OK_AND_ASSIGN(auto metadata, DecodeMetadata(buf.data(), buf.size()));
+  ASSERT_EQ(metadata.version, 1);
+  ASSERT_EQ(metadata.offset_size, 4);
+  ASSERT_EQ(metadata.strings.size(), 0);
+}
+
+// ===========================================================================
+// FindObjectField with binary search (large object >= 32 fields)
+// ===========================================================================
+
+class VariantFindFieldBinarySearchTest : public ::testing::Test {
+ protected:
+  VariantMetadata metadata_;
+  // Backing storage for string_views in metadata (must outlive metadata_).
+  // Do NOT modify key_storage_ after SetUp(); reallocation invalidates
+  // the string_views stored in metadata_.strings.
+  std::vector<std::string> key_storage_;
+
+  void SetUp() override {
+    metadata_.version = 1;
+    metadata_.is_sorted = true;
+    metadata_.offset_size = 1;
+    // 40 keys in sorted order to trigger binary search path
+    key_storage_.reserve(40);
+    for (int i = 0; i < 40; ++i) {
+      std::string key = "k" + std::string(i < 10 ? "0" : "") + std::to_string(i);
+      key_storage_.emplace_back(key);
+    }
+    for (const auto& k : key_storage_) {
+      metadata_.strings.push_back(k);
+    }
+  }
+};
+
+TEST_F(VariantFindFieldBinarySearchTest, FindMiddleField) {
+  // Build object with 40 fields, all null values
+  std::vector<uint32_t> field_ids;
+  std::vector<std::vector<uint8_t>> values;
+  for (int i = 0; i < 40; ++i) {
+    field_ids.push_back(static_cast<uint32_t>(i));
+    values.push_back({PrimitiveHeader(PrimitiveType::kNull)});
+  }
+  auto data = BuildObject(field_ids, values);
+
+  // Search for "k20" (middle of the sorted range)
+  int64_t field_offset = -1, field_size = 0;
+  ASSERT_OK(FindObjectField(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                            "k20", &field_offset, &field_size));
+  ASSERT_GT(field_offset, 0);
+  ASSERT_EQ(field_size, 1);  // Null = 1 byte
+}
+
+TEST_F(VariantFindFieldBinarySearchTest, FindFirstField) {
+  std::vector<uint32_t> field_ids;
+  std::vector<std::vector<uint8_t>> values;
+  for (int i = 0; i < 40; ++i) {
+    field_ids.push_back(static_cast<uint32_t>(i));
+    values.push_back({PrimitiveHeader(PrimitiveType::kNull)});
+  }
+  auto data = BuildObject(field_ids, values);
+
+  int64_t field_offset = -1, field_size = 0;
+  ASSERT_OK(FindObjectField(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                            "k00", &field_offset, &field_size));
+  ASSERT_GT(field_offset, 0);
+}
+
+TEST_F(VariantFindFieldBinarySearchTest, FindLastField) {
+  std::vector<uint32_t> field_ids;
+  std::vector<std::vector<uint8_t>> values;
+  for (int i = 0; i < 40; ++i) {
+    field_ids.push_back(static_cast<uint32_t>(i));
+    values.push_back({PrimitiveHeader(PrimitiveType::kNull)});
+  }
+  auto data = BuildObject(field_ids, values);
+
+  int64_t field_offset = -1, field_size = 0;
+  ASSERT_OK(FindObjectField(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                            "k39", &field_offset, &field_size));
+  ASSERT_GT(field_offset, 0);
+}
+
+TEST_F(VariantFindFieldBinarySearchTest, NotFoundInLargeObject) {
+  std::vector<uint32_t> field_ids;
+  std::vector<std::vector<uint8_t>> values;
+  for (int i = 0; i < 40; ++i) {
+    field_ids.push_back(static_cast<uint32_t>(i));
+    values.push_back({PrimitiveHeader(PrimitiveType::kNull)});
+  }
+  auto data = BuildObject(field_ids, values);
+
+  int64_t field_offset = -1, field_size = 0;
+  ASSERT_OK(FindObjectField(metadata_, data.data(), static_cast<int64_t>(data.size()),
+                            "zzz", &field_offset, &field_size));
+  ASSERT_EQ(field_offset, -1);
+}
+
+// ===========================================================================
+// GetArrayElement middle index
+// ===========================================================================
+
+class VariantGetArrayElementExtraTest : public ::testing::Test {};
+
+TEST_F(VariantGetArrayElementExtraTest, MiddleElement) {
+  // Array of [Int32(10), Int32(20), Int32(30)]
+  std::vector<uint8_t> e0 = {PrimitiveHeader(PrimitiveType::kInt32), 10, 0, 0, 0};
+  std::vector<uint8_t> e1 = {PrimitiveHeader(PrimitiveType::kInt32), 20, 0, 0, 0};
+  std::vector<uint8_t> e2 = {PrimitiveHeader(PrimitiveType::kInt32), 30, 0, 0, 0};
+  auto data = BuildArray({e0, e1, e2});
+
+  int64_t elem_offset = 0, elem_size = 0;
+  ASSERT_OK(GetArrayElement(data.data(), static_cast<int64_t>(data.size()), 1,
+                            &elem_offset, &elem_size));
+  ASSERT_EQ(elem_size, 5);  // Int32 = 5 bytes
+
+  // Decode the middle element
+  VariantMetadata meta;
+  meta.version = 1;
+  RecordingVisitor v;
+  ASSERT_OK(DecodeAndVisit(meta, data.data() + elem_offset, elem_size, &v));
+  ASSERT_EQ(v.events[0], "Int32(20)");
+}
+
+TEST_F(VariantGetArrayElementExtraTest, EmptyArrayOutOfRange) {
+  auto data = BuildArray({});
+  int64_t elem_offset = 0, elem_size = 0;
+  ASSERT_RAISES(Invalid, GetArrayElement(data.data(), static_cast<int64_t>(data.size()),
+                                         0, &elem_offset, &elem_size));
+}
+
+// ===========================================================================
+// Additional error case tests (missing coverage)
+// ===========================================================================
+
+class VariantErrorCaseTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+  }
+};
+
+TEST_F(VariantErrorCaseTest, MetadataVersionZero) {
+  // Version 0 is not supported (only version 1 is valid per spec)
+  uint8_t data[] = {0x00, 0x00, 0x00};
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
+TEST_F(VariantErrorCaseTest, GetObjectFieldCountOnArray) {
+  // Calling GetObjectFieldCount on an array value should produce an error
+  auto data = BuildArray({});
+  ASSERT_RAISES(Invalid,
+                GetObjectFieldCount(data.data(), static_cast<int64_t>(data.size())));
+}
+
+TEST_F(VariantErrorCaseTest, GetArrayElementCountOnObject) {
+  // Calling GetArrayElementCount on an object value should produce an error
+  auto data = BuildObject({}, {});
+  ASSERT_RAISES(Invalid,
+                GetArrayElementCount(data.data(), static_cast<int64_t>(data.size())));
+}
+
+TEST_F(VariantErrorCaseTest, GetObjectFieldCountOnPrimitive) {
+  // Calling GetObjectFieldCount on a primitive should produce an error
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kNull)};
+  ASSERT_RAISES(Invalid, GetObjectFieldCount(data, sizeof(data)));
+}
+
+TEST_F(VariantErrorCaseTest, GetArrayElementCountOnPrimitive) {
+  // Calling GetArrayElementCount on a primitive should produce an error
+  uint8_t data[] = {PrimitiveHeader(PrimitiveType::kNull)};
+  ASSERT_RAISES(Invalid, GetArrayElementCount(data, sizeof(data)));
+}
+
+TEST_F(VariantErrorCaseTest, MetadataStringOffsetExceedsBuffer) {
+  // Metadata where the last string offset claims more data than the buffer
+  // contains. This exercises the ValidateOffsets check for offsets.back() >
+  // data_length.
+  // Header: version=1, offset_size=1
+  // dict_size=1, offsets=[0, 100] — but only 3 bytes of string data
+  uint8_t data[] = {0x01,        // header: version=1, offset_size=1
+                    0x01,        // dict_size = 1
+                    0x00, 0x64,  // offsets: [0, 100] — 100 exceeds available string data
+                    'a',  'b',  'c'};
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
+TEST_F(VariantErrorCaseTest, GetArrayElementNegativeIndex) {
+  std::vector<uint8_t> e0 = {PrimitiveHeader(PrimitiveType::kNull)};
+  auto data = BuildArray({e0});
+  int64_t elem_offset = 0, elem_size = 0;
+  ASSERT_RAISES(Invalid, GetArrayElement(data.data(), static_cast<int64_t>(data.size()),
+                                         -1, &elem_offset, &elem_size));
+}
+
+TEST_F(VariantErrorCaseTest, FindObjectFieldOnNonObject) {
+  // Calling FindObjectField on an array should produce an error
+  auto data = BuildArray({});
+  int64_t field_offset = -1, field_size = 0;
+  ASSERT_RAISES(Invalid, FindObjectField(empty_metadata_, data.data(),
+                                         static_cast<int64_t>(data.size()), "key",
+                                         &field_offset, &field_size));
+}
+
+// TODO: Add fuzz targets for DecodeMetadata and DecodeVariantValue to exercise
+// adversarial/malformed input. Fuzz tests in Arrow are typically registered as
+// separate executables under cpp/src/arrow/testing/fuzzing/ — see GH-45948.
+
+// ===========================================================================
+// View API tests (new — demonstrates C++ ergonomic approach)
+// ===========================================================================
+
+class VariantViewTest : public ::testing::Test {};
+
+TEST_F(VariantViewTest, PrimitiveInt32) {
+  auto meta_buf = BuildMetadataBuffer({});
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  // Build an Int32 value: header + 4 bytes LE
+  std::vector<uint8_t> data = {PrimitiveHeader(PrimitiveType::kInt32), 0x2A, 0x00, 0x00,
+                               0x00};
+
+  ASSERT_OK_AND_ASSIGN(
+      auto view, VariantView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(view.type(), BasicType::kPrimitive);
+  ASSERT_FALSE(view.is_null());
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_int32());
+  ASSERT_EQ(val, 42);
+  ASSERT_EQ(view.size_bytes(), 5);
+}
+
+TEST_F(VariantViewTest, PrimitiveNull) {
+  auto meta_buf = BuildMetadataBuffer({});
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  std::vector<uint8_t> data = {PrimitiveHeader(PrimitiveType::kNull)};
+  ASSERT_OK_AND_ASSIGN(
+      auto view, VariantView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_TRUE(view.is_null());
+  ASSERT_EQ(view.size_bytes(), 1);
+}
+
+TEST_F(VariantViewTest, ShortString) {
+  auto meta_buf = BuildMetadataBuffer({});
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  auto data = BuildShortString("hello");
+  ASSERT_OK_AND_ASSIGN(
+      auto view, VariantView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(view.type(), BasicType::kShortString);
+  ASSERT_OK_AND_ASSIGN(auto str, view.as_string());
+  ASSERT_EQ(str, "hello");
+}
+
+TEST_F(VariantViewTest, TypeMismatchReturnsError) {
+  auto meta_buf = BuildMetadataBuffer({});
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  // Build a boolean true value
+  std::vector<uint8_t> data = {PrimitiveHeader(PrimitiveType::kTrue)};
+  ASSERT_OK_AND_ASSIGN(
+      auto view, VariantView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+
+  // Accessing as wrong type should fail
+  ASSERT_RAISES(Invalid, view.as_int32());
+  ASSERT_RAISES(Invalid, view.as_string());
+  ASSERT_RAISES(Invalid, view.as_object());
+}
+
+class VariantObjectViewTest : public ::testing::Test {};
+
+TEST_F(VariantObjectViewTest, SimpleObject) {
+  // Build {"name": "Alice", "age": 42}
+  auto meta_buf = BuildMetadataBuffer({"age", "name"}, /*sorted=*/true);
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  // Field values
+  auto val_name = BuildShortString("Alice");
+  std::vector<uint8_t> val_age = {PrimitiveHeader(PrimitiveType::kInt8), 42};
+
+  // Build object: field IDs sorted by key name → age=0, name=1
+  auto data = BuildObject({0, 1}, {val_age, val_name});
+
+  ASSERT_OK_AND_ASSIGN(
+      auto view, VariantView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(view.type(), BasicType::kObject);
+
+  ASSERT_OK_AND_ASSIGN(auto obj, view.as_object());
+  ASSERT_EQ(obj.num_fields(), 2);
+
+  // Lookup by name
+  auto age = obj.get("age");
+  ASSERT_TRUE(age.has_value());
+  ASSERT_OK_AND_ASSIGN(auto age_val, age->as_int8());
+  ASSERT_EQ(age_val, 42);
+
+  auto name = obj.get("name");
+  ASSERT_TRUE(name.has_value());
+  ASSERT_OK_AND_ASSIGN(auto name_val, name->as_string());
+  ASSERT_EQ(name_val, "Alice");
+
+  // Not found
+  auto missing = obj.get("nonexistent");
+  ASSERT_FALSE(missing.has_value());
+}
+
+TEST_F(VariantObjectViewTest, NestedNavigation) {
+  // Build: {"addresses": {"postal": {"city": "New York"}}}
+  // This test addresses reviewer comment #4 (nested field navigation)
+  auto meta_buf = BuildMetadataBuffer({"addresses", "city", "postal"}, /*sorted=*/true);
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  // innermost: {"city": "New York"} — field_id for "city" = 1
+  auto val_city = BuildShortString("New York");
+  auto inner_obj = BuildObject({1}, {val_city});
+
+  // middle: {"postal": <inner_obj>} — field_id for "postal" = 2
+  auto mid_obj = BuildObject({2}, {inner_obj});
+
+  // outer: {"addresses": <mid_obj>} — field_id for "addresses" = 0
+  auto outer_obj = BuildObject({0}, {mid_obj});
+
+  ASSERT_OK_AND_ASSIGN(
+      auto root,
+      VariantView::Make(meta, outer_obj.data(), static_cast<int64_t>(outer_obj.size())));
+
+  // Navigate: root -> addresses -> postal -> city
+  ASSERT_OK_AND_ASSIGN(auto root_obj, root.as_object());
+  auto addresses = root_obj.get("addresses");
+  ASSERT_TRUE(addresses.has_value());
+
+  ASSERT_OK_AND_ASSIGN(auto addr_obj, addresses->as_object());
+  auto postal = addr_obj.get("postal");
+  ASSERT_TRUE(postal.has_value());
+
+  ASSERT_OK_AND_ASSIGN(auto postal_obj, postal->as_object());
+  auto city = postal_obj.get("city");
+  ASSERT_TRUE(city.has_value());
+
+  ASSERT_OK_AND_ASSIGN(auto city_val, city->as_string());
+  ASSERT_EQ(city_val, "New York");
+}
+
+TEST_F(VariantObjectViewTest, IterateFields) {
+  auto meta_buf = BuildMetadataBuffer({"a", "b", "c"}, /*sorted=*/true);
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  std::vector<uint8_t> val_a = {PrimitiveHeader(PrimitiveType::kInt8), 1};
+  std::vector<uint8_t> val_b = {PrimitiveHeader(PrimitiveType::kInt8), 2};
+  std::vector<uint8_t> val_c = {PrimitiveHeader(PrimitiveType::kInt8), 3};
+  auto data = BuildObject({0, 1, 2}, {val_a, val_b, val_c});
+
+  ASSERT_OK_AND_ASSIGN(
+      auto obj,
+      VariantObjectView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+
+  std::vector<std::string> names;
+  for (auto [name, value] : obj) {
+    names.push_back(std::string(name));
+  }
+  ASSERT_EQ(names.size(), 3);
+  ASSERT_EQ(names[0], "a");
+  ASSERT_EQ(names[1], "b");
+  ASSERT_EQ(names[2], "c");
+}
+
+class VariantArrayViewTest : public ::testing::Test {};
+
+TEST_F(VariantArrayViewTest, SimpleArray) {
+  auto meta_buf = BuildMetadataBuffer({});
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  // Build array [42, 100]
+  std::vector<uint8_t> val_a = {PrimitiveHeader(PrimitiveType::kInt8), 42};
+  std::vector<uint8_t> val_b = {PrimitiveHeader(PrimitiveType::kInt8), 100};
+  auto data = BuildArray({val_a, val_b});
+
+  ASSERT_OK_AND_ASSIGN(
+      auto view, VariantView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+  ASSERT_EQ(view.type(), BasicType::kArray);
+
+  ASSERT_OK_AND_ASSIGN(auto arr, view.as_array());
+  ASSERT_EQ(arr.num_elements(), 2);
+
+  ASSERT_OK_AND_ASSIGN(auto elem0, arr.get(0));
+  ASSERT_OK_AND_ASSIGN(auto v0, elem0.as_int8());
+  ASSERT_EQ(v0, 42);
+
+  ASSERT_OK_AND_ASSIGN(auto elem1, arr.get(1));
+  ASSERT_OK_AND_ASSIGN(auto v1, elem1.as_int8());
+  ASSERT_EQ(v1, 100);
+
+  // Out of range
+  ASSERT_RAISES(Invalid, arr.get(2));
+  ASSERT_RAISES(Invalid, arr.get(-1));
+}
+
+TEST_F(VariantArrayViewTest, IterateElements) {
+  auto meta_buf = BuildMetadataBuffer({});
+  ASSERT_OK_AND_ASSIGN(
+      auto meta, DecodeMetadata(meta_buf.data(), static_cast<int64_t>(meta_buf.size())));
+
+  std::vector<uint8_t> val_a = {PrimitiveHeader(PrimitiveType::kInt8), 10};
+  std::vector<uint8_t> val_b = {PrimitiveHeader(PrimitiveType::kInt8), 20};
+  std::vector<uint8_t> val_c = {PrimitiveHeader(PrimitiveType::kInt8), 30};
+  auto data = BuildArray({val_a, val_b, val_c});
+
+  ASSERT_OK_AND_ASSIGN(
+      auto arr,
+      VariantArrayView::Make(meta, data.data(), static_cast<int64_t>(data.size())));
+
+  int count = 0;
+  for ([[maybe_unused]] auto elem : arr) {
+    ++count;
+  }
+  ASSERT_EQ(count, 3);
+}
+
+}  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_test.cc
+++ b/cpp/src/arrow/extension/variant_test.cc
@@ -2483,5 +2483,195 @@ TEST_F(VariantArrayViewTest, IterateElements) {
   }
   ASSERT_EQ(count, 3);
 }
+// ===========================================================================
+// Widening numeric accessor tests
+// ===========================================================================
+
+class VariantCoercionTest : public ::testing::Test {};
+
+TEST_F(VariantCoercionTest, Int8CoercesToInt64) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int8(42));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_int64_coerced());
+  ASSERT_EQ(val, 42);
+}
+
+TEST_F(VariantCoercionTest, Int16CoercesToInt64) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int16(1000));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_int64_coerced());
+  ASSERT_EQ(val, 1000);
+}
+
+TEST_F(VariantCoercionTest, Int32CoercesToInt64) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int32(100000));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_int64_coerced());
+  ASSERT_EQ(val, 100000);
+}
+
+TEST_F(VariantCoercionTest, Int64CoercesToInt64Identity) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int64(9876543210LL));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_int64_coerced());
+  ASSERT_EQ(val, 9876543210LL);
+}
+
+TEST_F(VariantCoercionTest, NegativeInt8CoercesToInt64) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int8(-42));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_int64_coerced());
+  ASSERT_EQ(val, -42);
+}
+
+TEST_F(VariantCoercionTest, StringDoesNotCoerceToInt64) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.String("hello"));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_NOT_OK(view.as_int64_coerced());
+}
+
+TEST_F(VariantCoercionTest, Int32CoercedRejectsInt64) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int64(9876543210LL));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_NOT_OK(view.as_int32_coerced());
+}
+
+TEST_F(VariantCoercionTest, DoubleCoercedFromFloat) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Float(3.14f));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_double_coerced());
+  ASSERT_NEAR(val, 3.14, 0.001);
+}
+
+TEST_F(VariantCoercionTest, DoubleCoercedFromInt32) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int32(42));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK_AND_ASSIGN(
+      auto view,
+      VariantView::Make(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+  ASSERT_OK_AND_ASSIGN(auto val, view.as_double_coerced());
+  ASSERT_EQ(val, 42.0);
+}
+
+// ===========================================================================
+// ValidateVariant tests
+// ===========================================================================
+
+class VariantValidationTest : public ::testing::Test {};
+
+TEST_F(VariantValidationTest, ValidPrimitive) {
+  VariantBuilder builder;
+  ASSERT_OK(builder.Int(42));
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK(
+      ValidateVariant(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+}
+
+TEST_F(VariantValidationTest, ValidNestedObject) {
+  VariantBuilder builder;
+  auto obj = builder.StartObject();
+  ASSERT_OK(obj.Insert("name", std::string_view("Alice")));
+  ASSERT_OK(obj.Insert("age", static_cast<int64_t>(30)));
+  auto inner = obj.InsertObject("address");
+  ASSERT_OK(inner.Insert("city", std::string_view("NYC")));
+  ASSERT_OK(inner.Finish());
+  ASSERT_OK(obj.Finish());
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK(
+      ValidateVariant(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+}
+
+TEST_F(VariantValidationTest, ValidArray) {
+  VariantBuilder builder;
+  auto list = builder.StartList();
+  ASSERT_OK(list.Append(static_cast<int64_t>(1)));
+  ASSERT_OK(list.Append(static_cast<int64_t>(2)));
+  ASSERT_OK(list.Append(static_cast<int64_t>(3)));
+  ASSERT_OK(list.Finish());
+  ASSERT_OK_AND_ASSIGN(auto enc, builder.Finish());
+  ASSERT_OK_AND_ASSIGN(
+      auto meta,
+      DecodeMetadata(enc.metadata.data(), static_cast<int64_t>(enc.metadata.size())));
+  ASSERT_OK(
+      ValidateVariant(meta, enc.value.data(), static_cast<int64_t>(enc.value.size())));
+}
+
+TEST_F(VariantValidationTest, NullBuffer) {
+  ASSERT_NOT_OK(ValidateVariant(VariantMetadata{}, nullptr, 0));
+}
+
+TEST_F(VariantValidationTest, TruncatedPrimitive) {
+  // A valid Int32 header (type=5 << 2 | 0 = 20 = 0x14) but no payload
+  uint8_t data[] = {0x14};
+  VariantMetadata meta;
+  meta.version = 1;
+  ASSERT_NOT_OK(ValidateVariant(meta, data, 1));
+}
 
 }  // namespace arrow::extension::variant

--- a/cpp/src/arrow/extension/variant_test.cc
+++ b/cpp/src/arrow/extension/variant_test.cc
@@ -395,6 +395,18 @@ TEST_F(VariantMetadataTest, NonMonotonicStringOffsets) {
   ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
 }
 
+TEST_F(VariantMetadataTest, LargeDictSizeOverflowsInt32) {
+  // dict_size = 0x80000001 (2,147,483,649) which overflows int32_t if cast.
+  // With offset_size=4, this should be rejected as truncated (the buffer is
+  // far too small to hold that many offsets) rather than wrapping to negative.
+  // Header: version=1, sorted=0, offset_size=4 (bits 6-7 = 0b11 → offset_size_minus_one=3)
+  uint8_t data[] = {
+      0xC1,                    // header: version=1, offset_size=4
+      0x01, 0x00, 0x00, 0x80  // dict_size = 0x80000001 in LE
+  };
+  ASSERT_RAISES(Invalid, DecodeMetadata(data, sizeof(data)));
+}
+
 // ===========================================================================
 // Primitive value decoding tests
 // ===========================================================================
@@ -1984,6 +1996,69 @@ TEST_F(VariantMetadataOffsetSizeTest, EmptyDictionaryOffsetSize4) {
   ASSERT_EQ(metadata.version, 1);
   ASSERT_EQ(metadata.offset_size, 4);
   ASSERT_EQ(metadata.strings.size(), 0);
+}
+
+// ===========================================================================
+// Overflow tests — large element counts that would overflow int32_t
+// ===========================================================================
+
+class VariantOverflowTest : public ::testing::Test {
+ protected:
+  VariantMetadata empty_metadata_;
+
+  void SetUp() override {
+    empty_metadata_.version = 1;
+    empty_metadata_.is_sorted = false;
+    empty_metadata_.offset_size = 1;
+    empty_metadata_.strings = {"key"};
+  }
+};
+
+TEST_F(VariantOverflowTest, ObjectNumFieldsOverflowsInt32) {
+  // Craft an object with is_large=true and num_fields = 0x80000001 (>INT32_MAX).
+  // header: basic_type=2(object), offset_size=1(bits2-3=0), id_size=1(bits4-5=0),
+  //         is_large=1(bit6=1) → 0x02 | (1 << 6) = 0x42
+  // num_fields = 0x80000001 in LE (4 bytes)
+  // This should be rejected as truncated (buffer is far too small).
+  uint8_t data[] = {
+      0x42,                    // object header with is_large=true
+      0x01, 0x00, 0x00, 0x80  // num_fields = 0x80000001 in LE
+  };
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+}
+
+TEST_F(VariantOverflowTest, ObjectNumFieldsOverflowsInt32View) {
+  // Same as above but via VariantObjectView::Make
+  uint8_t data[] = {
+      0x42,                    // object header with is_large=true
+      0x01, 0x00, 0x00, 0x80  // num_fields = 0x80000001 in LE
+  };
+  ASSERT_RAISES(Invalid,
+                VariantObjectView::Make(empty_metadata_, data, sizeof(data)));
+}
+
+TEST_F(VariantOverflowTest, ArrayNumElementsOverflowsInt32) {
+  // Craft an array with is_large=true and num_elements = 0x80000001 (>INT32_MAX).
+  // header: basic_type=3(array), offset_size=1(bits2-3=0),
+  //         is_large=1(bit4=1) → 0x03 | (1 << 4) = 0x13
+  // num_elements = 0x80000001 in LE (4 bytes)
+  uint8_t data[] = {
+      0x13,                    // array header with is_large=true
+      0x01, 0x00, 0x00, 0x80  // num_elements = 0x80000001 in LE
+  };
+  RecordingVisitor visitor;
+  ASSERT_RAISES(Invalid, DecodeAndVisit(empty_metadata_, data, sizeof(data), &visitor));
+}
+
+TEST_F(VariantOverflowTest, ArrayNumElementsOverflowsInt32View) {
+  // Same as above but via VariantArrayView::Make
+  uint8_t data[] = {
+      0x13,                    // array header with is_large=true
+      0x01, 0x00, 0x00, 0x80  // num_elements = 0x80000001 in LE
+  };
+  ASSERT_RAISES(Invalid,
+                VariantArrayView::Make(empty_metadata_, data, sizeof(data)));
 }
 
 // ===========================================================================

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -142,6 +142,7 @@ arrow_components = {
             'extension/bool8.cc',
             'extension/json.cc',
             'extension/parquet_variant.cc',
+            'extension/variant.cc',
             'extension/uuid.cc',
             'pretty_print.cc',
             'record_batch.cc',

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -143,6 +143,7 @@ arrow_components = {
             'extension/json.cc',
             'extension/parquet_variant.cc',
             'extension/variant.cc',
+            'extension/variant_builder.cc',
             'extension/uuid.cc',
             'pretty_print.cc',
             'record_batch.cc',

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -144,6 +144,7 @@ arrow_components = {
             'extension/parquet_variant.cc',
             'extension/variant.cc',
             'extension/variant_builder.cc',
+            'extension/variant_shredding.cc',
             'extension/uuid.cc',
             'pretty_print.cc',
             'record_batch.cc',


### PR DESCRIPTION
> **PR Stack (merge in order):**
> 1. #50121 Variant decoding
> 2. #50122 Variant encoding
> 3. **#50232 ← YOU ARE HERE** Variant shredding (this PR, depends on #50121 and #50122)
>
> All three PRs are part of the [GH-45937](https://github.com/apache/arrow/issues/45937) umbrella (Add variant support to C++ Parquet).

### Rationale for this change

Implements variant shredding/unshredding for C++ ([GH-45948](https://github.com/apache/arrow/issues/45948)), part of the [GH-45937](https://github.com/apache/arrow/issues/45937) umbrella. Enables decomposing variant binary columns into native typed Arrow columns for Parquet statistics-based predicate pushdown. Depends on #50121 (decoding) and #50122 (encoding).

**Note:** This PR depends on #50121 and #50122. Please review/merge those first.

### What changes are included in this PR?

Adds `variant_shredding.h` / `variant_shredding.cc` implementing:

- **`VariantShreddingSchema`** — tree structure defining shredding targets (Primitive,
  Object, Array). C++ equivalent of Rust's `ShreddedSchemaBuilder`.
- **`IsVariantCompatibleWithType()`** — strict type compatibility with safe int widening,
  Float→Double widening, timestamp unit+timezone matching, and decimal scale matching.
- **`ShredVariantColumn()`** — column-level shredding producing `{metadata, value, typed_value}`.
  Template-refactored loops (`ShredPrimitiveLoop<>`, `ShredBinaryLoop<>`) for all
  15+ supported Arrow target types.
- **`ReconstructVariantColumn()`** — column-level reconstruction reassembling shredded
  columns back to variant binary. Supports all list-like typed_value types (List,
  LargeList, FixedSizeList, ListView, LargeListView).

Extends `VariantBuilder` with 3 methods for shredding support:
- `BuildWithoutMeta()` — produce value bytes without metadata (for primitives)
- `UnsafeAppendEncoded()` — zero-copy raw byte append
- `SetAllowDuplicates(true)` — last-value-wins dedup for reconstruction safety

**Supported shredding targets (Rust parity):**
Bool, Int8, Int16, Int32, Int64, Float, Double, String, LargeString, StringView,
Binary, LargeBinary, BinaryView, Date32, Timestamp(Micro/Nano, TZ/NTZ), Time64(Micro),
FixedSizeBinary(16) (UUID), Decimal128 (scale-matched)

**Variant::Null semantics (Rust parity):** Variant::Null (0x00) is stored in the
value column, NOT the typed_value column. Distinguishes variant-null from SQL NULL.

**NullBuffer output (Rust parity):** Optional `out_null_bitmap` parameter on
`ReconstructVariantColumn` for SQL NULL disambiguation (bit=0 where both value and
typed_value are null).

**Known gaps (documented TODOs for follow-up PRs):**
- Recursive Object/Array sub-schema shredding in object fields (primitives only currently)
- CastOptions cross-type coercion (Uint, Float16, Decimal32/64, TimestampSecond/Milli)
- FixedSizeList/ListView as shredding output targets (reconstruction accepts all)
- Value-absent schemas (`{metadata, typed_value}` without `value`)
- DECIMAL256 shredding target (compatibility check exists but shred/reconstruct not wired)

### Are these changes tested?

335 total tests (114 new shredding + 221 prior) pass with `BUILD_WARNING_LEVEL=CHECKIN`
covering: schema definition, type compatibility, primitive round-trip for all supported
types, object shredding (full/partial/fallback), array shredding (recursive elements),
typed round-trip (Decimal128, UUID, all timestamps, Float→Double, Int8/Int16, LargeString,
LargeBinary, StringView, BinaryView), all list-like reconstruction, error cases, and
NullBitmap semantics.

### Are there any user-facing changes?

New public API in `arrow/extension/variant_shredding.h`: `VariantShreddingSchema`,
`IsVariantCompatibleWithType()`, `ShredVariantColumn()`, `ReconstructVariantColumn()`.
New methods on `VariantBuilder`: `BuildWithoutMeta()`, `UnsafeAppendEncoded()`,
`SetAllowDuplicates()`.

**AI Disclosure:** AI coding assistants were used during development for scaffolding,
test generation, and review iteration. All code has been reviewed, debugged, and
verified by the author who owns and understands the changes.

* GitHub Issue: #45948
