### PR TITLE
GH-50291: [Python][Packaging] Stop using nightly build dependencies for building free-threaded wheels

### DIFF
--- a/ci/docker/python-free-threaded-wheel-manylinux-test-unittests.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-manylinux-test-unittests.dockerfile
@@ -41,11 +41,6 @@ RUN python${python_version}t -m venv ${ARROW_PYTHON_VENV}
 ENV PYTHON_GIL 0
 ENV PATH "${ARROW_PYTHON_VENV}/bin:${PATH}"
 
-# pandas doesn't provide wheels for aarch64 yet, so we have to install nightly Cython
-# along with the rest of pandas' build dependencies and disable build isolation
-RUN python -m pip install \
-    --pre \
-    --prefer-binary \
-    --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" \
-    Cython numpy
+COPY python/requirements-wheel-test.txt /arrow/python/
+RUN python -m pip install -r /arrow/python/requirements-wheel-test.txt
 RUN python -m pip install "meson-python==0.13.1" "meson==1.2.1" wheel "versioneer[toml]" ninja

--- a/ci/docker/python-free-threaded-wheel-musllinux-test-unittests.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-musllinux-test-unittests.dockerfile
@@ -56,11 +56,6 @@ ENV PATH "${ARROW_PYTHON_VENV}/bin:${PATH}"
 ENV TZDIR=/usr/share/zoneinfo
 RUN cp /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
-# pandas doesn't provide wheels for aarch64 yet, so we have to install nightly Cython
-# along with the rest of pandas' build dependencies and disable build isolation
-RUN python -m pip install \
-    --pre \
-    --prefer-binary \
-    --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" \
-    Cython numpy
+COPY python/requirements-wheel-test.txt /arrow/python/
+RUN python -m pip install -r /arrow/python/requirements-wheel-test.txt
 RUN python -m pip install "meson-python==0.13.1" "meson==1.2.1" wheel "versioneer[toml]" ninja

--- a/ci/docker/python-free-threaded-wheel-windows-test-vs2022.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-windows-test-vs2022.dockerfile
@@ -42,12 +42,7 @@ SHELL ["cmd", "/S", "/C"]
 RUN %PYTHON_CMD% -m pip install -U pip setuptools
 
 COPY python/requirements-wheel-test.txt C:/arrow/python/
-# Cython and Pandas wheels for free-threaded are not released yet
-RUN %PYTHON_CMD% -m pip install \
-    --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-    --pre \
-    --prefer-binary \
-    -r C:/arrow/python/requirements-wheel-test.txt
+RUN %PYTHON_CMD% -m pip install -r C:/arrow/python/requirements-wheel-test.txt
 
 ENV PYTHON="${python}t"
 ENV PYTHON_GIL=0


### PR DESCRIPTION
### Rationale for this change

We are currently using nightly wheels for Pandas and Cython for building free-threaded wheels. This is remnant from when there were not released wheels for those dependencies for free-threaded.

### What changes are included in this PR?

Stop using scientific-python-nightly-wheels channel for test dependencies for free threaded wheels

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No

* GitHub Issue: #50291