### PR TITLE
GH-50231: [C++] Handle unset Substrait extension mapping type

### DIFF
--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1552,6 +1552,35 @@ TEST(Substrait, InvalidMinimumVersion) {
   ASSERT_RAISES(Invalid, DeserializePlans(*buf, [] { return kNullConsumer; }));
 }
 
+TEST(Substrait, InvalidEmptyExtensionDeclaration) {
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
+    "version": { "major_number": 9999, "minor_number": 9999, "patch_number": 9999 },
+    "relations": [{
+      "rel": {
+        "read": {
+          "base_schema": {
+            "names": ["A"],
+            "struct": {
+              "types": [{
+                "i32": {}
+              }]
+            }
+          },
+          "named_table": {
+            "names": ["x"]
+          }
+        }
+      }
+    }],
+    "extensionUris": [],
+    "extensions": [
+      {}
+    ]
+  })"));
+
+  ASSERT_RAISES(Invalid, DeserializePlans(*buf, [] { return kNullConsumer; }));
+}
+
 TEST(Substrait, JoinPlanBasic) {
   std::string substrait_json = R"({
   "version": { "major_number": 9999, "minor_number": 9999, "patch_number": 9999 },

--- a/cpp/src/arrow/engine/substrait/util_internal.h
+++ b/cpp/src/arrow/engine/substrait/util_internal.h
@@ -79,7 +79,9 @@ Result<ExtensionSet> GetExtensionSetFromMessage(
       }
 
       default:
-        Unreachable();
+        return Status::Invalid(
+            "Invalid Substrait SimpleExtensionDeclaration: mapping_type is unset or "
+            "unknown");
     }
   }
 


### PR DESCRIPTION
### Rationale for this change

A malformed Substrait `SimpleExtensionDeclaration` with an unset `mapping_type` currently reaches `Unreachable()`, causing the process to abort during deserialization. Since this can be triggered by malformed input, the deserializer should instead return an `Invalid` status.

### What changes are included in this PR?

* Replace the `Unreachable()` call in `GetExtensionSetFromMessage` with a `Status::Invalid` return for unset or unknown `mapping_type` values.
* Add a regression test to verify that deserializing a Substrait plan containing an empty `SimpleExtensionDeclaration` returns an `Invalid` status instead of aborting.

### Are these changes tested?

Yes. A regression test covering the malformed `SimpleExtensionDeclaration` case has been added to `serde_test.cc`.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".**

This change prevents process termination when deserializing malformed Substrait plans or expressions by returning a proper error instead of calling `std::abort()`.

* GitHub Issue: #50231