### PR TITLE
GH-50336: [Release][Archery] Fix archery GitHub integration for release scripts

### DIFF
--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -208,7 +208,7 @@ def verify_release_candidate(obj, base_branch, create_pr,
         for flag, group in zip(verify_flags, verify_groups):
             if flag:
                 job_groups += f" --group {group}"
-        response.create_comment(
+        response.create_issue_comment(
             f"{command} {job_groups} --param " +
             f"release={version} --param rc={rc}")
 
@@ -300,6 +300,10 @@ def status(obj, job_name, fetch, task_filters, validate):
 
 
 @crossbow.command()
+@click.option('--base-branch', default='main',
+              help='Set base branch for the PR.')
+@click.option('--head-branch', default=None,
+              help='Set head branch for the PR.')
 @click.option('--arrow-remote', '-r', default=None,
               help='Set GitHub remote explicitly, which is going to be cloned '
                    'on the CI services. Note, that no validation happens '
@@ -313,7 +317,8 @@ def status(obj, job_name, fetch, task_filters, validate):
 @click.option('--pr-title', required=True,
               help='Track the job submitted on PR with given title')
 @click.pass_obj
-def report_pr(obj, arrow_remote, crossbow, fetch, job_name, pr_title):
+def report_pr(obj, base_branch, head_branch, arrow_remote, crossbow,
+              fetch, job_name, pr_title):
     arrow = obj['arrow']
     queue = obj['queue']
     if fetch:
@@ -322,11 +327,12 @@ def report_pr(obj, arrow_remote, crossbow, fetch, job_name, pr_title):
 
     report = CommentReport(job, crossbow_repo=crossbow)
     target_arrow = Repo(path=arrow.path, remote_url=arrow_remote)
-    pull_request = target_arrow.github_pr(title=pr_title,
+    pull_request = target_arrow.github_pr(base=base_branch, head=head_branch,
+                                          title=pr_title,
                                           github_token=queue.github_token,
                                           create=False)
     # render the response comment's content on the PR
-    pull_request.create_comment(report.show())
+    pull_request.create_issue_comment(report.show())
     click.echo(f'Job is tracked on PR {pull_request.html_url}')
 
 

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -34,7 +34,7 @@ version_with_rc="${version}-rc${rc}"
 crossbow_job_prefix="release-${version_with_rc}"
 release_tag="apache-arrow-${version}-rc${rc}"
 rc_branch="release-${version_with_rc}"
-maint-branch="maint-${version}"
+maint_branch="maint-${version}"
 
 : ${ARROW_REPOSITORY:="apache/arrow"}
 : ${ARROW_BRANCH:=${release_tag}}

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -34,6 +34,7 @@ version_with_rc="${version}-rc${rc}"
 crossbow_job_prefix="release-${version_with_rc}"
 release_tag="apache-arrow-${version}-rc${rc}"
 rc_branch="release-${version_with_rc}"
+maint-branch="maint-${version}"
 
 : ${ARROW_REPOSITORY:="apache/arrow"}
 : ${ARROW_BRANCH:=${release_tag}}
@@ -57,5 +58,7 @@ job_name=$(archery crossbow latest-prefix --no-fetch ${crossbow_job_prefix})
 archery crossbow report-pr \
     --no-fetch \
     --arrow-remote "https://github.com/${ARROW_REPOSITORY}" \
+    --base-branch ${maint_branch} \
+    --head-branch ${rc_branch} \
     --job-name ${job_name} \
     --pr-title "WIP: [Release] Verify ${rc_branch}"


### PR DESCRIPTION
### Rationale for this change

The source verification and binary verification scripts comment to the Verification PR were failing due to the last updates to archery in order to use a single dependency.

### What changes are included in this PR?

Add required base and head branches to be used when looking for a PR.

Use create_issue_comment on PRs instead of create_comment which tries to create a review comment which requires more arguments.

### Are these changes tested?

Yes, I've tested them locally in isolation in order to add comments on the verification PR.

### Are there any user-facing changes?

No

* GitHub Issue: #50336