### PR TITLE
GH-50087: [Docs][C++] Fix sentence structure in memory.rst regarding `MemoryManager`

### DIFF
--- a/docs/source/cpp/memory.rst
+++ b/docs/source/cpp/memory.rst
@@ -171,9 +171,6 @@ Arrow represents the CPU and other devices using the
 :class:`arrow::Device` abstraction.  The associated class :class:`arrow::MemoryManager`
 specifies how to allocate on a given device.  Each device has a default memory manager, but
 additional instances may be constructed (for example, wrapping a custom
-:class:`arrow::MemoryPool` the CPU).
-:class:`arrow::MemoryManager` instances which specify how to allocate
-memory on a given device (for example, using a particular
 :class:`arrow::MemoryPool` on the CPU).
 
 Device-Agnostic Programming


### PR DESCRIPTION
In file `docs/source/cpp/memory.rst`:
* Removes a duplicate line
* Minor grammar fix

### Rationale for this change

I believe the statement 

>  The associated class :class:`arrow::MemoryManager` specifies how to allocate on a given device.

was repeated twice and there was some grammatical mistake in the same paragraph 
* GitHub Issue: #50087