### PR TITLE
GH-49231: [C++] Deprecate Feather reader and writer

### DIFF
--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -781,7 +781,9 @@ GArrowFeatherFileReader *
 garrow_feather_file_reader_new(GArrowSeekableInputStream *file, GError **error)
 {
   auto arrow_random_access_file = garrow_seekable_input_stream_get_raw(file);
+  ARROW_SUPPRESS_DEPRECATION_WARNING
   auto reader = arrow::ipc::feather::Reader::Open(arrow_random_access_file);
+  ARROW_UNSUPPRESS_DEPRECATION_WARNING
   if (garrow::check(error, reader, "[feather-file-reader][new]")) {
     return garrow_feather_file_reader_new_raw(&(*reader));
   } else {

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -772,6 +772,9 @@ garrow_table_validate_full(GArrowTable *table, GError **error)
   return garrow::check(error, arrow_table->ValidateFull(), "[table][validate-full]");
 }
 
+// The Feather C++ API is deprecated; this GLib binding still wraps it.
+ARROW_SUPPRESS_DEPRECATION_WARNING
+
 typedef struct GArrowFeatherWritePropertiesPrivate_
 {
   arrow::ipc::feather::WriteProperties properties;
@@ -932,6 +935,8 @@ garrow_table_write_as_feather(GArrowTable *table,
   return garrow::check(error, status, "[feather-write-file]");
 }
 
+ARROW_UNSUPPRESS_DEPRECATION_WARNING
+
 G_END_DECLS
 
 GArrowTable *
@@ -948,9 +953,11 @@ garrow_table_get_raw(GArrowTable *table)
   return priv->table;
 }
 
+ARROW_SUPPRESS_DEPRECATION_WARNING
 arrow::ipc::feather::WriteProperties *
 garrow_feather_write_properties_get_raw(GArrowFeatherWriteProperties *properties)
 {
   auto priv = GARROW_FEATHER_WRITE_PROPERTIES_GET_PRIVATE(properties);
   return &(priv->properties);
 }
+ARROW_UNSUPPRESS_DEPRECATION_WARNING

--- a/c_glib/arrow-glib/table.hpp
+++ b/c_glib/arrow-glib/table.hpp
@@ -32,6 +32,8 @@ GARROW_EXTERN
 std::shared_ptr<arrow::Table>
 garrow_table_get_raw(GArrowTable *table);
 
+ARROW_SUPPRESS_DEPRECATION_WARNING
 GARROW_EXTERN
 arrow::ipc::feather::WriteProperties *
 garrow_feather_write_properties_get_raw(GArrowFeatherWriteProperties *properties);
+ARROW_UNSUPPRESS_DEPRECATION_WARNING

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -770,7 +770,9 @@ class ReaderV2 : public Reader {
 
 Result<std::shared_ptr<Reader>> Reader::Open(
     const std::shared_ptr<io::RandomAccessFile>& source) {
+  ARROW_SUPPRESS_DEPRECATION_WARNING
   return Reader::Open(source, IpcReadOptions::Defaults());
+  ARROW_UNSUPPRESS_DEPRECATION_WARNING
 }
 
 Result<std::shared_ptr<Reader>> Reader::Open(

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -805,6 +805,9 @@ Result<std::shared_ptr<Reader>> Reader::Open(
   }
 }
 
+// GCC warns about the deprecated type in these definitions, Clang doesn't
+ARROW_SUPPRESS_DEPRECATION_WARNING
+
 WriteProperties WriteProperties::Defaults() {
   WriteProperties result;
 #ifdef ARROW_WITH_LZ4
@@ -833,6 +836,8 @@ Status WriteTable(const Table& table, io::OutputStream* dst,
     return writer->Close();
   }
 }
+
+ARROW_UNSUPPRESS_DEPRECATION_WARNING
 
 }  // namespace feather
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -28,6 +28,7 @@
 #include "arrow/ipc/options.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -54,6 +55,9 @@ static constexpr const int kFeatherV2Version = 3;
 
 /// \class Reader
 /// \brief An interface for reading columns from Feather files
+///
+/// \note Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
+///   use arrow::ipc::RecordBatchFileReader instead.
 class ARROW_EXPORT Reader {
  public:
   virtual ~Reader() = default;
@@ -62,6 +66,9 @@ class ARROW_EXPORT Reader {
   ///
   /// \param[in] source a RandomAccessFile instance
   /// \return the table reader
+  /// \deprecated Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.
+  ARROW_DEPRECATED(
+      "Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
   static Result<std::shared_ptr<Reader>> Open(
       const std::shared_ptr<io::RandomAccessFile>& source);
 
@@ -71,6 +78,9 @@ class ARROW_EXPORT Reader {
   /// \param[in] source a RandomAccessFile instance
   /// \param[in] options IPC Read options
   /// \return the table reader
+  /// \deprecated Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.
+  ARROW_DEPRECATED(
+      "Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
   static Result<std::shared_ptr<Reader>> Open(
       const std::shared_ptr<io::RandomAccessFile>& source, const IpcReadOptions& options);
 
@@ -107,6 +117,11 @@ class ARROW_EXPORT Reader {
                       std::shared_ptr<Table>* out) = 0;
 };
 
+/// \struct WriteProperties
+/// \brief Options for writing Feather files
+///
+/// \note Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
+///   use arrow::ipc::MakeFileWriter with arrow::ipc::IpcWriteOptions instead.
 struct ARROW_EXPORT WriteProperties {
   static WriteProperties Defaults();
 
@@ -141,6 +156,11 @@ struct ARROW_EXPORT WriteProperties {
   int compression_level = ::arrow::util::kUseDefaultCompressionLevel;
 };
 
+/// \brief Write a Table to a Feather file
+///
+/// \deprecated Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
+///   use arrow::ipc::MakeFileWriter instead.
+ARROW_DEPRECATED("Deprecated in 25.0.0. Use arrow::ipc::MakeFileWriter instead.")
 ARROW_EXPORT
 Status WriteTable(const Table& table, io::OutputStream* dst,
                   const WriteProperties& properties = WriteProperties::Defaults());

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -56,7 +56,7 @@ static constexpr const int kFeatherV2Version = 3;
 /// \class Reader
 /// \brief An interface for reading columns from Feather files
 ///
-/// \note Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
+/// \note Deprecated in 26.0.0. Feather V2 is the Arrow IPC file format;
 ///   use arrow::ipc::RecordBatchFileReader instead.
 class ARROW_EXPORT Reader {
  public:
@@ -66,8 +66,8 @@ class ARROW_EXPORT Reader {
   ///
   /// \param[in] source a RandomAccessFile instance
   /// \return the table reader
-  /// \deprecated Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.
-  ARROW_DEPRECATED("Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
+  /// \deprecated Deprecated in 26.0.0. Use arrow::ipc::RecordBatchFileReader instead.
+  ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
   static Result<std::shared_ptr<Reader>> Open(
       const std::shared_ptr<io::RandomAccessFile>& source);
 
@@ -77,8 +77,8 @@ class ARROW_EXPORT Reader {
   /// \param[in] source a RandomAccessFile instance
   /// \param[in] options IPC Read options
   /// \return the table reader
-  /// \deprecated Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.
-  ARROW_DEPRECATED("Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
+  /// \deprecated Deprecated in 26.0.0. Use arrow::ipc::RecordBatchFileReader instead.
+  ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
   static Result<std::shared_ptr<Reader>> Open(
       const std::shared_ptr<io::RandomAccessFile>& source, const IpcReadOptions& options);
 
@@ -115,9 +115,10 @@ class ARROW_EXPORT Reader {
                       std::shared_ptr<Table>* out) = 0;
 };
 
-/// \note Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
+/// \deprecated Deprecated in 26.0.0. Feather V2 is the Arrow IPC file format;
 ///   use arrow::ipc::MakeFileWriter with arrow::ipc::IpcWriteOptions instead.
-struct ARROW_EXPORT WriteProperties {
+struct ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::MakeFileWriter instead.")
+    ARROW_EXPORT WriteProperties {
   static WriteProperties Defaults();
 
   static WriteProperties DefaultsV1() {
@@ -151,9 +152,9 @@ struct ARROW_EXPORT WriteProperties {
   int compression_level = ::arrow::util::kUseDefaultCompressionLevel;
 };
 
-/// \deprecated Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
+/// \deprecated Deprecated in 26.0.0. Feather V2 is the Arrow IPC file format;
 ///   use arrow::ipc::MakeFileWriter instead.
-ARROW_DEPRECATED("Deprecated in 25.0.0. Use arrow::ipc::MakeFileWriter instead.")
+ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::MakeFileWriter instead.")
 ARROW_EXPORT
 Status WriteTable(const Table& table, io::OutputStream* dst,
                   const WriteProperties& properties = WriteProperties::Defaults());

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -67,8 +67,7 @@ class ARROW_EXPORT Reader {
   /// \param[in] source a RandomAccessFile instance
   /// \return the table reader
   /// \deprecated Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.
-  ARROW_DEPRECATED(
-      "Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
+  ARROW_DEPRECATED("Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
   static Result<std::shared_ptr<Reader>> Open(
       const std::shared_ptr<io::RandomAccessFile>& source);
 
@@ -79,8 +78,7 @@ class ARROW_EXPORT Reader {
   /// \param[in] options IPC Read options
   /// \return the table reader
   /// \deprecated Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.
-  ARROW_DEPRECATED(
-      "Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
+  ARROW_DEPRECATED("Deprecated in 25.0.0. Use arrow::ipc::RecordBatchFileReader instead.")
   static Result<std::shared_ptr<Reader>> Open(
       const std::shared_ptr<io::RandomAccessFile>& source, const IpcReadOptions& options);
 
@@ -117,9 +115,6 @@ class ARROW_EXPORT Reader {
                       std::shared_ptr<Table>* out) = 0;
 };
 
-/// \struct WriteProperties
-/// \brief Options for writing Feather files
-///
 /// \note Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
 ///   use arrow::ipc::MakeFileWriter with arrow::ipc::IpcWriteOptions instead.
 struct ARROW_EXPORT WriteProperties {
@@ -156,8 +151,6 @@ struct ARROW_EXPORT WriteProperties {
   int compression_level = ::arrow::util::kUseDefaultCompressionLevel;
 };
 
-/// \brief Write a Table to a Feather file
-///
 /// \deprecated Deprecated in 25.0.0. Feather V2 is the Arrow IPC file format;
 ///   use arrow::ipc::MakeFileWriter instead.
 ARROW_DEPRECATED("Deprecated in 25.0.0. Use arrow::ipc::MakeFileWriter instead.")

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -117,7 +117,7 @@ class ARROW_EXPORT Reader {
 
 /// \deprecated Deprecated in 26.0.0. Feather V2 is the Arrow IPC file format;
 ///   use arrow::ipc::MakeFileWriter with arrow::ipc::IpcWriteOptions instead.
-struct ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::MakeFileWriter instead.")
+struct ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::IpcWriteOptions instead.")
     ARROW_EXPORT WriteProperties {
   static WriteProperties Defaults();
 

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -152,12 +152,15 @@ struct ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::MakeFileWriter in
   int compression_level = ::arrow::util::kUseDefaultCompressionLevel;
 };
 
+// Only suppresses the deprecated WriteProperties in the default argument
+ARROW_SUPPRESS_DEPRECATION_WARNING
 /// \deprecated Deprecated in 26.0.0. Feather V2 is the Arrow IPC file format;
 ///   use arrow::ipc::MakeFileWriter instead.
 ARROW_DEPRECATED("Deprecated in 26.0.0. Use arrow::ipc::MakeFileWriter instead.")
 ARROW_EXPORT
 Status WriteTable(const Table& table, io::OutputStream* dst,
                   const WriteProperties& properties = WriteProperties::Defaults());
+ARROW_UNSUPPRESS_DEPRECATION_WARNING
 
 }  // namespace feather
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -44,6 +44,10 @@ using internal::checked_cast;
 namespace ipc {
 namespace feather {
 
+// These tests intentionally exercise the deprecated Feather API, supressing
+// the deprecation warnings for the whole file.
+ARROW_SUPPRESS_DEPRECATION_WARNING
+
 struct TestParam {
   TestParam(int arg_version,
             Compression::type arg_compression = Compression::UNCOMPRESSED)
@@ -382,6 +386,8 @@ TEST_P(TestFeatherRoundTrip, RoundTrip) {
 
 INSTANTIATE_TEST_SUITE_P(FeatherRoundTripTests, TestFeatherRoundTrip,
                          ::testing::ValuesIn(kBatchCases));
+
+ARROW_UNSUPPRESS_DEPRECATION_WARNING
 
 }  // namespace feather
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -44,7 +44,7 @@ using internal::checked_cast;
 namespace ipc {
 namespace feather {
 
-// These tests intentionally exercise the deprecated Feather API, supressing
+// These tests intentionally exercise the deprecated Feather API, suppressing
 // the deprecation warnings for the whole file.
 ARROW_SUPPRESS_DEPRECATION_WARNING
 

--- a/python/pyarrow/includes/libarrow_feather.pxd
+++ b/python/pyarrow/includes/libarrow_feather.pxd
@@ -23,6 +23,8 @@ from pyarrow.includes.libarrow cimport (CCompressionType, CStatus, CTable,
                                         c_string, CIpcReadOptions)
 
 
+# NOTE: these feather C++ APIs are deprecated. Pyarrow still binds them,
+# the user-facing FutureWarning lives in pyarrow/feather.py (GH-49232).
 cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     int kFeatherV1Version" arrow::ipc::feather::kFeatherV1Version"
     int kFeatherV2Version" arrow::ipc::feather::kFeatherV2Version"

--- a/python/pyarrow/includes/libarrow_feather.pxd
+++ b/python/pyarrow/includes/libarrow_feather.pxd
@@ -23,8 +23,6 @@ from pyarrow.includes.libarrow cimport (CCompressionType, CStatus, CTable,
                                         c_string, CIpcReadOptions)
 
 
-# NOTE: these feather C++ APIs are deprecated; pyarrow still binds them.
-# The user-facing FutureWarning is in pyarrow/feather.py (GH-49232)
 cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     int kFeatherV1Version" arrow::ipc::feather::kFeatherV1Version"
     int kFeatherV2Version" arrow::ipc::feather::kFeatherV2Version"

--- a/python/pyarrow/includes/libarrow_feather.pxd
+++ b/python/pyarrow/includes/libarrow_feather.pxd
@@ -23,8 +23,8 @@ from pyarrow.includes.libarrow cimport (CCompressionType, CStatus, CTable,
                                         c_string, CIpcReadOptions)
 
 
-# NOTE: these feather C++ APIs are deprecated. Pyarrow still binds them,
-# the user-facing FutureWarning lives in pyarrow/feather.py (GH-49232).
+# NOTE: these feather C++ APIs are deprecated; pyarrow still binds them.
+# The user-facing FutureWarning is in pyarrow/feather.py (GH-49232)
 cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     int kFeatherV1Version" arrow::ipc::feather::kFeatherV1Version"
     int kFeatherV2Version" arrow::ipc::feather::kFeatherV2Version"

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -84,8 +84,8 @@ std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(
 // [[arrow::export]]
 std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(
     const std::shared_ptr<arrow::io::RandomAccessFile>& stream) {
-  auto result = RunWithCapturedRIfPossible<std::shared_ptr<arrow::ipc::feather::Reader>>(
-      [&]() {
+  auto result =
+      RunWithCapturedRIfPossible<std::shared_ptr<arrow::ipc::feather::Reader>>([&]() {
         ARROW_SUPPRESS_DEPRECATION_WARNING
         return arrow::ipc::feather::Reader::Open(stream);
         ARROW_UNSUPPRESS_DEPRECATION_WARNING

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -29,6 +29,7 @@ void ipc___WriteFeather__Table(const std::shared_ptr<arrow::io::OutputStream>& s
                                const std::shared_ptr<arrow::Table>& table, int version,
                                int chunk_size, arrow::Compression::type compression,
                                int compression_level) {
+  ARROW_SUPPRESS_DEPRECATION_WARNING
   auto properties = arrow::ipc::feather::WriteProperties::Defaults();
   properties.version = version;
   properties.chunksize = chunk_size;
@@ -36,7 +37,6 @@ void ipc___WriteFeather__Table(const std::shared_ptr<arrow::io::OutputStream>& s
   if (compression_level != -1) {
     properties.compression_level = compression_level;
   }
-  ARROW_SUPPRESS_DEPRECATION_WARNING
   StopIfNotOk(arrow::ipc::feather::WriteTable(*table, stream.get(), properties));
   ARROW_UNSUPPRESS_DEPRECATION_WARNING
 }

--- a/r/src/feather.cpp
+++ b/r/src/feather.cpp
@@ -36,7 +36,9 @@ void ipc___WriteFeather__Table(const std::shared_ptr<arrow::io::OutputStream>& s
   if (compression_level != -1) {
     properties.compression_level = compression_level;
   }
+  ARROW_SUPPRESS_DEPRECATION_WARNING
   StopIfNotOk(arrow::ipc::feather::WriteTable(*table, stream.get(), properties));
+  ARROW_UNSUPPRESS_DEPRECATION_WARNING
 }
 
 // ----------- Reader
@@ -83,7 +85,11 @@ std::shared_ptr<arrow::Table> ipc___feather___Reader__Read(
 std::shared_ptr<arrow::ipc::feather::Reader> ipc___feather___Reader__Open(
     const std::shared_ptr<arrow::io::RandomAccessFile>& stream) {
   auto result = RunWithCapturedRIfPossible<std::shared_ptr<arrow::ipc::feather::Reader>>(
-      [&]() { return arrow::ipc::feather::Reader::Open(stream); });
+      [&]() {
+        ARROW_SUPPRESS_DEPRECATION_WARNING
+        return arrow::ipc::feather::Reader::Open(stream);
+        ARROW_UNSUPPRESS_DEPRECATION_WARNING
+      });
   return ValueOrStop(result);
 }
 


### PR DESCRIPTION
### Rationale for this change
See #49231. Deprecate the Feather reader/writer and point users to the Arrow IPC file API.

### What changes are included in this PR?
`ipc::feather::Reader::Open`, `ipc::feather::WriteTable` and the `WriteProperties` struct marked with `ARROW_DEPRECATED`, pointing users to `ipc::RecordBatchFileReader` and `ipc::MakeFileWriter`.
Deprecation warnings supressed at the internal call sites: `feather.cc`, `feather_test.cc`, the R binding `r/src/feather.cpp` (R deprecation is in #49276), and the GLib binding (GLib deprecation is in #49673).

### Are these changes tested?
`-Werror` build of arrow-feather-test passes locally.

### Are there any user-facing changes?
No functional change, compile-time deprecation warning for `feather::Reader::Open`, `feather::WriteTable` or feather::WriteProperties.

* GitHub Issue: #49231