### PR TITLE
GH-50172: [Doc][Format] Clarify that variadic buffers can also be null

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -491,7 +491,8 @@ It has the following fields:
    The buffer pointers MAY be null only in two situations:
 
    1. for the null bitmap buffer, if :c:member:`ArrowArray.null_count` is 0;
-   2. for any buffer, if the size in bytes of the corresponding buffer would be 0.
+   2. for any buffer (including variadic buffers), if the size in bytes of the
+      corresponding buffer would be 0.
 
    Buffers of children arrays are not included.
 


### PR DESCRIPTION
### Rationale for this change

Some implementations are known to produce null variadic buffers in BinaryView arrays, and expose them on the C Data Interface.

Since Arrow C++, and perhaps other implementations, make the wrong assumption that imported variadic buffers cannot be null, clarify the docs.

### Are these changes tested?

N/A.

### Are there any user-facing changes?

No.


* GitHub Issue: #50172