### PR TITLE
MINOR: [R] Adjust parallel::detectCores if NA to not break --parallel input in CMake

### DIFF
--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,7 +114,7 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-(unset MAKEFLAGS MFLAGS; ${CMAKE} --build . --target install -- -j "${N_JOBS}")
+(unset MAKEFLAGS MFLAGS; ${CMAKE} --build . --target install --parallel "${N_JOBS}")
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,7 +114,7 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-${CMAKE} --build . --target install -- -j $N_JOBS
+(unset MAKEFLAGS MFLAGS; ${CMAKE} --build . --target install -- -j "${N_JOBS}")
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,30 +114,10 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-sanitize_makeflags() {
-  printf '%s\n' "$1" |
-    sed -E \
-      -e 's/(^|[[:space:]])-j[[:space:]]+[0-9]*([[:space:]]|$)/ /g' \
-      -e 's/(^|[[:space:]])-j[^[:space:]]*([[:space:]]|$)/ /g' \
-      -e 's/(^|[[:space:]])([[:alpha:]]*)j[[:alnum:]]*([[:alpha:]]*)($|[[:space:]])/ \2\3 /g' \
-      -e 's/[[:space:]]+/ /g' \
-      -e 's/^ //; s/ $//'
-}
-
-env | sort
-SANITIZED_MAKEFLAGS="$(sanitize_makeflags "${MAKEFLAGS:-}")"
-SANITIZED_MFLAGS="$(sanitize_makeflags "${MFLAGS:-}")"
-SANITIZED_GNUMAKEFLAGS="$(sanitize_makeflags "${GNUMAKEFLAGS:-}")"
+SANITIZED_MAKEFLAGS="${MAKEFLAGS/-jNA/}"
 printf 'MAKEFLAGS before sanitize: %s\n' "${MAKEFLAGS:-}"
-printf 'MFLAGS before sanitize: %s\n' "${MFLAGS:-}"
-printf 'GNUMAKEFLAGS before sanitize: %s\n' "${GNUMAKEFLAGS:-}"
 printf 'MAKEFLAGS after sanitize: %s\n' "${SANITIZED_MAKEFLAGS}"
-printf 'MFLAGS after sanitize: %s\n' "${SANITIZED_MFLAGS}"
-printf 'GNUMAKEFLAGS after sanitize: %s\n' "${SANITIZED_GNUMAKEFLAGS}"
-MAKEFLAGS="${SANITIZED_MAKEFLAGS}" \
-MFLAGS="${SANITIZED_MFLAGS}" \
-GNUMAKEFLAGS="${SANITIZED_GNUMAKEFLAGS}" \
-  ${CMAKE} --build . --target install -- -j"${N_JOBS}"
+MAKEFLAGS="${SANITIZED_MAKEFLAGS}" ${CMAKE} --build . --target install -- -j"${N_JOBS}"
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,7 +114,7 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-(unset MAKEFLAGS MFLAGS; ${CMAKE} --build . --target install --parallel "${N_JOBS}")
+${CMAKE} --build . --target install --parallel $N_JOBS
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,7 +114,7 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-MAKEFLAGS="${MAKEFLAGS/-jNA/}" ${CMAKE} --build . --target install -- -j $N_JOBS
+${CMAKE} --build . --target install -- -j $N_JOBS
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,7 +114,7 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-${CMAKE} --build . --target install -- -j $N_JOBS
+${CMAKE} --build . --target install -- -j"${N_JOBS}"
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -117,8 +117,9 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
 sanitize_makeflags() {
   printf '%s\n' "$1" |
     sed -E \
-      -e 's/(^|[[:space:]])-j[[:space:]]*[0-9]*([[:space:]]|$)/ /g' \
-      -e 's/(^|[[:space:]])([[:alpha:]]*)j[0-9]*([[:alpha:]]*)($|[[:space:]])/ \2\3 /g' \
+      -e 's/(^|[[:space:]])-j[[:space:]]+[0-9]*([[:space:]]|$)/ /g' \
+      -e 's/(^|[[:space:]])-j[^[:space:]]*([[:space:]]|$)/ /g' \
+      -e 's/(^|[[:space:]])([[:alpha:]]*)j[[:alnum:]]*([[:alpha:]]*)($|[[:space:]])/ \2\3 /g' \
       -e 's/[[:space:]]+/ /g' \
       -e 's/^ //; s/ $//'
 }

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,7 +114,8 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-${CMAKE} --build . --target install -- -j"${N_JOBS}"
+env | sort
+(unset MAKEFLAGS MFLAGS GNUMAKEFLAGS; ${CMAKE} --build . --target install -- -j"${N_JOBS}")
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,8 +114,29 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
+sanitize_makeflags() {
+  printf '%s\n' "$1" |
+    sed -E \
+      -e 's/(^|[[:space:]])-j[[:space:]]*[0-9]*([[:space:]]|$)/ /g' \
+      -e 's/(^|[[:space:]])([[:alpha:]]*)j[0-9]*([[:alpha:]]*)($|[[:space:]])/ \2\3 /g' \
+      -e 's/[[:space:]]+/ /g' \
+      -e 's/^ //; s/ $//'
+}
+
 env | sort
-(unset MAKEFLAGS MFLAGS GNUMAKEFLAGS; ${CMAKE} --build . --target install -- -j"${N_JOBS}")
+SANITIZED_MAKEFLAGS="$(sanitize_makeflags "${MAKEFLAGS:-}")"
+SANITIZED_MFLAGS="$(sanitize_makeflags "${MFLAGS:-}")"
+SANITIZED_GNUMAKEFLAGS="$(sanitize_makeflags "${GNUMAKEFLAGS:-}")"
+printf 'MAKEFLAGS before sanitize: %s\n' "${MAKEFLAGS:-}"
+printf 'MFLAGS before sanitize: %s\n' "${MFLAGS:-}"
+printf 'GNUMAKEFLAGS before sanitize: %s\n' "${GNUMAKEFLAGS:-}"
+printf 'MAKEFLAGS after sanitize: %s\n' "${SANITIZED_MAKEFLAGS}"
+printf 'MFLAGS after sanitize: %s\n' "${SANITIZED_MFLAGS}"
+printf 'GNUMAKEFLAGS after sanitize: %s\n' "${SANITIZED_GNUMAKEFLAGS}"
+MAKEFLAGS="${SANITIZED_MAKEFLAGS}" \
+MFLAGS="${SANITIZED_MFLAGS}" \
+GNUMAKEFLAGS="${SANITIZED_GNUMAKEFLAGS}" \
+  ${CMAKE} --build . --target install -- -j"${N_JOBS}"
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,10 +114,7 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-SANITIZED_MAKEFLAGS="${MAKEFLAGS/-jNA/}"
-printf 'MAKEFLAGS before sanitize: %s\n' "${MAKEFLAGS:-}"
-printf 'MAKEFLAGS after sanitize: %s\n' "${SANITIZED_MAKEFLAGS}"
-MAKEFLAGS="${SANITIZED_MAKEFLAGS}" ${CMAKE} --build . --target install -- -j"${N_JOBS}"
+MAKEFLAGS="${MAKEFLAGS/-jNA/}" ${CMAKE} --build . --target install -- -j $N_JOBS
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -114,7 +114,7 @@ ${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     ${SOURCE_DIR}
 
-${CMAKE} --build . --target install --parallel $N_JOBS
+${CMAKE} --build . --target install -- -j $N_JOBS
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -527,9 +527,6 @@ build_libarrow <- function(src_dir, dst_dir) {
   # CRAN policy says not to use more than 2 cores during checks
   # If you have more and want to use more, set MAKEFLAGS or NOT_CRAN
   ncores <- parallel::detectCores()
-  if (is.na(ncores)) {
-    ncores <- 2
-  }
   if (!not_cran) {
     ncores <- min(ncores, 2)
   }

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -535,11 +535,26 @@ build_libarrow <- function(src_dir, dst_dir) {
     makeflags <- sprintf("-j%s", ncores)
     Sys.setenv(MAKEFLAGS = makeflags)
   } else {
-    # Extract -j value from existing MAKEFLAGS if present
-    j_match <- regmatches(makeflags, regexpr("-j\\s*([0-9]+)", makeflags, perl = TRUE))
+    # Extract -j/--jobs value from existing MAKEFLAGS if present
+    j_match <- regmatches(makeflags, regexpr("(^|\\s)(-j\\s*|--jobs(=|\\s)+)([0-9]+)(?=\\s|$)", makeflags, perl = TRUE))
     if (length(j_match) > 0) {
-      ncores <- as.integer(sub("-j\\s*", "", j_match, perl = TRUE))
+      ncores <- as.integer(sub(".*?([0-9]+)$", "\\1", j_match, perl = TRUE))
     }
+    # Keep GNU make's optional -j/--jobs argument in one token for nested gmake
+    makeflags <- gsub("(^|\\s)-j\\s+([0-9]+)(?=\\s|$)", "\\1-j\\2", makeflags, perl = TRUE)
+    makeflags <- gsub("(^|\\s)--jobs\\s+([0-9]+)(?=\\s|$)", "\\1--jobs=\\2", makeflags, perl = TRUE)
+    # Give any remaining bare `-j`/`--jobs` an explicit count
+    makeflags <- gsub("(^|\\s)-j(?=\\s|$)", sprintf("\\1-j%s", ncores), makeflags, perl = TRUE)
+    makeflags <- gsub("(^|\\s)--jobs(?=\\s|$)", sprintf("\\1--jobs=%s", ncores), makeflags, perl = TRUE)
+    Sys.setenv(MAKEFLAGS = makeflags)
+  }
+  gnumakeflags <- Sys.getenv("GNUMAKEFLAGS")
+  if (nzchar(gnumakeflags)) {
+    gnumakeflags <- gsub("(^|\\s)-j\\s+([0-9]+)(?=\\s|$)", "\\1-j\\2", gnumakeflags, perl = TRUE)
+    gnumakeflags <- gsub("(^|\\s)--jobs\\s+([0-9]+)(?=\\s|$)", "\\1--jobs=\\2", gnumakeflags, perl = TRUE)
+    gnumakeflags <- gsub("(^|\\s)-j(?=\\s|$)", sprintf("\\1-j%s", ncores), gnumakeflags, perl = TRUE)
+    gnumakeflags <- gsub("(^|\\s)--jobs(?=\\s|$)", sprintf("\\1--jobs=%s", ncores), gnumakeflags, perl = TRUE)
+    Sys.setenv(GNUMAKEFLAGS = gnumakeflags)
   }
   if (!quietly) {
     lg("Building with MAKEFLAGS=%s", makeflags)

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -526,7 +526,7 @@ build_libarrow <- function(src_dir, dst_dir) {
   # Set up make for parallel building
   # CRAN policy says not to use more than 2 cores during checks
   # If you have more and want to use more, set MAKEFLAGS or NOT_CRAN
-  ncores <- parallel::detectCores()
+  ncores <- max(1, parallel::detectCores(), na.rm = TRUE)
   if (!not_cran) {
     ncores <- min(ncores, 2)
   }

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -516,6 +516,14 @@ env_vars_as_string <- function(env_var_list) {
   env_var_string
 }
 
+strip_make_job_flags <- function(makeflags) {
+  makeflags <- gsub("(^|\\s)--jobserver-[^[:space:]]+", " ", makeflags, perl = TRUE)
+  makeflags <- gsub("(^|\\s)--jobs(=|\\s+)?[0-9]*(?=\\s|$)", " ", makeflags, perl = TRUE)
+  makeflags <- gsub("(^|\\s)-j\\s*[0-9]*(?=\\s|$)", " ", makeflags, perl = TRUE)
+  makeflags <- gsub("(^|\\s)([[:alpha:]]*)j[0-9]*([[:alpha:]]*)(?=\\s|$)", "\\1\\2\\3", makeflags, perl = TRUE)
+  trimws(gsub("\\s+", " ", makeflags, perl = TRUE))
+}
+
 R_CMD_config <- function(var) {
   tools::Rcmd(paste("config", var), stdout = TRUE)
 }
@@ -536,7 +544,10 @@ build_libarrow <- function(src_dir, dst_dir) {
     Sys.setenv(MAKEFLAGS = makeflags)
   } else {
     # Extract -j/--jobs value from existing MAKEFLAGS if present
-    j_match <- regmatches(makeflags, regexpr("(^|\\s)(-j\\s*|--jobs(=|\\s)+)([0-9]+)(?=\\s|$)", makeflags, perl = TRUE))
+    j_match <- regmatches(
+      makeflags,
+      regexpr("(^|\\s)(-j\\s*|--jobs(=|\\s)+|[[:alpha:]]*j)([0-9]+)(?=\\s|$)", makeflags, perl = TRUE)
+    )
     if (length(j_match) > 0) {
       ncores <- as.integer(sub(".*?([0-9]+)$", "\\1", j_match, perl = TRUE))
     }
@@ -556,6 +567,9 @@ build_libarrow <- function(src_dir, dst_dir) {
     gnumakeflags <- gsub("(^|\\s)--jobs(?=\\s|$)", sprintf("\\1--jobs=%s", ncores), gnumakeflags, perl = TRUE)
     Sys.setenv(GNUMAKEFLAGS = gnumakeflags)
   }
+  makeflags <- strip_make_job_flags(makeflags)
+  gnumakeflags <- strip_make_job_flags(Sys.getenv("GNUMAKEFLAGS"))
+  Sys.setenv(MAKEFLAGS = makeflags, GNUMAKEFLAGS = gnumakeflags)
   if (!quietly) {
     lg("Building with MAKEFLAGS=%s", makeflags)
   }
@@ -594,6 +608,8 @@ build_libarrow <- function(src_dir, dst_dir) {
     ),
     # CXXFLAGS = R_CMD_config("CXX20FLAGS"), # We don't want the same debug symbols
     LDFLAGS = R_CMD_config("LDFLAGS"),
+    MAKEFLAGS = makeflags,
+    GNUMAKEFLAGS = gnumakeflags,
     N_JOBS = ncores
   )
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -526,6 +526,7 @@ build_libarrow <- function(src_dir, dst_dir) {
   # Set up make for parallel building
   # CRAN policy says not to use more than 2 cores during checks
   # If you have more and want to use more, set MAKEFLAGS or NOT_CRAN
+  # detectCores() returns NA if number of cores is unknown. Set ncores to 1 if NA.
   ncores <- max(1, parallel::detectCores(), na.rm = TRUE)
   if (!not_cran) {
     ncores <- min(ncores, 2)

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -516,14 +516,6 @@ env_vars_as_string <- function(env_var_list) {
   env_var_string
 }
 
-strip_make_job_flags <- function(makeflags) {
-  makeflags <- gsub("(^|\\s)--jobserver-[^[:space:]]+", " ", makeflags, perl = TRUE)
-  makeflags <- gsub("(^|\\s)--jobs(=|\\s+)?[0-9]*(?=\\s|$)", " ", makeflags, perl = TRUE)
-  makeflags <- gsub("(^|\\s)-j\\s*[0-9]*(?=\\s|$)", " ", makeflags, perl = TRUE)
-  makeflags <- gsub("(^|\\s)([[:alpha:]]*)j[0-9]*([[:alpha:]]*)(?=\\s|$)", "\\1\\2\\3", makeflags, perl = TRUE)
-  trimws(gsub("\\s+", " ", makeflags, perl = TRUE))
-}
-
 R_CMD_config <- function(var) {
   tools::Rcmd(paste("config", var), stdout = TRUE)
 }
@@ -543,33 +535,12 @@ build_libarrow <- function(src_dir, dst_dir) {
     makeflags <- sprintf("-j%s", ncores)
     Sys.setenv(MAKEFLAGS = makeflags)
   } else {
-    # Extract -j/--jobs value from existing MAKEFLAGS if present
-    j_match <- regmatches(
-      makeflags,
-      regexpr("(^|\\s)(-j\\s*|--jobs(=|\\s)+|[[:alpha:]]*j)([0-9]+)(?=\\s|$)", makeflags, perl = TRUE)
-    )
+    # Extract -j value from existing MAKEFLAGS if present
+    j_match <- regmatches(makeflags, regexpr("-j\\s*([0-9]+)", makeflags, perl = TRUE))
     if (length(j_match) > 0) {
-      ncores <- as.integer(sub(".*?([0-9]+)$", "\\1", j_match, perl = TRUE))
+      ncores <- as.integer(sub("-j\\s*", "", j_match, perl = TRUE))
     }
-    # Keep GNU make's optional -j/--jobs argument in one token for nested gmake
-    makeflags <- gsub("(^|\\s)-j\\s+([0-9]+)(?=\\s|$)", "\\1-j\\2", makeflags, perl = TRUE)
-    makeflags <- gsub("(^|\\s)--jobs\\s+([0-9]+)(?=\\s|$)", "\\1--jobs=\\2", makeflags, perl = TRUE)
-    # Give any remaining bare `-j`/`--jobs` an explicit count
-    makeflags <- gsub("(^|\\s)-j(?=\\s|$)", sprintf("\\1-j%s", ncores), makeflags, perl = TRUE)
-    makeflags <- gsub("(^|\\s)--jobs(?=\\s|$)", sprintf("\\1--jobs=%s", ncores), makeflags, perl = TRUE)
-    Sys.setenv(MAKEFLAGS = makeflags)
   }
-  gnumakeflags <- Sys.getenv("GNUMAKEFLAGS")
-  if (nzchar(gnumakeflags)) {
-    gnumakeflags <- gsub("(^|\\s)-j\\s+([0-9]+)(?=\\s|$)", "\\1-j\\2", gnumakeflags, perl = TRUE)
-    gnumakeflags <- gsub("(^|\\s)--jobs\\s+([0-9]+)(?=\\s|$)", "\\1--jobs=\\2", gnumakeflags, perl = TRUE)
-    gnumakeflags <- gsub("(^|\\s)-j(?=\\s|$)", sprintf("\\1-j%s", ncores), gnumakeflags, perl = TRUE)
-    gnumakeflags <- gsub("(^|\\s)--jobs(?=\\s|$)", sprintf("\\1--jobs=%s", ncores), gnumakeflags, perl = TRUE)
-    Sys.setenv(GNUMAKEFLAGS = gnumakeflags)
-  }
-  makeflags <- strip_make_job_flags(makeflags)
-  gnumakeflags <- strip_make_job_flags(Sys.getenv("GNUMAKEFLAGS"))
-  Sys.setenv(MAKEFLAGS = makeflags, GNUMAKEFLAGS = gnumakeflags)
   if (!quietly) {
     lg("Building with MAKEFLAGS=%s", makeflags)
   }
@@ -608,8 +579,6 @@ build_libarrow <- function(src_dir, dst_dir) {
     ),
     # CXXFLAGS = R_CMD_config("CXX20FLAGS"), # We don't want the same debug symbols
     LDFLAGS = R_CMD_config("LDFLAGS"),
-    MAKEFLAGS = makeflags,
-    GNUMAKEFLAGS = gnumakeflags,
     N_JOBS = ncores
   )
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -527,6 +527,9 @@ build_libarrow <- function(src_dir, dst_dir) {
   # CRAN policy says not to use more than 2 cores during checks
   # If you have more and want to use more, set MAKEFLAGS or NOT_CRAN
   ncores <- parallel::detectCores()
+  if (is.na(ncores)) {
+    ncores <- 2
+  }
   if (!not_cran) {
     ncores <- min(ncores, 2)
   }


### PR DESCRIPTION
### Rationale for this change

See [failure here](https://github.com/ursacomputing/crossbow/actions/runs/28486933942/job/84435321636#step:6:719).

### What changes are included in this PR?

Bash command used is adjusted to prevent this error.
```bash
/usr/bin/cmake --build . --target install -- -j 2
gmake: the '-j' option requires a positive integer argument
```

### Are these changes tested?

By CI.

### Are there any user-facing changes?

No.