### PR TITLE
GH-50236: [C++] Remove obsolete OpenSUSE 15.5 workarounds

### DIFF
--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -636,8 +636,7 @@ class ConcatenateImpl {
       }
       out_data += data->length * index_width;
     }
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(out));
+    return out;
   }
 
   Status Visit(const DictionaryType& d) {

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -125,8 +125,7 @@ class ArrayDataEndianSwapper {
     for (int64_t i = 0; i < length; i++) {
       out_data[i] = bit_util::ByteSwap(in_data[i]);
     }
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(out_buffer));
+    return out_buffer;
   }
 
   template <typename VALUE_TYPE>

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -41,8 +41,7 @@ Result<std::shared_ptr<Buffer>> Buffer::CopySlice(const int64_t start,
 
   ARROW_ASSIGN_OR_RAISE(auto new_buffer, AllocateResizableBuffer(nbytes, pool));
   std::memcpy(new_buffer->mutable_data(), data() + start, static_cast<size_t>(nbytes));
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(new_buffer));
+  return new_buffer;
 }
 
 Buffer::Buffer() : Buffer(memory_pool::internal::kZeroSizeArea, 0) {}
@@ -186,8 +185,7 @@ Result<std::shared_ptr<Buffer>> AllocateBitmap(int64_t length, MemoryPool* pool)
   if (buf->size() > 0) {
     buf->mutable_data()[buf->size() - 1] = 0;
   }
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(buf));
+  return buf;
 }
 
 Result<std::shared_ptr<Buffer>> AllocateEmptyBitmap(int64_t length, MemoryPool* pool) {
@@ -199,8 +197,7 @@ Result<std::shared_ptr<Buffer>> AllocateEmptyBitmap(int64_t length, int64_t alig
   ARROW_ASSIGN_OR_RAISE(auto buf,
                         AllocateBuffer(bit_util::BytesForBits(length), alignment, pool));
   memset(buf->mutable_data(), 0, static_cast<size_t>(buf->size()));
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(buf));
+  return buf;
 }
 
 Result<std::shared_ptr<Buffer>> ConcatenateBuffers(
@@ -218,8 +215,7 @@ Result<std::shared_ptr<Buffer>> ConcatenateBuffers(
       out_data += buffer->size();
     }
   }
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(out));
+  return out;
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -706,8 +706,7 @@ const FunctionOptionsType* GetFunctionOptionsType(const Properties&... propertie
       auto options = std::make_unique<Options>();
       RETURN_NOT_OK(
           FromStructScalarImpl<Options>(options.get(), scalar, properties_).status_);
-      // R build with openSUSE155 requires an explicit unique_ptr construction
-      return std::unique_ptr<FunctionOptions>(std::move(options));
+      return options;
     }
     std::unique_ptr<FunctionOptions> Copy(const FunctionOptions& options) const override {
       auto out = std::make_unique<Options>();

--- a/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
@@ -159,10 +159,7 @@ Result<std::unique_ptr<KernelState>> PivotInit(KernelContext* ctx,
   const auto& options = checked_cast<const PivotWiderOptions&>(*args.options);
   auto state = std::make_unique<PivotImpl>();
   RETURN_NOT_OK(state->Init(options, args.inputs, ctx->exec_context()));
-  // GH-45718: This can be simplified once we drop the R openSUSE155 crossbow
-  // job
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::unique_ptr<KernelState>(std::move(state));
+  return state;
 }
 
 Result<TypeHolder> ResolveOutputType(KernelContext* ctx, const std::vector<TypeHolder>&) {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_internal.h
@@ -55,8 +55,7 @@ Result<std::unique_ptr<KernelState>> HashAggregateInit(KernelContext* ctx,
                                                        const KernelInitArgs& args) {
   auto impl = std::make_unique<Impl>();
   RETURN_NOT_OK(impl->Init(ctx->exec_context(), args));
-  // R build with openSUSE155 requires an explicit unique_ptr construction
-  return std::unique_ptr<KernelState>(std::move(impl));
+  return impl;
 }
 
 inline Status HashAggregateResize(KernelContext* ctx, int64_t num_groups) {

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -533,8 +533,7 @@ Result<std::unique_ptr<KernelState>> HashInit(KernelContext* ctx,
   auto result = std::make_unique<HashKernel>(args.inputs[0].GetSharedPtr(), args.options,
                                              ctx->memory_pool());
   RETURN_NOT_OK(result->Reset());
-  // R build with openSUSE155 requires an explicit unique_ptr construction
-  return std::unique_ptr<KernelState>(std::move(result));
+  return result;
 }
 
 template <typename Action>

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -512,8 +512,7 @@ Result<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
   ARROW_ASSIGN_OR_RAISE(auto arrow_reader,
                         parquet::arrow::FileReader::Make(options->pool, std::move(reader),
                                                          std::move(arrow_properties)));
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<parquet::arrow::FileReader>(std::move(arrow_reader));
+  return arrow_reader;
 }
 
 Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReaderAsync(
@@ -532,37 +531,37 @@ Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
                                          source.filesystem(), options->pool);
   auto self = checked_pointer_cast<const ParquetFileFormat>(shared_from_this());
 
-  return source.OpenAsync().Then([self = self, properties = std::move(properties),
-                                  source = source, options = options, metadata = metadata,
-                                  parquet_scan_options = parquet_scan_options](
-                                     const std::shared_ptr<io::RandomAccessFile>&
-                                         input) mutable {
-    return parquet::ParquetFileReader::OpenAsync(input, properties, metadata)
-        .Then(
-            [=](const std::unique_ptr<parquet::ParquetFileReader>& reader) mutable
-            -> Result<std::shared_ptr<parquet::arrow::FileReader>> {
-              auto arrow_properties = MakeArrowReaderProperties(
-                  *self, *reader->metadata(), *options, *parquet_scan_options);
-
-              ARROW_ASSIGN_OR_RAISE(
-                  auto arrow_reader,
-                  parquet::arrow::FileReader::Make(
-                      options->pool,
-                      // TODO(ARROW-12259): workaround since we have Future<(move-only
-                      // type)> It *wouldn't* be safe to const_cast reader except that
-                      // here we know there are no other waiters on the reader.
-                      std::move(const_cast<std::unique_ptr<parquet::ParquetFileReader>&>(
-                          reader)),
-                      arrow_properties));
-
-              // R build with openSUSE155 requires an explicit shared_ptr construction
-              return std::shared_ptr<parquet::arrow::FileReader>(std::move(arrow_reader));
-            },
-            [path = source.path()](const Status& status)
+  return source.OpenAsync().Then(
+      [self = self, properties = std::move(properties), source = source,
+       options = options, metadata = metadata,
+       parquet_scan_options = parquet_scan_options](
+          const std::shared_ptr<io::RandomAccessFile>& input) mutable {
+        return parquet::ParquetFileReader::OpenAsync(input, properties, metadata)
+            .Then(
+                [=](const std::unique_ptr<parquet::ParquetFileReader>& reader) mutable
                 -> Result<std::shared_ptr<parquet::arrow::FileReader>> {
-              return WrapSourceError(status, path);
-            });
-  });
+                  auto arrow_properties = MakeArrowReaderProperties(
+                      *self, *reader->metadata(), *options, *parquet_scan_options);
+
+                  ARROW_ASSIGN_OR_RAISE(
+                      auto arrow_reader,
+                      parquet::arrow::FileReader::Make(
+                          options->pool,
+                          // TODO(ARROW-12259): workaround since we have Future<(move-only
+                          // type)> It *wouldn't* be safe to const_cast reader except that
+                          // here we know there are no other waiters on the reader.
+                          std::move(
+                              const_cast<std::unique_ptr<parquet::ParquetFileReader>&>(
+                                  reader)),
+                          arrow_properties));
+
+                  return arrow_reader;
+                },
+                [path = source.path()](const Status& status)
+                    -> Result<std::shared_ptr<parquet::arrow::FileReader>> {
+                  return WrapSourceError(status, path);
+                });
+      });
 }
 
 struct SlicingGenerator {

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1605,8 +1605,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
       DCHECK_LE(bytes_read, nbytes);
       RETURN_NOT_OK(buf->Resize(bytes_read));
     }
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(buf));
+    return buf;
   }
 
   Result<int64_t> Read(int64_t nbytes, void* out) override {

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -452,8 +452,7 @@ class BufferedInputStream::Impl : public BufferedBase {
       RETURN_NOT_OK(buffer->Resize(bytes_read, false /* shrink_to_fit */));
       buffer->ZeroPadding();
     }
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(buffer));
+    return buffer;
   }
 
   // For providing access to the raw file handles

--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -411,8 +411,7 @@ class CompressedInputStream::Impl {
     ARROW_ASSIGN_OR_RAISE(auto buf, AllocateResizableBuffer(nbytes, pool_));
     ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, Read(nbytes, buf->mutable_data()));
     RETURN_NOT_OK(buf->Resize(bytes_read));
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(buf));
+    return buf;
   }
 
   const std::shared_ptr<InputStream>& raw() const { return raw_; }

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -172,8 +172,7 @@ class HdfsReadableFile::HdfsReadableFileImpl : public HdfsAnyFileImpl {
       RETURN_NOT_OK(buffer->Resize(bytes_read));
       buffer->ZeroPadding();
     }
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(buffer));
+    return buffer;
   }
 
   Result<int64_t> Read(int64_t nbytes, void* buffer) {
@@ -201,8 +200,7 @@ class HdfsReadableFile::HdfsReadableFileImpl : public HdfsAnyFileImpl {
     if (bytes_read < nbytes) {
       RETURN_NOT_OK(buffer->Resize(bytes_read));
     }
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(buffer));
+    return buffer;
   }
 
   Result<int64_t> GetSize() {

--- a/cpp/src/arrow/io/stdio.cc
+++ b/cpp/src/arrow/io/stdio.cc
@@ -85,8 +85,7 @@ Result<std::shared_ptr<Buffer>> StdinStream::Read(int64_t nbytes) {
   ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, Read(nbytes, buffer->mutable_data()));
   ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read, false));
   buffer->ZeroPadding();
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(buffer));
+  return buffer;
 }
 
 }  // namespace io

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -238,8 +238,7 @@ static inline Result<std::shared_ptr<Buffer>> WriteFlatbufferBuilder(
 
   uint8_t* dst = result->mutable_data();
   memcpy(dst, fbb.GetBufferPointer(), size);
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(result));
+  return result;
 }
 
 ARROW_EXPORT

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -573,8 +573,7 @@ Result<std::shared_ptr<Buffer>> DecompressBuffer(const std::shared_ptr<Buffer>& 
                            actual_decompressed);
   }
 
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(uncompressed));
+  return uncompressed;
 }
 
 Status DecompressBuffers(Compression::type compression, const IpcReadOptions& options,

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1587,8 +1587,7 @@ Result<std::unique_ptr<RecordBatchWriter>> OpenRecordBatchWriter(
   auto writer = std::make_unique<internal::IpcFormatWriter>(
       std::move(sink), schema, options, /*is_file_format=*/false);
   RETURN_NOT_OK(writer->Start());
-  // R build with openSUSE155 requires an explicit unique_ptr construction
-  return std::unique_ptr<RecordBatchWriter>(std::move(writer));
+  return writer;
 }
 
 Result<std::unique_ptr<IpcPayloadWriter>> MakePayloadStreamWriter(

--- a/cpp/src/arrow/util/align_util.cc
+++ b/cpp/src/arrow/util/align_util.cc
@@ -166,8 +166,7 @@ Result<std::shared_ptr<Buffer>> EnsureAlignment(std::shared_ptr<Buffer> buffer,
         auto new_buffer,
         AllocateBuffer(buffer->size(), minimum_desired_alignment, memory_pool));
     std::memcpy(new_buffer->mutable_data(), buffer->data(), buffer->size());
-    // R build with openSUSE155 requires an explicit shared_ptr construction
-    return std::shared_ptr<Buffer>(std::move(new_buffer));
+    return new_buffer;
   } else {
     return buffer;
   }

--- a/cpp/src/arrow/util/bitmap_builders.cc
+++ b/cpp/src/arrow/util/bitmap_builders.cc
@@ -52,8 +52,7 @@ Result<std::shared_ptr<Buffer>> BytesToBits(std::span<const uint8_t> bytes,
   uint8_t* out_buf = buffer->mutable_data();
   memset(out_buf, 0, static_cast<size_t>(buffer->capacity()));
   FillBitsFromBytes(bytes, out_buf);
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(buffer));
+  return buffer;
 }
 
 Result<std::shared_ptr<Buffer>> BitmapAllButOne(MemoryPool* pool, int64_t length,
@@ -68,8 +67,7 @@ Result<std::shared_ptr<Buffer>> BitmapAllButOne(MemoryPool* pool, int64_t length
   auto bitmap_data = buffer->mutable_data();
   bit_util::SetBitsTo(bitmap_data, 0, length, value);
   bit_util::SetBitTo(bitmap_data, straggler_pos, !value);
-  // R build with openSUSE155 requires an explicit shared_ptr construction
-  return std::shared_ptr<Buffer>(std::move(buffer));
+  return buffer;
 }
 
 }  // namespace internal


### PR DESCRIPTION
### Rationale for this change

Apache Arrow no longer supports the OpenSUSE 15.5 build configuration that required explicit `shared_ptr` and `unique_ptr` constructions.

This PR removes obsolete OpenSUSE 15.5-specific workarounds and simplifies the affected return statements by relying on standard implicit conversions.

### What changes are included in this PR?

* Removed OpenSUSE 15.5-specific workaround comments.
* Replaced explicit `std::shared_ptr<T>(std::move(...))` constructions with direct returns.
* Replaced explicit `std::unique_ptr<T>(std::move(...))` constructions with direct returns.
* Simplified code in the affected Arrow C++ source files without changing functionality.

### Are these changes tested?

Yes.

The changes were verified by building the affected components and running the relevant compute test suite:

```bash
ninja arrow-compute-tests
ctest -R "arrow-compute" --output-on-failure
```

All tests passed successfully.

### Are there any user-facing changes?

No. This change is an internal code cleanup and does not affect public APIs, behavior, or user-facing functionality.

* GitHub Issue: #50236