### PR TITLE
MINOR: [Docs] Remove indent from _compute.pyx

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2274,7 +2274,7 @@ class SortOptions(_SortOptions):
         The field name can be a string column name or expression.
     null_placement : str | None, default None
         Where nulls in input should be sorted, overwrites
-         `null_placement` in `sort_keys`.
+        `null_placement` in `sort_keys`.
         Accepted values are "at_start", "at_end".
     """
 


### PR DESCRIPTION
### Rationale for this change
To avoid the following warning in Sphinx building [html]:
`docstring of pyarrow._compute.SortOptions:17: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]`
(example [log1](https://github.com/apache/arrow/actions/runs/27986965171/job/82830648258#step:7:5343), [log2](https://github.com/apache/arrow/actions/runs/28172749827/job/83440967201#step:6:3984))
### What changes are included in this PR?
Remove incorrect indent.
### Are these changes tested?
Yes, docs built locally.
### Are there any user-facing changes?
No.