### PR TITLE
GH-50283: [CI][Ruby] Switch caching to apache/infrastructure-actions/stash

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -59,6 +59,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -104,9 +105,15 @@ jobs:
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run \
-            -e ARROW_FLIGHT=ON \
-            -e ARROW_FLIGHT_SQL=ON \
-            -e ARROW_GCS=ON \
+            -e ARROW_AZURE=OFF \
+            -e ARROW_FLIGHT=OFF \
+            -e ARROW_FLIGHT_SQL=OFF \
+            -e ARROW_GANDIVA=OFF \
+            -e ARROW_GCS=OFF \
+            -e ARROW_ORC=OFF \
+            -e ARROW_S3=OFF \
+            -e ARROW_SUBSTRAIT=OFF \
+            -e ARROW_WITH_OPENTELEMETRY=OFF \
             -e nlohmann_json_SOURCE=BUNDLED \
             -e Protobuf_SOURCE=BUNDLED \
             -e gRPC_SOURCE=BUNDLED \
@@ -381,7 +388,7 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_ZLIB: ON
       ARROW_WITH_ZSTD: ON
-      CCACHE_DIR: /ccache
+      CCACHE_DIR: C:/ccache
       CMAKE_CXX_STANDARD: "20"
       CMAKE_GENERATOR: Ninja
       CMAKE_INSTALL_PREFIX: "${{ github.workspace }}/dist"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -105,15 +105,9 @@ jobs:
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run \
-            -e ARROW_AZURE=OFF \
-            -e ARROW_FLIGHT=OFF \
-            -e ARROW_FLIGHT_SQL=OFF \
-            -e ARROW_GANDIVA=OFF \
-            -e ARROW_GCS=OFF \
-            -e ARROW_ORC=OFF \
-            -e ARROW_S3=OFF \
-            -e ARROW_SUBSTRAIT=OFF \
-            -e ARROW_WITH_OPENTELEMETRY=OFF \
+            -e ARROW_FLIGHT=ON \
+            -e ARROW_FLIGHT_SQL=ON \
+            -e ARROW_GCS=ON \
             -e nlohmann_json_SOURCE=BUNDLED \
             -e Protobuf_SOURCE=BUNDLED \
             -e gRPC_SOURCE=BUNDLED \

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -86,12 +86,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@v6
+      - name: Restore Docker Volumes
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: .docker
-          key: ubuntu-${{ matrix.ubuntu }}-ruby-${{ hashFiles('cpp/**') }}
-          restore-keys: ubuntu-${{ matrix.ubuntu }}-ruby-
+          key: ruby-ubuntu-${{ matrix.ubuntu }}
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -112,6 +111,14 @@ jobs:
             -e Protobuf_SOURCE=BUNDLED \
             -e gRPC_SOURCE=BUNDLED \
             ubuntu-ruby
+      - name: Save Docker Volumes
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: .docker
+          key: ruby-ubuntu-${{ matrix.ubuntu }}
+          include-hidden-files: true
       - name: Docker Push
         if: >-
           success() &&
@@ -186,20 +193,26 @@ jobs:
           ci/scripts/ccache_setup.sh
       - name: ccache info
         id: ccache-info
-        run: |
-          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v6
+        shell: bash
+        run: echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: ruby-ccache-macos-${{ hashFiles('cpp/**') }}
-          restore-keys: ruby-ccache-macos-
+          key: ruby-ccache-macos
       - name: Build C++
         run: |
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Build GLib
         run: |
           ci/scripts/c_glib_build.sh $(pwd) $(pwd)/build
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: ruby-ccache-macos
       - name: Test GLib
         shell: bash
         run: ci/scripts/c_glib_test.sh $(pwd) $(pwd)/build
@@ -268,12 +281,15 @@ jobs:
       - name: Setup MSYS2
         run: |
           ridk exec bash ci\scripts\msys2_setup.sh ruby
-      - name: Cache ccache
-        uses: actions/cache@v6
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
-          path: ccache
-          key: ruby-ccache-ucrt${{ matrix.mingw-n-bits }}-${{ hashFiles('cpp/**') }}
-          restore-keys: ruby-ccache-ucrt${{ matrix.mingw-n-bits }}-
+          # CCACHE_DIR is set by `msys2_setup.sh`
+          path: ${{ env.CCACHE_DIR }}
+          key: ruby-ccache-ucrt${{ matrix.mingw-n-bits }}
+      - name: Show ccache config
+        run: |
+          ccache --show-config
       - name: Build C++
         run: |
           $Env:CMAKE_BUILD_PARALLEL_LEVEL = $Env:NUMBER_OF_PROCESSORS
@@ -287,6 +303,13 @@ jobs:
           $build_dir = "$(ridk exec cygpath --unix "$(Get-Location)\build")"
           $ErrorActionPreference = "Continue"
           ridk exec bash ci\scripts\c_glib_build.sh "${source_dir}" "${build_dir}"
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ruby-ccache-ucrt${{ matrix.mingw-n-bits }}
       - name: RubyGems info
         id: rubygems-info
         run: |
@@ -358,6 +381,7 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_ZLIB: ON
       ARROW_WITH_ZSTD: ON
+      CCACHE_DIR: /ccache
       CMAKE_CXX_STANDARD: "20"
       CMAKE_GENERATOR: Ninja
       CMAKE_INSTALL_PREFIX: "${{ github.workspace }}/dist"
@@ -391,20 +415,14 @@ jobs:
         shell: bash
         run: |
           ci/scripts/ccache_setup.sh
-      - name: ccache info
-        id: ccache-info
-        shell: bash
-        run: |
-          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v6
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: glib-ccache-msvc-${{ env.CACHE_VERSION }}-${{ hashFiles('cpp/**') }}
-          restore-keys: glib-ccache-msvc-${{ env.CACHE_VERSION }}-
-        env:
-          # We can invalidate the current cache by updating this.
-          CACHE_VERSION: "2024-05-09"
+          path: ${{ env.CCACHE_DIR }}
+          key: ruby-ccache-msvc
+      - name: Show ccache config
+        run: |
+          ccache --show-config
       - name: Checkout vcpkg
         uses: actions/checkout@v7
         with:
@@ -447,3 +465,10 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           set VCPKG_ROOT=%VCPKG_ROOT_KEEP%
           bash -c "ci/scripts/c_glib_build.sh $(pwd) $(pwd)/build"
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ruby-ccache-msvc

--- a/ci/scripts/ccache_fix_perms.sh
+++ b/ci/scripts/ccache_fix_perms.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eux
+
+# Some builds such as C/GLib seem to use a different umask at some point,
+# and the ccache files end up not world-readable which can prevent caching on GHA.
+
+cache_dir=$(ccache --get-config cache_dir)
+
+find ${cache_dir} -type f -exec chmod 644 {} \;

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -75,6 +75,8 @@ if [ "${ARROW_ENABLE_THREADING:-ON}" = "OFF" ]; then
 fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
+    echo -e "===\n=== ccache configuration\n==="
+    ccache --show-config
     echo -e "===\n=== ccache statistics before build\n==="
     ccache -sv 2>/dev/null || ccache -s
 fi

--- a/compose.yaml
+++ b/compose.yaml
@@ -901,7 +901,8 @@ services:
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/c_glib_build.sh /arrow /build &&
         /arrow/ci/scripts/c_glib_test.sh /arrow /build &&
-        /arrow/ci/scripts/ruby_test.sh /arrow /build"
+        /arrow/ci/scripts/ruby_test.sh /arrow /build &&
+        /arrow/ci/scripts/ccache_fix_perms.sh"
 
   ubuntu-ruby:
     # Usage:


### PR DESCRIPTION
### Rationale for this change

`apache/infrastructure-actions/stash` benefits from much greater size limits than `actions/cache`, so our compilation cache stands a greater chance of not being evicted by the next time a build runs.

### Are these changes tested?

By the affected CI jobs.

### Are there any user-facing changes?

No.


* GitHub Issue: #50283