### PR TITLE
GH-50277: [CI][Python] Avoid using generators for test parametrization on newer Pytest

### DIFF
--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -38,9 +38,10 @@ def backend_factory(backend_name):
 
 
 def supported_factories():
-    yield pa.default_memory_pool
+    factories = [pa.default_memory_pool]
     for backend_name in pa.supported_memory_backends():
-        yield backend_factory(backend_name)
+        factories.append(backend_factory(backend_name))
+    return factories
 
 
 @contextlib.contextmanager

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -39,9 +39,7 @@ def backend_factory(backend_name):
 
 def supported_factories():
     factories = [pa.default_memory_pool]
-    for backend_name in pa.supported_memory_backends():
-        factories.append(backend_factory(backend_name))
-    return factories
+    return factories + [backend_factory(bn) for bn in pa.supported_memory_backends()]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
### Rationale for this change

On the hypothesis tests we treat Warnings as errors and the job has been failing with the latest Pytest version (9.1.0). This is related to:
- https://github.com/pytest-dev/pytest/issues/13409

With the latest pytest using generators for parametrization has been deprecated.

### What changes are included in this PR?

Change the generator that was causing the failures and return a list of supported_factories instead.

### Are these changes tested?

Yes both locally and the archery test that was failing.

### Are there any user-facing changes?

No

* GitHub Issue: #50277