### PR TITLE
GH-50311: [C++] `KeyValueMetadata::Delete` returns IndexError instead of crashing due to seg fault

### DIFF
--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -100,6 +100,20 @@ Result<std::string> KeyValueMetadata::Get(std::string_view key) const {
 }
 
 Status KeyValueMetadata::Delete(int64_t index) {
+  if (ARROW_PREDICT_FALSE(index < 0 || std::cmp_greater_equal(index, values_.size()))) {
+    const size_t n = keys_.size();
+    if (n == 0LL) {
+      return Status::IndexError("KeyValueMetadata::Delete: index ", std::to_string(index),
+                                " is out of bounds for metadata "
+                                "of size ",
+                                std::to_string(n), ". Metadata is empty.");
+    }
+    return Status::IndexError("KeyValueMetadata::Delete: index ", std::to_string(index),
+                              " is out of bounds for metadata "
+                              "of size ",
+                              std::to_string(n), " (valid range: [0, ",
+                              std::to_string(n - 1), "])");
+  }
   keys_.erase(keys_.begin() + index);
   values_.erase(values_.begin() + index);
   return Status::OK();

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -100,19 +100,11 @@ Result<std::string> KeyValueMetadata::Get(std::string_view key) const {
 }
 
 Status KeyValueMetadata::Delete(int64_t index) {
-  if (ARROW_PREDICT_FALSE(index < 0 || std::cmp_greater_equal(index, values_.size()))) {
-    const size_t n = keys_.size();
-    if (n == 0LL) {
-      return Status::IndexError("KeyValueMetadata::Delete: index ", std::to_string(index),
-                                " is out of bounds for metadata "
-                                "of size ",
-                                std::to_string(n), ". Metadata is empty.");
-    }
-    return Status::IndexError("KeyValueMetadata::Delete: index ", std::to_string(index),
+  if (ARROW_PREDICT_FALSE(index < 0 || std::cmp_greater_equal(index, keys_.size()))) {
+    return Status::IndexError("KeyValueMetadata::Delete: index ", index,
                               " is out of bounds for metadata "
                               "of size ",
-                              std::to_string(n), " (valid range: [0, ",
-                              std::to_string(n - 1), "])");
+                              keys_.size());
   }
   keys_.erase(keys_.begin() + index);
   values_.erase(values_.begin() + index);

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -100,7 +100,7 @@ Result<std::string> KeyValueMetadata::Get(std::string_view key) const {
 }
 
 Status KeyValueMetadata::Delete(int64_t index) {
-  if (ARROW_PREDICT_FALSE(index < 0 || std::cmp_greater_equal(index, keys_.size()))) {
+  if (ARROW_PREDICT_FALSE(index < 0 || index >= static_cast<int64_t>(keys_.size()))) {
     return Status::IndexError("KeyValueMetadata::Delete: index ", index,
                               " is out of bounds for metadata "
                               "of size ",

--- a/cpp/src/arrow/util/key_value_metadata_test.cc
+++ b/cpp/src/arrow/util/key_value_metadata_test.cc
@@ -190,11 +190,11 @@ TEST(KeyValueMetadataTest, Delete) {
 
     std::string expected_error_message =
         "Index error: KeyValueMetadata::Delete: index -1 is out of bounds for metadata "
-        "of size 5 (valid range: [0, 4])";
+        "of size 5";
     ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(-1));
     expected_error_message =
         "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata "
-        "of size 5 (valid range: [0, 4])";
+        "of size 5";
     ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(7));
 
     ASSERT_OK(metadata.Delete(4));
@@ -205,7 +205,7 @@ TEST(KeyValueMetadataTest, Delete) {
 
     expected_error_message =
         "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata "
-        "of size 0. Metadata is empty.";
+        "of size 0";
     ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(7));
   }
   {

--- a/cpp/src/arrow/util/key_value_metadata_test.cc
+++ b/cpp/src/arrow/util/key_value_metadata_test.cc
@@ -187,6 +187,26 @@ TEST(KeyValueMetadataTest, Delete) {
     ASSERT_OK(metadata.Delete(3));
     ASSERT_TRUE(metadata.Equals(
         KeyValueMetadata({"aa", "bb", "dd", "ff", "gg"}, {"1", "2", "4", "6", "7"})));
+
+    std::string expected_error_message =
+        "Index error: KeyValueMetadata::Delete: index -1 is out of bounds for metadata "
+        "of size 5 (valid range: [0, 4])";
+    ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(-1));
+    expected_error_message =
+        "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata "
+        "of size 5 (valid range: [0, 4])";
+    ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(7));
+
+    ASSERT_OK(metadata.Delete(4));
+    ASSERT_OK(metadata.Delete(3));
+    ASSERT_OK(metadata.Delete(2));
+    ASSERT_OK(metadata.Delete(1));
+    ASSERT_OK(metadata.Delete(0));
+
+    expected_error_message =
+        "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata "
+        "of size 0. Metadata is empty.";
+    ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(7));
   }
   {
     KeyValueMetadata metadata(keys, values);


### PR DESCRIPTION
* The Delete function now catches out of bound index and does not throw a segmentation fault.

### Rationale for this change
The `KeyValueMetadata::Delete(int64_t index)` never checked for out of bounds value of `index`, & if `index` was out of bounds, then a seg fault was thrown by the program and it aborted.

### What changes are included in this PR?
The `KeyValueMetadata::Delete(int64_t index)` now returns a IndexError for out of bounds values of `index`

### Are these changes tested?
Yes, CI tests pass on my fork

### Are there any user-facing changes?
No API changes

* GitHub Issue: #50311