### PR TITLE
GH-50294: [C++][R] Missing typename in ulp_distance.cc breaks clang-15 builds

### DIFF
--- a/cpp/src/arrow/util/ulp_distance.cc
+++ b/cpp/src/arrow/util/ulp_distance.cc
@@ -50,7 +50,7 @@ struct FloatToUInt<util::Float16> {
 template <typename Float>
 struct UlpDistanceUtil {
  public:
-  using UIntType = FloatToUInt<Float>::Type;
+  using UIntType = typename FloatToUInt<Float>::Type;
   static constexpr UIntType kNumberOfBits = sizeof(Float) * 8;
   static constexpr UIntType kSignMask = static_cast<UIntType>(1) << (kNumberOfBits - 1);
 


### PR DESCRIPTION
### Rationale for this change

Broken nightlies due to older clang version on CRAN

### What changes are included in this PR?

Add `typename` explicitly

### Are these changes tested?

Will run CI

### Are there any user-facing changes?

No
* GitHub Issue: #50294