### PR TITLE
GH-50345: [CI] Remove redundant checkout step from check_labels.yml

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -41,11 +41,6 @@ jobs:
     outputs:
       ci-extra-labels: ${{ steps.check.outputs.ci-extra-labels }}
     steps:
-      - name: Checkout Arrow
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
       - name: Check
         id: check
         env:


### PR DESCRIPTION
### Rationale for this change

`check_labels.yml` no longer uses fork repository content because GH-50256 removed changed paths based check. 

### What changes are included in this PR?

Remove redundant `actions/checkout` step.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50345