### PR TITLE
GH-50293: [CI] Run check-labels for all triggers to avoid cancelling further steps and add tag to set_enabled

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -74,12 +74,14 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}
     steps:
       - id: set_enabled
         if: >-
+          github.ref_type == 'tag' ||
           (github.event_name == 'schedule' && github.repository == 'apache/arrow') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -66,7 +66,6 @@ permissions:
 
 jobs:
   check-labels:
-    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/check_labels.yml
     with:
       parent-workflow: cpp_extra
@@ -74,7 +73,6 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
-    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}

--- a/.github/workflows/cuda_extra.yml
+++ b/.github/workflows/cuda_extra.yml
@@ -57,12 +57,14 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}
     steps:
       - id: set_enabled
         if: >-
+          github.ref_type == 'tag' ||
           (github.event_name == 'schedule' && github.repository == 'apache/arrow') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: CUDA')

--- a/.github/workflows/cuda_extra.yml
+++ b/.github/workflows/cuda_extra.yml
@@ -49,7 +49,6 @@ permissions:
 
 jobs:
   check-labels:
-    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/check_labels.yml
     with:
       parent-workflow: cuda_extra
@@ -57,7 +56,6 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
-    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -66,12 +66,14 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}
     steps:
       - id: set_enabled
         if: >-
+          github.ref_type == 'tag' ||
           (github.event_name == 'schedule' && github.repository == 'apache/arrow') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: Package: Linux')

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -58,7 +58,6 @@ permissions:
 
 jobs:
   check-labels:
-    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/check_labels.yml
     with:
       parent-workflow: package_linux
@@ -66,7 +65,6 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
-    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}

--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -69,12 +69,14 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}
     steps:
       - id: set_enabled
         if: >-
+          github.ref_type == 'tag' ||
           (github.event_name == 'schedule' && github.repository == 'apache/arrow') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
           contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: R')

--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -61,7 +61,6 @@ permissions:
 
 jobs:
   check-labels:
-    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/check_labels.yml
     with:
       parent-workflow: r_extra
@@ -69,7 +68,6 @@ jobs:
   check-enabled:
     # Check whether the CI builds in this workflow need to be run
     needs: check-labels
-    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       is_enabled: ${{ steps.set_enabled.outputs.is_enabled }}


### PR DESCRIPTION
### Rationale for this change

Currently when check-labels is not a pull_request even the following steps are cancelled. Also we don't enable tags execution which is required for releases.

### What changes are included in this PR?

Run check-labels for the specified events and enable jobs for tags.

### Are these changes tested?

I've tested on my fork by pushing to main and creating tags, more details on the comment on the PR.

### Are there any user-facing changes?

No

* GitHub Issue: #50293