### PR TITLE
GH-47877: [Packaging][C++][FlightRPC][ODBC] Add arrow-flight-sql-odbc

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -258,6 +258,10 @@ if [ "${have_flight}" = "yes" ]; then
     ruby -r gi -e "p GI.load('ArrowFlightSQL')"
   fi
   echo "::endgroup::"
+
+  echo "::group::Test Apache Arrow Flight SQL ODBC driver"
+  ${install_command} ${enablerepo_epel} arrow-flight-sql-odbc-devel-${package_version}
+  echo "::endgroup::"
 fi
 
 if [ "${have_gandiva}" = "yes" ]; then

--- a/dev/tasks/linux-packages/apache-arrow/yum/almalinux-10/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/almalinux-10/Dockerfile
@@ -59,6 +59,7 @@ RUN \
     snappy-devel \
     tar \
     thrift-devel \
+    unixODBC-devel \
     utf8proc-devel \
     vala \
     which \

--- a/dev/tasks/linux-packages/apache-arrow/yum/almalinux-8/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/almalinux-8/Dockerfile
@@ -63,6 +63,7 @@ RUN \
     snappy-devel \
     tar \
     thrift-devel \
+    unixODBC-devel \
     # utf8proc-devel \
     vala \
     which \

--- a/dev/tasks/linux-packages/apache-arrow/yum/almalinux-9/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/almalinux-9/Dockerfile
@@ -60,6 +60,7 @@ RUN \
     snappy-devel \
     tar \
     thrift-devel \
+    unixODBC-devel \
     utf8proc-devel \
     vala \
     which \

--- a/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023/Dockerfile
@@ -57,6 +57,7 @@ RUN \
     rpmdevtools \
     snappy-devel \
     tar \
+    unixODBC-devel \
     utf8proc-devel \
     vala \
     which \

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -114,6 +114,7 @@ BuildRequires:	snappy-devel
 %if %{have_thrift}
 BuildRequires:	thrift-devel
 %endif
+BuildRequires:	unixODBC-devel
 %if %{have_utf8proc}
 BuildRequires:	utf8proc-devel
 %endif
@@ -144,6 +145,7 @@ cd cpp
   -DARROW_DATASET=ON \
   -DARROW_FLIGHT=ON \
   -DARROW_FLIGHT_SQL=ON \
+  -DARROW_FLIGHT_SQL_ODBC=ON \
   -DARROW_GANDIVA=ON \
 %if %{use_gcs}
   -DARROW_GCS=ON \
@@ -472,7 +474,7 @@ This package contains the libraries for Apache Arrow Flight SQL.
 Summary:	Libraries and header files for Apache Arrow Flight SQL.
 License:	Apache-2.0
 Requires:	%{name}%{so_version}-flight-sql-libs = %{version}-%{release}
-Requires:	%{name}-devel = %{version}-%{release}
+Requires:	%{name}-flight-devel = %{version}-%{release}
 
 %description flight-sql-devel
 Libraries and header files for Apache Arrow Flight SQL.
@@ -482,10 +484,45 @@ Libraries and header files for Apache Arrow Flight SQL.
 %doc README.md
 %license LICENSE.txt NOTICE.txt
 %{_includedir}/arrow/flight/sql/
+%exclude %{_includedir}/arrow/flight/sql/odbc/
 %{_libdir}/cmake/ArrowFlightSql/
 %{_libdir}/libarrow_flight_sql.a
 %{_libdir}/libarrow_flight_sql.so
 %{_libdir}/pkgconfig/arrow-flight-sql.pc
+
+%package -n %{name}%{so_version}-flight-sql-odbc-libs
+Summary:	C++ library for interacting with SQL databases via ODBC.
+License:	Apache-2.0
+Requires:	%{name}%{so_version}-flight-sql-libs = %{version}-%{release}
+
+%description -n %{name}%{so_version}-flight-sql-odbc-libs
+This package contains the libraries for Apache Arrow Flight SQL ODBC driver.
+
+%files -n %{name}%{so_version}-flight-sql-odbc-libs
+%defattr(-,root,root,-)
+%doc README.md
+%license LICENSE.txt NOTICE.txt
+%{_libdir}/libarrow_flight_sql_odbc.so.*
+
+%package flight-sql-odbc-devel
+Summary:	Libraries and header files for Apache Arrow Flight SQL ODBC driver.
+License:	Apache-2.0
+Requires:	%{name}%{so_version}-flight-sql-odbc-libs = %{version}-%{release}
+Requires:	%{name}-flight-sql-devel = %{version}-%{release}
+Requires:	unixODBC-devel
+
+%description flight-sql-odbc-devel
+Libraries and header files for Apache Arrow Flight SQL ODBC driver.
+
+%files flight-sql-odbc-devel
+%defattr(-,root,root,-)
+%doc README.md
+%license LICENSE.txt NOTICE.txt
+%{_includedir}/arrow/flight/sql/odbc/
+%{_libdir}/cmake/ArrowFlightSqlOdbc/
+%{_libdir}/libarrow_flight_sql_odbc.a
+%{_libdir}/libarrow_flight_sql_odbc.so
+%{_libdir}/pkgconfig/arrow-flight-sql-odbc.pc
 
 %package -n gandiva%{so_version}-libs
 Summary:	C++ library for compiling and evaluating expressions on Apache Arrow data.

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
@@ -57,6 +57,7 @@ RUN \
     snappy-devel \
     tar \
     thrift-devel \
+    unixODBC-devel \
     utf8proc-devel \
     vala \
     which \


### PR DESCRIPTION
### Rationale for this change

If we provide RPM for Flight SQL ODBC driver, users can install it easily. 

### What changes are included in this PR?

* Add `arrow${MAJOR_VERSION}-flight-sql-odbc-libs`
* Add `arrow-flight-sql-odbc-devel`

### Are these changes tested?

No.

We need to generate configuration files but it's out-of-scope of this PR. We need to work on it as a separated task.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47877