### PR TITLE
GH-49928: [C++][Parquet] Fix UB in UpdateLevelHistogram from nullptr std::span

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1809,7 +1809,8 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
 
     auto add_levels = [](std::vector<int64_t>& level_histogram, const int16_t* levels,
                          int64_t num_levels, int16_t max_level) {
-      if (max_level == 0) {
+      ARROW_DCHECK(levels != nullptr || num_levels == 0 || max_level == 0);
+      if (max_level == 0 || levels == nullptr) {
         return;
       }
       ARROW_DCHECK_EQ(static_cast<size_t>(max_level) + 1, level_histogram.size());

--- a/cpp/src/parquet/size_statistics_test.cc
+++ b/cpp/src/parquet/size_statistics_test.cc
@@ -60,6 +60,43 @@ TEST(SizeStatistics, UpdateLevelHistogram) {
     UpdateLevelHistogram(std::vector<int16_t>{}, histogram);
     EXPECT_THAT(histogram, ::testing::ElementsAre(3, 3, 2));
   }
+  {
+    // Empty span should be a no-op.
+    std::vector<int64_t> histogram(2, 0);
+    UpdateLevelHistogram(std::span<const int16_t>{}, histogram);
+    EXPECT_THAT(histogram, ::testing::ElementsAre(0, 0));
+  }
+}
+
+// Regression test for GH-49928: WriteBatch(0, nullptr, ...) on a nullable column
+// must not crash or DCHECK-fail, even though max_definition_level > 0.
+TEST(SizeStatistics, NullLevelsInColumnWriter) {
+  auto node = schema::Int32("a", Repetition::OPTIONAL);
+  auto schema_node = schema::GroupNode::Make("schema", Repetition::REQUIRED, {node});
+
+  auto props = WriterProperties::Builder()
+                   .enable_write_page_index()
+                   ->enable_statistics()
+                   ->set_size_statistics_level(SizeStatisticsLevel::PageAndColumnChunk)
+                   ->build();
+
+  auto sink = CreateOutputStream();
+  auto writer = ParquetFileWriter::Open(sink, std::dynamic_pointer_cast<schema::GroupNode>(schema_node), props);
+  auto rg = writer->AppendRowGroup();
+  auto col = static_cast<Int32Writer*>(rg->NextColumn());
+
+  // Empty write: num_values=0 with nullptr levels — must not crash.
+  col->WriteBatch(/*num_values=*/0, /*def_levels=*/nullptr,
+                  /*rep_levels=*/nullptr, /*values=*/nullptr);
+
+  // Follow up with a real write so the file is valid.
+  std::vector<int32_t> values = {42};
+  std::vector<int16_t> def_levels = {1};
+  col->WriteBatch(1, def_levels.data(), nullptr, values.data());
+
+  col->Close();
+  rg->Close();
+  writer->Close();
 }
 
 TEST(SizeStatistics, ThriftSerDe) {


### PR DESCRIPTION
[Parquet] Guard against null level pointers in UpdateLevelHistogram

column_writer.cc
 1. Added ARROW_DCHECK and null guard in the add_levels lambda
size_statistics_test.cc
2. Added regression test for empty/null span 

Add an explicit null-pointer check before constructing a std::span in
TypedColumnWriterImpl::UpdateLevelHistogram. This avoids relying on the
implicit invariant that nullptr level pointers only occur when
max_level == 0.

Also add a regression test verifying that UpdateLevelHistogram handles
an empty span as a no op.
* GitHub Issue: #49928