### PR TITLE
GH-50316: [C++][CI] Install libboost-process-dev on Debian experimental

### DIFF
--- a/ci/docker/debian-experimental-cpp.dockerfile
+++ b/ci/docker/debian-experimental-cpp.dockerfile
@@ -44,6 +44,7 @@ RUN if [ -n "${gcc}" ]; then \
         git \
         libbenchmark-dev \
         libboost-filesystem-dev \
+        libboost-process-dev \
         libbrotli-dev \
         libbz2-dev \
         libc-ares-dev \


### PR DESCRIPTION
### Rationale for this change
#50316 - The nightly job `test-debian-experimental-cpp-gcc-15` fails build with
`/arrow/cpp/src/arrow/testing/process.cc:42:16: fatal error: boost/process/v2/src.hpp: No such file or directory`
debian:experimental image resolves [Boost packages from Debian unstable](https://github.com/ursacomputing/crossbow/actions/runs/28558613897/job/84671412037#step:6:652), currently Boost version 1.90 where `Boost.Process` is already a compiled library and `boost/process/v2/src.hpp` no longer exists ([since version 1.86](https://www.boost.org/releases/1.86.0/)).

### What changes are included in this PR?
Added apt-get install `libboost-process-dev` to `ci/docker/debian-experimental-cpp.dockerfile`

### Are these changes tested?
Yes, [nightly job build and tests pass](https://github.com/ursacomputing/crossbow/actions/runs/28531990056/job/84583612465)

### Are there any user-facing changes?
No.
* GitHub Issue: #50316