### PR TITLE
GH-50312: [Python] Fix UUID extension type round-trip to pandas returning bytes

### DIFF
--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1401,13 +1401,11 @@ struct ObjectWriterVisitor {
       storage_arrays.push_back(extension_array.storage());
     }
     ChunkedArray storage(std::move(storage_arrays), type.storage_type());
-    OwnedRef args(PyTuple_New(0));
-    RETURN_IF_PYERROR();
     OwnedRef kwargs(PyDict_New());
     RETURN_IF_PYERROR();
     auto WrapUuid = [&](const std::string_view& view, PyObject** out) {
       ARROW_ASSIGN_OR_RAISE(*out,
-                            internal::UuidFromBytes(view, args.obj(), kwargs.obj()));
+                            internal::UuidFromBytes(view, kwargs.obj()));
       return Status::OK();
     };
     return ConvertAsPyObjects<FixedSizeBinaryType>(options, storage, WrapUuid,

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1401,8 +1401,13 @@ struct ObjectWriterVisitor {
       storage_arrays.push_back(extension_array.storage());
     }
     ChunkedArray storage(std::move(storage_arrays), type.storage_type());
+    OwnedRef args(PyTuple_New(0));
+    RETURN_IF_PYERROR();
+    OwnedRef kwargs(PyDict_New());
+    RETURN_IF_PYERROR();
     auto WrapUuid = [&](const std::string_view& view, PyObject** out) {
-      ARROW_ASSIGN_OR_RAISE(*out, internal::UuidFromBytes(view));
+      ARROW_ASSIGN_OR_RAISE(*out,
+                            internal::UuidFromBytes(view, args.obj(), kwargs.obj()));
       return Status::OK();
     };
     return ConvertAsPyObjects<FixedSizeBinaryType>(options, storage, WrapUuid,

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1401,24 +1401,8 @@ struct ObjectWriterVisitor {
       storage_arrays.push_back(extension_array.storage());
     }
     ChunkedArray storage(std::move(storage_arrays), type.storage_type());
-    OwnedRef uuid_module;
-    OwnedRef uuid_constructor;
-    RETURN_NOT_OK(internal::ImportModule("uuid", &uuid_module));
-    RETURN_NOT_OK(
-        internal::ImportFromModule(uuid_module.obj(), "UUID", &uuid_constructor));
-    // Reuse the args tuple and kwargs dict across calls to avoid per-element allocation.
-    OwnedRef args(PyTuple_New(0));
-    OwnedRef kwargs(PyDict_New());
-    RETURN_IF_PYERROR();
     auto WrapUuid = [&](const std::string_view& view, PyObject** out) {
-      OwnedRef bytes(
-          PyBytes_FromStringAndSize(view.data(), static_cast<Py_ssize_t>(view.size())));
-      RETURN_IF_PYERROR();
-      if (PyDict_SetItemString(kwargs.obj(), "bytes", bytes.obj()) < 0) {
-        RETURN_IF_PYERROR();
-      }
-      *out = PyObject_Call(uuid_constructor.obj(), args.obj(), kwargs.obj());
-      RETURN_IF_PYERROR();
+      ARROW_ASSIGN_OR_RAISE(*out, internal::UuidFromBytes(view));
       return Status::OK();
     };
     return ConvertAsPyObjects<FixedSizeBinaryType>(options, storage, WrapUuid,

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -2638,8 +2638,9 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
   modified_options.allow_zero_copy_blocks = true;
 
   // In case of an extension array default to the storage type, except for UUID
-  // which has a native Python object conversion.
-  if (arr->type()->id() == Type::EXTENSION && !IsUuidExtension(*arr->type())) {
+  // which has a native Python object conversion (unless converting to NumPy).
+  if (arr->type()->id() == Type::EXTENSION &&
+      (options.to_numpy || !IsUuidExtension(*arr->type()))) {
     arr = GetStorageChunkedArray(arr);
   }
   // In case of a RunEndEncodedArray decode the array

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1406,9 +1406,11 @@ struct ObjectWriterVisitor {
     RETURN_NOT_OK(internal::ImportModule("uuid", &uuid_module));
     RETURN_NOT_OK(
         internal::ImportFromModule(uuid_module.obj(), "UUID", &uuid_constructor));
+    // Reuse the args tuple and kwargs dict across calls to avoid per-element allocation.
+    OwnedRef args(PyTuple_New(0));
+    OwnedRef kwargs(PyDict_New());
+    RETURN_IF_PYERROR();
     auto WrapUuid = [&](const std::string_view& view, PyObject** out) {
-      OwnedRef args(PyTuple_New(0));
-      OwnedRef kwargs(PyDict_New());
       OwnedRef bytes(
           PyBytes_FromStringAndSize(view.data(), static_cast<Py_ssize_t>(view.size())));
       RETURN_IF_PYERROR();

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -116,6 +116,17 @@ void BufferCapsule_Destructor(PyObject* capsule) {
 using internal::arrow_traits;
 using internal::npy_traits;
 
+bool IsUuidExtension(const DataType& type) {
+  if (type.id() != Type::EXTENSION) {
+    return false;
+  }
+  const auto& extension_type = checked_cast<const ExtensionType&>(type);
+  const auto& storage_type = *extension_type.storage_type();
+  return extension_type.extension_name() == "arrow.uuid" &&
+         storage_type.id() == Type::FIXED_SIZE_BINARY &&
+         checked_cast<const FixedSizeBinaryType&>(storage_type).byte_width() == 16;
+}
+
 template <typename T>
 struct WrapBytes {};
 
@@ -1378,6 +1389,40 @@ struct ObjectWriterVisitor {
     return ConvertStruct(options, data, out_values);
   }
 
+  Status Visit(const ExtensionType& type) {
+    if (!IsUuidExtension(type)) {
+      return Status::NotImplemented("No implemented conversion to object dtype: ",
+                                    type.ToString());
+    }
+    ArrayVector storage_arrays;
+    storage_arrays.reserve(data.num_chunks());
+    for (int c = 0; c < data.num_chunks(); ++c) {
+      const auto& extension_array = checked_cast<const ExtensionArray&>(*data.chunk(c));
+      storage_arrays.push_back(extension_array.storage());
+    }
+    ChunkedArray storage(std::move(storage_arrays), type.storage_type());
+    OwnedRef uuid_module;
+    OwnedRef uuid_constructor;
+    RETURN_NOT_OK(internal::ImportModule("uuid", &uuid_module));
+    RETURN_NOT_OK(
+        internal::ImportFromModule(uuid_module.obj(), "UUID", &uuid_constructor));
+    auto WrapUuid = [&](const std::string_view& view, PyObject** out) {
+      OwnedRef args(PyTuple_New(0));
+      OwnedRef kwargs(PyDict_New());
+      OwnedRef bytes(
+          PyBytes_FromStringAndSize(view.data(), static_cast<Py_ssize_t>(view.size())));
+      RETURN_IF_PYERROR();
+      if (PyDict_SetItemString(kwargs.obj(), "bytes", bytes.obj()) < 0) {
+        RETURN_IF_PYERROR();
+      }
+      *out = PyObject_Call(uuid_constructor.obj(), args.obj(), kwargs.obj());
+      RETURN_IF_PYERROR();
+      return Status::OK();
+    };
+    return ConvertAsPyObjects<FixedSizeBinaryType>(options, storage, WrapUuid,
+                                                   out_values);
+  }
+
   template <typename Type>
   enable_if_t<is_floating_type<Type>::value ||
                   std::is_same<DictionaryType, Type>::value ||
@@ -2253,7 +2298,10 @@ static Status GetPandasWriterType(const ChunkedArray& data, const PandasOptions&
       *output_type = PandasWriter::CATEGORICAL;
       break;
     case Type::EXTENSION:
-      *output_type = PandasWriter::EXTENSION;
+      // UUID has a native object conversion to uuid.UUID. Other extension
+      // types continue through the pandas ExtensionArray protocol.
+      *output_type =
+          IsUuidExtension(*data.type()) ? PandasWriter::OBJECT : PandasWriter::EXTENSION;
       break;
     default:
       return Status::NotImplemented(
@@ -2358,8 +2406,10 @@ class ConsolidatedBlockCreator : public PandasBlockCreator {
       *out = PandasWriter::EXTENSION;
       return Status::OK();
     } else {
-      // In case of an extension array default to the storage type
-      if (arrays_[column_index]->type()->id() == Type::EXTENSION) {
+      // In case of an extension array default to the storage type, except for
+      // UUID which has a native Python object conversion.
+      if (arrays_[column_index]->type()->id() == Type::EXTENSION &&
+          !IsUuidExtension(*arrays_[column_index]->type())) {
         arrays_[column_index] = GetStorageChunkedArray(arrays_[column_index]);
       }
       // In case of a RunEndEncodedArray default to the values type
@@ -2599,8 +2649,9 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
   // Table->DataFrame
   modified_options.allow_zero_copy_blocks = true;
 
-  // In case of an extension array default to the storage type
-  if (arr->type()->id() == Type::EXTENSION) {
+  // In case of an extension array default to the storage type, except for UUID
+  // which has a native Python object conversion.
+  if (arr->type()->id() == Type::EXTENSION && !IsUuidExtension(*arr->type())) {
     arr = GetStorageChunkedArray(arr);
   }
   // In case of a RunEndEncodedArray decode the array

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1404,8 +1404,7 @@ struct ObjectWriterVisitor {
     OwnedRef kwargs(PyDict_New());
     RETURN_IF_PYERROR();
     auto WrapUuid = [&](const std::string_view& view, PyObject** out) {
-      ARROW_ASSIGN_OR_RAISE(*out,
-                            internal::UuidFromBytes(view, kwargs.obj()));
+      ARROW_ASSIGN_OR_RAISE(*out, internal::UuidFromBytes(view, kwargs.obj()));
       return Status::OK();
     };
     return ConvertAsPyObjects<FixedSizeBinaryType>(options, storage, WrapUuid,

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -361,7 +361,8 @@ bool IsPyUuid(PyObject* obj) {
   return result != 0;
 }
 
-Result<PyObject*> UuidFromBytes(std::string_view bytes) {
+Result<PyObject*> UuidFromBytes(std::string_view bytes, PyObject* args,
+                                PyObject* kwargs) {
   PyObject* uuid_class = GetUuidClass();
   if (!uuid_class) {
     return Status::Invalid("Could not import uuid.UUID");
@@ -369,13 +370,10 @@ Result<PyObject*> UuidFromBytes(std::string_view bytes) {
   OwnedRef py_bytes(
       PyBytes_FromStringAndSize(bytes.data(), static_cast<Py_ssize_t>(bytes.size())));
   RETURN_IF_PYERROR();
-  OwnedRef kwargs(PyDict_New());
-  RETURN_IF_PYERROR();
-  if (PyDict_SetItemString(kwargs.obj(), "bytes", py_bytes.obj()) < 0) {
+  if (PyDict_SetItemString(kwargs, "bytes", py_bytes.obj()) < 0) {
     RETURN_IF_PYERROR();
   }
-  OwnedRef args(PyTuple_New(0));
-  PyObject* result = PyObject_Call(uuid_class, args.obj(), kwargs.obj());
+  PyObject* result = PyObject_Call(uuid_class, args, kwargs);
   RETURN_IF_PYERROR();
   return result;
 }

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -18,6 +18,7 @@
 // helpers.h includes a NumPy header, so we include this first
 #include "arrow/python/numpy_init.h"
 #include "arrow/python/numpy_interop.h"
+#include "arrow/python/vendored/pythoncapi_compat.h"
 
 #include "arrow/python/helpers.h"
 
@@ -361,8 +362,7 @@ bool IsPyUuid(PyObject* obj) {
   return result != 0;
 }
 
-Result<PyObject*> UuidFromBytes(std::string_view bytes, PyObject* args,
-                                PyObject* kwargs) {
+Result<PyObject*> UuidFromBytes(std::string_view bytes, PyObject* kwargs) {
   PyObject* uuid_class = GetUuidClass();
   if (!uuid_class) {
     return Status::Invalid("Could not import uuid.UUID");
@@ -373,7 +373,8 @@ Result<PyObject*> UuidFromBytes(std::string_view bytes, PyObject* args,
   if (PyDict_SetItemString(kwargs, "bytes", py_bytes.obj()) < 0) {
     RETURN_IF_PYERROR();
   }
-  PyObject* result = PyObject_Call(uuid_class, args, kwargs);
+  PyObject* empty_args = Py_GetConstantBorrowed(Py_CONSTANT_EMPTY_TUPLE);
+  PyObject* result = PyObject_Call(uuid_class, empty_args, kwargs);
   RETURN_IF_PYERROR();
   return result;
 }

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -338,22 +338,46 @@ struct ModuleOnceRunner {
 static PyObject* uuid_UUID = nullptr;
 static ModuleOnceRunner uuid_runner("uuid");
 
-}  // namespace
-
-bool IsPyUuid(PyObject* obj) {
+PyObject* GetUuidClass() {
   uuid_runner.RunOnce([](OwnedRef& module) {
     OwnedRef ref;
     if (ImportFromModule(module.obj(), "UUID", &ref).ok()) {
       uuid_UUID = ref.obj();
     }
   });
-  if (!uuid_UUID) return false;
-  int result = PyObject_IsInstance(obj, uuid_UUID);
+  return uuid_UUID;
+}
+
+}  // namespace
+
+bool IsPyUuid(PyObject* obj) {
+  PyObject* uuid_class = GetUuidClass();
+  if (!uuid_class) return false;
+  int result = PyObject_IsInstance(obj, uuid_class);
   if (result < 0) {
     PyErr_Clear();
     return false;
   }
   return result != 0;
+}
+
+Result<PyObject*> UuidFromBytes(std::string_view bytes) {
+  PyObject* uuid_class = GetUuidClass();
+  if (!uuid_class) {
+    return Status::Invalid("Could not import uuid.UUID");
+  }
+  OwnedRef py_bytes(
+      PyBytes_FromStringAndSize(bytes.data(), static_cast<Py_ssize_t>(bytes.size())));
+  RETURN_IF_PYERROR();
+  OwnedRef kwargs(PyDict_New());
+  RETURN_IF_PYERROR();
+  if (PyDict_SetItemString(kwargs.obj(), "bytes", py_bytes.obj()) < 0) {
+    RETURN_IF_PYERROR();
+  }
+  OwnedRef args(PyTuple_New(0));
+  PyObject* result = PyObject_Call(uuid_class, args.obj(), kwargs.obj());
+  RETURN_IF_PYERROR();
+  return result;
 }
 
 namespace {

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -22,6 +22,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "arrow/python/numpy_interop.h"
@@ -95,6 +96,10 @@ bool PyFloat_IsNaN(PyObject* obj);
 // \brief Check whether obj is a uuid.UUID instance
 ARROW_PYTHON_EXPORT
 bool IsPyUuid(PyObject* obj);
+
+// \brief Construct a uuid.UUID from 16 raw bytes
+ARROW_PYTHON_EXPORT
+Result<PyObject*> UuidFromBytes(std::string_view bytes);
 
 inline bool IsPyBinary(PyObject* obj) {
   return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -99,7 +99,7 @@ bool IsPyUuid(PyObject* obj);
 
 // \brief Construct a uuid.UUID from 16 raw bytes
 ARROW_PYTHON_EXPORT
-Result<PyObject*> UuidFromBytes(std::string_view bytes, PyObject* args, PyObject* kwargs);
+Result<PyObject*> UuidFromBytes(std::string_view bytes, PyObject* kwargs);
 
 inline bool IsPyBinary(PyObject* obj) {
   return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -99,7 +99,7 @@ bool IsPyUuid(PyObject* obj);
 
 // \brief Construct a uuid.UUID from 16 raw bytes
 ARROW_PYTHON_EXPORT
-Result<PyObject*> UuidFromBytes(std::string_view bytes);
+Result<PyObject*> UuidFromBytes(std::string_view bytes, PyObject* args, PyObject* kwargs);
 
 inline bool IsPyBinary(PyObject* obj) {
   return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);

--- a/python/pyarrow/src/arrow/python/pyarrow-baseline-venv.code-workspace
+++ b/python/pyarrow/src/arrow/python/pyarrow-baseline-venv.code-workspace
@@ -1,0 +1,51 @@
+{
+	"folders": [
+		{
+			"path": "../../../../../../../../pyarrow-baseline-venv"
+		},
+		{
+			"path": "../../../../../../../../pyarrow-build-venv"
+		},
+		{
+			"path": "../../../../../../../../pyarrow-dist"
+		},
+		{
+			"path": "../../../../../../../../pyarrow-test-venvs"
+		}
+	],
+	"settings": {
+		"files.associations": {
+			"__locale": "cpp",
+			"__verbose_abort": "cpp",
+			"bitset": "cpp",
+			"cmath": "cpp",
+			"complex": "cpp",
+			"cstdarg": "cpp",
+			"cstddef": "cpp",
+			"cstdint": "cpp",
+			"cstdio": "cpp",
+			"cstdlib": "cpp",
+			"cstring": "cpp",
+			"ctime": "cpp",
+			"cwchar": "cpp",
+			"execution": "cpp",
+			"memory": "cpp",
+			"initializer_list": "cpp",
+			"ios": "cpp",
+			"iosfwd": "cpp",
+			"istream": "cpp",
+			"limits": "cpp",
+			"locale": "cpp",
+			"mutex": "cpp",
+			"new": "cpp",
+			"print": "cpp",
+			"sstream": "cpp",
+			"stdexcept": "cpp",
+			"streambuf": "cpp",
+			"string": "cpp",
+			"string_view": "cpp",
+			"typeinfo": "cpp",
+			"algorithm": "cpp"
+		}
+	}
+}

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -604,6 +604,27 @@ def test_uuid_extension_type():
         store_schema=False)
 
 
+@pytest.mark.pandas
+def test_uuid_roundtrip(tempdir):
+    import uuid
+    u1, u2 = uuid.uuid4(), uuid.uuid4()
+    df = pd.DataFrame({"id": [u1, None, u2]})
+    table = pa.Table.from_pandas(df)
+    assert table.column("id").type == pa.uuid()
+
+    path = tempdir / "uuid_pandas_roundtrip.parquet"
+    pq.write_table(table, path)
+    read_table = pq.read_table(path)
+    assert read_table.column("id").type == pa.uuid()
+
+    result_df = read_table.to_pandas()
+    assert isinstance(result_df.loc[0, "id"], uuid.UUID)
+    assert isinstance(result_df.loc[2, "id"], uuid.UUID)
+    assert result_df.loc[0, "id"] == u1
+    assert result_df.loc[2, "id"] == u2
+    assert pd.isna(result_df.loc[1, "id"])
+
+
 def test_undefined_logical_type(parquet_test_datadir):
     test_file = f"{parquet_test_datadir}/unknown-logical-type.parquet"
 

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1400,6 +1400,40 @@ def test_uuid_extension():
     assert isinstance(array[0], pa.UuidScalar)
 
 
+@pytest.mark.pandas
+def test_uuid_to_pandas():
+    import pandas as pd
+    import pandas.testing as tm
+    values = [uuid4(), None, uuid4()]
+    array = pa.array(values, type=pa.uuid())
+    chunked_array = pa.chunked_array([array.slice(0, 1), array.slice(1)])
+    expected = pd.Series(values, dtype=object)
+    tm.assert_series_equal(array.to_pandas(), expected)
+    tm.assert_series_equal(chunked_array.to_pandas(), expected)
+    tm.assert_frame_equal(
+        pa.table({"uuid": chunked_array}).to_pandas(),
+        expected.to_frame(name="uuid"),
+    )
+
+
+@pytest.mark.pandas
+def test_uuid_to_pandas_options():
+    values = [uuid4(), uuid4()] * 2
+    array = pa.array(values, type=pa.uuid())
+    chunked_array = pa.chunked_array([array.slice(0, 2), array.slice(2)])
+    for obj in [array, chunked_array, pa.table({"uuid": chunked_array})]:
+        with pytest.raises(pa.ArrowInvalid):
+            obj.to_pandas(zero_copy_only=True)
+        result = obj.to_pandas()
+        if result.ndim == 2:
+            result = result["uuid"]
+        assert len({id(value) for value in result}) == 2
+        result = obj.to_pandas(deduplicate_objects=False)
+        if result.ndim == 2:
+            result = result["uuid"]
+        assert len({id(value) for value in result}) == 4
+
+
 def test_uuid_scalar_from_python():
     # Test with explicit type
     py_uuid = uuid4()

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1400,6 +1400,13 @@ def test_uuid_extension():
     assert isinstance(array[0], pa.UuidScalar)
 
 
+@pytest.mark.numpy
+def test_uuid_to_numpy_uses_storage():
+    value = uuid4()
+    array = pa.array([value], type=pa.uuid())
+    assert array.to_numpy(zero_copy_only=False).tolist() == [value.bytes]
+
+
 @pytest.mark.pandas
 def test_uuid_to_pandas():
     import pandas as pd


### PR DESCRIPTION
### Rationale for this change

Converting a Table with an `arrow.uuid` extension column to pandas currently produces a column of `bytes` instead of `uuid.UUID` objects. Without a dedicated conversion path, `Table.to_pandas()` / `Array.to_pandas()` falls back to the storage type (`fixed_size_binary(16)`) and materializes raw bytes. Downstream callers (and tests such as those landing via pandas UUID Parquet coverage) expect `uuid.UUID` objects, matching what `to_pylist()` / `UuidScalar.as_py()` already return.

Note: the original issue suggested this might be specific to Python 3.14, but the same `bytes` result reproduces on Python 3.10-3.14 with current PyArrow - `UuidType` never had a pandas conversion path.

Closes #50312

### What changes are included in this PR?

Convert UUID extension arrays to `uuid.UUID` objects in the C++ pandas conversion path (integrated from @rok's proposal in rok/arrow#55), rather than relying on a Python `to_pandas_dtype()` / `__from_arrow__` compat layer:

- Construct `uuid.UUID` objects from storage bytes in `helpers.cc` (`UuidFromBytes`) and use that from `arrow_to_pandas.cc`
- Reuse empty kwargs / shared empty tuple constants so conversion does not allocate per element
- Keep `to_numpy(zero_copy_only=False)` on UUID extension arrays returning storage `bytes` (extension to NumPy should follow storage type)
- Add/extend regression tests for pandas round-trip and NumPy behavior

### Are these changes tested?

Yes.

Acceptance criteria:
- [x] Tests added for the UUID to pandas round-trip (and NumPy storage behavior)
- [x] Relevant local / CI Python tests passing for the touched paths
- [x] Follows project style / review feedback (lint fix included)
- [x] No intentional breaking public API change beyond correcting incorrect `bytes` return values to `uuid.UUID` for `to_pandas()`

Before / after evidence (backend; console):

```text
# Before (repro on Python 3.10-3.14 with unfixed PyArrow)
>>> type(result_df.loc[0, "id"])
<class 'bytes'>

# After (with this PR)
>>> type(result_df.loc[0, "id"])
<class 'uuid.UUID'>
```

Also covered by added unit tests in `python/pyarrow/tests/parquet/test_data_types.py` and `python/pyarrow/tests/test_extension_type.py`.

### Are there any user-facing changes?

Yes. `Table.to_pandas()` / `Array.to_pandas()` now returns `uuid.UUID` for `arrow.uuid` columns instead of `bytes`. `to_numpy(zero_copy_only=False)` continues to expose storage `bytes`.

* GitHub Issue: #50312

