### PR TITLE
GH-50298: [CI][R] Update ubuntu-clang CI job to use clang 22 to match CRAN

### DIFF
--- a/ci/docker/linux-r.dockerfile
+++ b/ci/docker/linux-r.dockerfile
@@ -33,6 +33,9 @@ ENV R_PRUNE_DEPS=${r_prune_deps}
 ARG r_custom_ccache=false
 ENV R_CUSTOM_CCACHE=${r_custom_ccache}
 
+ARG r_update_clang=false
+ENV R_UPDATE_CLANG=${r_update_clang}
+
 ARG tz="UTC"
 ENV TZ=${tz}
 

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -86,5 +86,17 @@ else
 fi
 
 
+# Update clang version to latest available.
+# The rhub/ubuntu-clang image ships clang-15 but CRAN's debian-clang now uses
+# clang 22. Install clang-22 from LLVM's apt repos to match.
+if [ "$R_UPDATE_CLANG" = true ]; then
+  apt-get update -y --allow-releaseinfo-change
+  apt-get install -y gnupg
+  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg
+  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-22 main" > /etc/apt/sources.list.d/llvm22.list
+  apt-get update -y --allow-releaseinfo-change
+  apt-get install -y clang-22 lld-22
+fi
+
 # Workaround for html help install failure; see https://github.com/r-lib/devtools/issues/2084#issuecomment-530912786
 Rscript -e 'x <- file.path(R.home("doc"), "html"); if (!file.exists(x)) {dir.create(x, recursive=TRUE); file.copy(system.file("html/R.css", package="stats"), x)}'

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -93,9 +93,14 @@ if [ "$R_UPDATE_CLANG" = true ]; then
   apt-get update -y --allow-releaseinfo-change
   apt-get install -y gnupg
   curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg
-  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-22 main" > /etc/apt/sources.list.d/llvm22.list
+  echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-22 main" > /etc/apt/sources.list.d/llvm22.list
   apt-get update -y --allow-releaseinfo-change
   apt-get install -y clang-22 lld-22
+  # The rhub image hardcodes clang-15/clang++-15 in R's Makeconf, so installing
+  # clang-22 alone isn't enough: point R at the new compilers.
+  sed -i 's/clang++-15/clang++-22/g; s/clang-15/clang-22/g' "$(R RHOME)/etc/Makeconf"
+  echo "R is now using CC=$(R CMD config CC) CXX=$(R CMD config CXX)"
+  clang-22 --version
 fi
 
 # Workaround for html help install failure; see https://github.com/r-lib/devtools/issues/2084#issuecomment-530912786

--- a/compose.yaml
+++ b/compose.yaml
@@ -1685,6 +1685,7 @@ services:
         tz: ${TZ}
         r_prune_deps: ${R_PRUNE_DEPS}
         r_custom_ccache: ${R_CUSTOM_CCACHE}
+        r_update_clang: ${R_UPDATE_CLANG}
     shm_size: *shm-size
     environment:
       <<: [*common, *sccache]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1684,6 +1684,7 @@ services:
         tz: ${TZ}
         r_prune_deps: ${R_PRUNE_DEPS}
         r_custom_ccache: ${R_CUSTOM_CCACHE}
+        r_update_clang: ${R_UPDATE_CLANG}
     shm_size: *shm-size
     environment:
       <<: [*common, *sccache]

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -30,7 +30,7 @@ jobs:
         config:
           # See https://r-hub.github.io/containers/
           - { r_image: "ubuntu-gcc12" }  # ~ r-devel-linux-x86_64-debian-gcc
-          - { r_image: "ubuntu-clang" }  # ~ r-devel-linux-x86_64-debian-clang
+          - { r_image: "ubuntu-clang", r_update_clang: true }  # ~ r-devel-linux-x86_64-debian-clang
           - { r_image: "ubuntu-next" }  # ~ r-patched-linux-x86_64
           - { r_image: "ubuntu-release" }  # ~ r-release-linux-x86_64
           - { r_image: "clang22", skip_vignettes: true }  # ~ r-devel-linux-x86_64-fedora-clang
@@ -39,6 +39,7 @@ jobs:
       R_IMAGE: {{ '${{ matrix.config.r_image }}' }}
       R_TAG: "latest"
       ARROW_R_DEV: "FALSE"
+      R_UPDATE_CLANG: {{ '${{ matrix.config.r_update_clang }}' }}
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}


### PR DESCRIPTION
### Rationale for this change

CI clang version outdated, false positive failures against CRAN

### What changes are included in this PR?

Update clang manually

### Are these changes tested?

Will run CI

### Are there any user-facing changes?

No
* GitHub Issue: #50298