### PR TITLE
GH-50300: [C++][CI] Update include to generated/Message_generated.h so Meson is able to find 

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -551,9 +551,6 @@ message(STATUS "CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}: ${CMAKE_CXX_FLAGS_${UPP
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
 include_directories(src)
 
-# Compiled flatbuffers files
-include_directories(src/generated)
-
 #
 # Visibility
 #

--- a/cpp/src/arrow/ipc/message_internal_test.cc
+++ b/cpp/src/arrow/ipc/message_internal_test.cc
@@ -24,7 +24,7 @@
 
 #include <gtest/gtest.h>
 
-#include "Message_generated.h"
+#include "generated/Message_generated.h"
 
 #include "arrow/buffer.h"
 #include "arrow/io/memory.h"


### PR DESCRIPTION
### Rationale for this change

The meson job is currently failing due to not finding header for include on flatbuffers generated file. This works on CMake because we have: `include_directories(src/generated)` and didn't failed previously on Meson because we use the full `generated/xxx.h` path to the files on includes.

### What changes are included in this PR?

Add `generated` in the include so meson can also find the header without requiring to include directory.
Remove `include_directories(src/generated)` on CMake to match Meson configuration.

### Are these changes tested?

Yes, via CI

### Are there any user-facing changes?
No

* GitHub Issue: #50300