### PR TITLE
MINOR: [CI] Bump ccache version

### DIFF
--- a/.github/actions/odbc-windows/action.yml
+++ b/.github/actions/odbc-windows/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Install ccache
       shell: bash
       run: |
-        ci/scripts/install_ccache.sh 4.12.1 /usr
+        ci/scripts/install_ccache.sh 4.13.6 /usr
     - name: Setup ccache
       shell: bash
       run: |

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install ccache
         shell: bash
         run: |
-          ci/scripts/install_ccache.sh 4.12.1 /usr
+          ci/scripts/install_ccache.sh 4.13.6 /usr
       - name: Setup ccache
         shell: bash
         run: |

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -152,7 +152,7 @@ jobs:
           release: R2025b
       - name: Install ccache
         shell: bash
-        run: ci/scripts/install_ccache.sh 4.6.3 /usr
+        run: ci/scripts/install_ccache.sh 4.13.6 /usr
       - name: Setup ccache
         shell: bash
         run: ci/scripts/ccache_setup.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -265,7 +265,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     env:
-      CCACHE_DIR: /ccache
+      CCACHE_DIR: C:/ccache
       PYTHON_CMD: "py -3.13"
     steps:
       - name: Disable Crash Dialogs
@@ -289,7 +289,7 @@ jobs:
       - name: Install ccache
         shell: bash
         run: |
-          ci/scripts/install_ccache.sh 4.6.3 /usr
+          ci/scripts/install_ccache.sh 4.13.6 /usr
       - name: Setup ccache
         shell: bash
         run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -386,7 +386,7 @@ jobs:
       - name: Install ccache
         shell: bash
         run: |
-          ci/scripts/install_ccache.sh 4.6.3 /usr
+          ci/scripts/install_ccache.sh 4.13.6 /usr
       - name: Setup ccache
         shell: bash
         run: |

--- a/ci/docker/cpp-jni.dockerfile
+++ b/ci/docker/cpp-jni.dockerfile
@@ -54,7 +54,7 @@ COPY ci/scripts/install_ninja.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ninja.sh ${ninja} /usr/local
 
 # Install ccache
-ARG ccache=4.1
+ARG ccache=4.13.6
 COPY ci/scripts/install_ccache.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ccache.sh ${ccache} /usr/local
 

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -46,7 +46,7 @@ COPY ci/scripts/install_ninja.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ninja.sh ${ninja} /usr/local
 
 # Install ccache
-ARG ccache=4.1
+ARG ccache=4.13.6
 COPY ci/scripts/install_ccache.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ccache.sh ${ccache} /usr/local
 


### PR DESCRIPTION
### Rationale for this change

Bump the hardcoded ccache version that we install on CI builds. This might make builds faster if it allows more files to be cached.

### Are these changes tested?

By the corresponding CI builds.

### Are there any user-facing changes?

No.