### PR TITLE
GH-50257: [CI][Docs] Fix doxygen failing due to double backticks

### DIFF
--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -191,7 +191,7 @@ struct CopyBitsParams {
 ///
 /// Copy bits [start, end[ from src into the position [start, end[ in dst
 /// and return the result (inputs are unmodified).
-/// Setting ``kAllowFullCopy`` to false is an optimization when the caller can
+/// Setting `kAllowFullCopy` to false is an optimization when the caller can
 /// guarantee that the range of bits to copy does not cover the whole range.
 template <typename Uint, bool kAllowFullCopy = true>
 [[nodiscard]] constexpr Uint CopyBitsInInteger(const CopyBitsParams<Uint>& params) {


### PR DESCRIPTION
### Rationale for this change

Doxygen is currently failing on main

### What changes are included in this PR?

Remove double backticks because they trip doxygen.

### Are these changes tested?

I have tested them locally with:
`archery docker run conda-python-docs`

Without the change I could reproduce the CI issue. With the change the job is successful.

### Are there any user-facing changes?

No

* GitHub Issue: #50257