### PR TITLE
GH-46914: [C++][FlightSQL] Remove boost/algorithm/string.h dependency

### DIFF
--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -17,8 +17,6 @@
 
 #include "arrow/flight/sql/example/sqlite_server.h"
 
-#define BOOST_NO_CXX98_FUNCTION_BASE  // ARROW-17805
-#include <boost/algorithm/string.hpp>
 #include <mutex>
 #include <random>
 #include <sstream>
@@ -37,6 +35,7 @@
 #include "arrow/scalar.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
 namespace flight {
@@ -46,6 +45,11 @@ namespace example {
 using arrow::internal::checked_cast;
 
 namespace {
+
+bool AsciiStartsWithCaseInsensitive(std::string_view value, std::string_view prefix) {
+  return value.size() >= prefix.size() && arrow::internal::AsciiEqualsCaseInsensitive(
+                                              value.substr(0, prefix.size()), prefix);
+}
 
 std::string PrepareQueryForGetTables(const GetTables& command) {
   std::stringstream table_query;
@@ -174,15 +178,17 @@ arrow::Result<std::shared_ptr<DataType>> GetArrowType(const char* sqlite_type) {
     return null();
   }
 
-  if (boost::iequals(sqlite_type, "int") || boost::iequals(sqlite_type, "integer")) {
+  if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "int") ||
+      arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "integer")) {
     return int64();
-  } else if (boost::iequals(sqlite_type, "REAL")) {
+  } else if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "REAL")) {
     return float64();
-  } else if (boost::iequals(sqlite_type, "BLOB")) {
+  } else if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "BLOB")) {
     return binary();
-  } else if (boost::iequals(sqlite_type, "TEXT") || boost::iequals(sqlite_type, "DATE") ||
-             boost::istarts_with(sqlite_type, "char") ||
-             boost::istarts_with(sqlite_type, "varchar")) {
+  } else if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "TEXT") ||
+             arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "DATE") ||
+             AsciiStartsWithCaseInsensitive(sqlite_type, "char") ||
+             AsciiStartsWithCaseInsensitive(sqlite_type, "varchar")) {
     return utf8();
   }
   return Status::Invalid("Invalid SQLite type: ", sqlite_type);
@@ -194,15 +200,17 @@ int32_t GetSqlTypeFromTypeName(const char* sqlite_type) {
     return SQLITE_NULL;
   }
 
-  if (boost::iequals(sqlite_type, "int") || boost::iequals(sqlite_type, "integer")) {
+  if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "int") ||
+      arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "integer")) {
     return SQLITE_INTEGER;
-  } else if (boost::iequals(sqlite_type, "REAL")) {
+  } else if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "REAL")) {
     return SQLITE_FLOAT;
-  } else if (boost::iequals(sqlite_type, "BLOB")) {
+  } else if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "BLOB")) {
     return SQLITE_BLOB;
-  } else if (boost::iequals(sqlite_type, "TEXT") || boost::iequals(sqlite_type, "DATE") ||
-             boost::istarts_with(sqlite_type, "char") ||
-             boost::istarts_with(sqlite_type, "varchar")) {
+  } else if (arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "TEXT") ||
+             arrow::internal::AsciiEqualsCaseInsensitive(sqlite_type, "DATE") ||
+             AsciiStartsWithCaseInsensitive(sqlite_type, "char") ||
+             AsciiStartsWithCaseInsensitive(sqlite_type, "varchar")) {
     return SQLITE_TEXT;
   } else {
     return SQLITE_NULL;

--- a/cpp/src/arrow/flight/sql/test_app_cli.cc
+++ b/cpp/src/arrow/flight/sql/test_app_cli.cc
@@ -18,8 +18,6 @@
 #include "arrow/util/config.h"
 
 #include <gflags/gflags.h>
-#define BOOST_NO_CXX98_FUNCTION_BASE  // ARROW-17805
-#include <boost/algorithm/string.hpp>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -33,6 +31,7 @@
 #include "arrow/pretty_print.h"
 #include "arrow/status.h"
 #include "arrow/table.h"
+#include "arrow/util/string.h"
 
 #ifdef ARROW_WITH_OPENTELEMETRY
 #  include "arrow/flight/otel_logging.h"
@@ -74,6 +73,15 @@ DEFINE_string(query, "", "Query");
 DEFINE_string(catalog, "", "Catalog");
 DEFINE_string(schema, "", "Schema");
 DEFINE_string(table, "", "Table");
+
+namespace {
+
+bool AsciiStartsWithCaseInsensitive(std::string_view value, std::string_view prefix) {
+  return value.size() >= prefix.size() && arrow::internal::AsciiEqualsCaseInsensitive(
+                                              value.substr(0, prefix.size()), prefix);
+}
+
+}  // namespace
 
 #ifdef ARROW_WITH_OPENTELEMETRY
 class OtelScope {
@@ -234,7 +242,7 @@ Status RunMain() {
   }
 
   if (info != NULLPTR &&
-      !boost::istarts_with(FLAGS_command, "PreparedStatementExecute")) {
+      !AsciiStartsWithCaseInsensitive(FLAGS_command, "PreparedStatementExecute")) {
     return PrintResults(sql_client, call_options, info);
   }
 


### PR DESCRIPTION
### Rationale for this change

Issue #46914 requests removing the remaining boost/algorithm/string.hpp dependency from FlightSQL.

### What changes are included in this PR?

* Replace boost::iequals() with arrow::internal::AsciiEqualsCaseInsensitive()
* Replace boost::istarts_with() with a local case-insensitive prefix helper
* Remove boost/algorithm/string.hpp includes from sqlite_server.cc and test_app_cli.cc

### Are these changes tested?

The modified files compile successfully in the local build configuration. CI will validate FlightSQL configurations.

### Are there any user-facing changes?

No.

* GitHub Issue: #46914