### PR TITLE
GH-50348: [C++] Fix duplicate keys issue in `KeyValueMetadata`

### DIFF
--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -62,12 +62,27 @@ KeyValueMetadata::KeyValueMetadata(
     const std::unordered_map<std::string, std::string>& map)
     : keys_(UnorderedMapKeys(map)), values_(UnorderedMapValues(map)) {
   ARROW_CHECK_EQ(keys_.size(), values_.size());
+  std::vector<std::string> unique_keys, unique_values;
+  for (size_t i = 0; i < keys_.size(); i++) {
+    if (map_.find(keys_[i]) == map_.end()) {
+      map_[keys_[i]] = i;
+      unique_keys.push_back(keys_[i]);
+      unique_values.push_back(values_[i]);
+    } else {
+      unique_values[map_[keys_[i]]] = values_[i];
+    }
+  }
+  keys_ = std::move(unique_keys);
+  values_ = std::move(unique_values);
 }
 
 KeyValueMetadata::KeyValueMetadata(std::vector<std::string> keys,
                                    std::vector<std::string> values)
     : keys_(std::move(keys)), values_(std::move(values)) {
   ARROW_CHECK_EQ(keys.size(), values.size());
+  for (size_t i = 0; i < keys_.size(); i++) {
+    map_[keys_[i]] = i;
+  }
 }
 
 std::shared_ptr<KeyValueMetadata> KeyValueMetadata::Make(
@@ -86,8 +101,16 @@ void KeyValueMetadata::ToUnorderedMap(
 }
 
 void KeyValueMetadata::Append(std::string key, std::string value) {
-  keys_.push_back(std::move(key));
-  values_.push_back(std::move(value));
+  auto it = map_.find(key);
+
+  if (it != map_.end()) {
+    values_[it->second] = std::move(value);
+  } else {
+    size_t new_index = keys_.size();
+    map_[key] = new_index;
+    keys_.push_back(std::move(key));
+    values_.push_back(std::move(value));
+  }
 }
 
 Result<std::string> KeyValueMetadata::Get(std::string_view key) const {
@@ -106,8 +129,13 @@ Status KeyValueMetadata::Delete(int64_t index) {
                               "of size ",
                               keys_.size());
   }
+  map_.erase(map_.find(keys_[index]));
   keys_.erase(keys_.begin() + index);
   values_.erase(values_.begin() + index);
+  size_t n = keys_.size();
+  for (size_t i = index; i < n; i++) {
+    map_[keys_[i]] = i;
+  }
   return Status::OK();
 }
 
@@ -162,6 +190,7 @@ void KeyValueMetadata::reserve(int64_t n) {
   const auto m = static_cast<size_t>(n);
   keys_.reserve(m);
   values_.reserve(m);
+  map_.reserve(m);
 }
 
 int64_t KeyValueMetadata::size() const {
@@ -193,10 +222,9 @@ std::vector<std::pair<std::string, std::string>> KeyValueMetadata::sorted_pairs(
 }
 
 int KeyValueMetadata::FindKey(std::string_view key) const {
-  for (size_t i = 0; i < keys_.size(); ++i) {
-    if (keys_[i] == key) {
-      return static_cast<int>(i);
-    }
+  auto it = map_.find(std::string(key));
+  if (it != map_.end()) {
+    return static_cast<int>(it->second);
   }
   return -1;
 }

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -62,26 +62,18 @@ KeyValueMetadata::KeyValueMetadata(
     const std::unordered_map<std::string, std::string>& map)
     : keys_(UnorderedMapKeys(map)), values_(UnorderedMapValues(map)) {
   ARROW_CHECK_EQ(keys_.size(), values_.size());
-  std::vector<std::string> unique_keys, unique_values;
+  map_.reserve(keys_.size());
   for (size_t i = 0; i < keys_.size(); i++) {
-    if (map_.find(keys_[i]) == map_.end()) {
-      map_[keys_[i]] = i;
-      unique_keys.push_back(keys_[i]);
-      unique_values.push_back(values_[i]);
-    } else {
-      unique_values[map_[keys_[i]]] = values_[i];
-    }
+    map_[keys_[i]] = i;
   }
-  keys_ = std::move(unique_keys);
-  values_ = std::move(unique_values);
 }
 
 KeyValueMetadata::KeyValueMetadata(std::vector<std::string> keys,
-                                   std::vector<std::string> values)
-    : keys_(std::move(keys)), values_(std::move(values)) {
+                                   std::vector<std::string> values) {
   ARROW_CHECK_EQ(keys.size(), values.size());
-  for (size_t i = 0; i < keys_.size(); i++) {
-    map_[keys_[i]] = i;
+  reserve(static_cast<int64_t>(keys.size()));
+  for (size_t i = 0; i < keys.size(); ++i) {
+    Append(std::move(keys[i]), std::move(values[i]));
   }
 }
 
@@ -106,8 +98,7 @@ void KeyValueMetadata::Append(std::string key, std::string value) {
   if (it != map_.end()) {
     values_[it->second] = std::move(value);
   } else {
-    size_t new_index = keys_.size();
-    map_[key] = new_index;
+    map_[key] = keys_.size();
     keys_.push_back(std::move(key));
     values_.push_back(std::move(value));
   }
@@ -129,7 +120,7 @@ Status KeyValueMetadata::Delete(int64_t index) {
                               "of size ",
                               keys_.size());
   }
-  map_.erase(map_.find(keys_[index]));
+  map_.erase(keys_[index]);
   keys_.erase(keys_.begin() + index);
   values_.erase(values_.begin() + index);
   size_t n = keys_.size();
@@ -142,6 +133,9 @@ Status KeyValueMetadata::Delete(int64_t index) {
 Status KeyValueMetadata::DeleteMany(std::vector<int64_t> indices) {
   std::sort(indices.begin(), indices.end());
   const int64_t size = static_cast<int64_t>(keys_.size());
+  for (int64_t idx : indices) {
+    map_.erase(keys_[idx]);
+  }
   indices.push_back(size);
 
   int64_t shift = 0;
@@ -156,6 +150,7 @@ Status KeyValueMetadata::DeleteMany(std::vector<int64_t> indices) {
     for (int64_t index = start; index < stop; ++index) {
       keys_[index - shift] = std::move(keys_[index]);
       values_[index - shift] = std::move(values_[index]);
+      map_[keys_[index - shift]] = index - shift;
     }
   }
   keys_.resize(size - shift);

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -79,6 +79,7 @@ class ARROW_EXPORT KeyValueMetadata {
  private:
   std::vector<std::string> keys_;
   std::vector<std::string> values_;
+  std::unordered_map<std::string, size_t> map_;
 
   ARROW_DISALLOW_COPY_AND_ASSIGN(KeyValueMetadata);
 };

--- a/cpp/src/arrow/util/key_value_metadata_test.cc
+++ b/cpp/src/arrow/util/key_value_metadata_test.cc
@@ -193,8 +193,8 @@ TEST(KeyValueMetadataTest, Delete) {
         "of size 5";
     ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(-1));
     expected_error_message =
-        "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata "
-        "of size 5";
+        "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata of "
+        "size 5";
     ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(7));
 
     ASSERT_OK(metadata.Delete(4));
@@ -204,8 +204,8 @@ TEST(KeyValueMetadataTest, Delete) {
     ASSERT_OK(metadata.Delete(0));
 
     expected_error_message =
-        "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata "
-        "of size 0";
+        "Index error: KeyValueMetadata::Delete: index 7 is out of bounds for metadata of "
+        "size 0";
     ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message, metadata.Delete(7));
   }
   {
@@ -229,21 +229,25 @@ TEST(KeyValueMetadataTest, Delete) {
 }
 
 TEST(KeyValueMetadataTest, DuplicateKeys) {
-  KeyValueMetadata metadata1;
-  metadata1.Append("k", "v1");
-  metadata1.Append("k", "v2");
-  std::string result = metadata1.ToString();
-  std::string expected = R"(
--- metadata --
-k: v2)";
-  ASSERT_EQ(result, expected);
-
-  ASSERT_EQ(metadata1.FindKey("k"), 0);
-
-  KeyValueMetadata metadata2;
-  metadata2.Append("k", "v2");
-
-  ASSERT_TRUE(metadata1.Equals(metadata2));
+  {  // FindKey method
+    KeyValueMetadata metadata;
+    metadata.Append("k", "v1");
+    metadata.Append("k", "v2");
+    ASSERT_EQ(metadata.FindKey("k"), 0);
+  }
+  {  // Append method
+    KeyValueMetadata metadata1, metadata2;
+    metadata1.Append("k", "v1");
+    metadata1.Append("k", "v2");
+    metadata2.Append("k", "v2");
+    ASSERT_EQ(metadata1.ToString(), metadata2.ToString());
+  }
+  {  // KeyValueMetadata(vector<string> keys, vector<string> values) constructor
+    KeyValueMetadata metadata({"k", "other", "k"}, {"v1", "x", "v2"});
+    ASSERT_EQ(metadata.size(), 2);
+    ASSERT_EQ(metadata.FindKey("k"), 0);
+    ASSERT_EQ(metadata.value(0), "v2");
+  }
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/key_value_metadata_test.cc
+++ b/cpp/src/arrow/util/key_value_metadata_test.cc
@@ -228,4 +228,22 @@ TEST(KeyValueMetadataTest, Delete) {
   }
 }
 
+TEST(KeyValueMetadataTest, DuplicateKeys) {
+  KeyValueMetadata metadata1;
+  metadata1.Append("k", "v1");
+  metadata1.Append("k", "v2");
+  std::string result = metadata1.ToString();
+  std::string expected = R"(
+-- metadata --
+k: v2)";
+  ASSERT_EQ(result, expected);
+
+  ASSERT_EQ(metadata1.FindKey("k"), 0);
+
+  KeyValueMetadata metadata2;
+  metadata2.Append("k", "v2");
+
+  ASSERT_TRUE(metadata1.Equals(metadata2));
+}
+
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

`KeyValueMetadata` uses 2 vectors internally to manage the keys and the values. This causes it to accept duplicate keys. When new key-value pairs are appended such that the key already exists in the metadata, the metadata just accepts it as a duplicate, but while finding the key, it returns the first inserted value, not the last updated value. This causes the updated key added using the `Append` function to become "virtually non-existant". I use an hashmap - unordered_map to store pairs of (key, index) where index is the index of the key in the vector `keys_`. This enables significant performance gains also in some methods of `KeyValueMetadata`.

### What changes are included in this PR?
* I added an `unordered_map` along with the existing vectors to keep track of the key value pairs in the metadata. 
* Logic to avoid duplicate keys is added.
* If a user adds an already existing key, then the existing key's value gets update rather than making a duplicate entry.
* Reduces the time complexity of `FindKey` from `O(n)` to `O(1)`.
* `Equals` works properly with the new logic

### Are these changes tested?
I have added tests in `key_value_metadata_test.cc` testing the duplicate keys scenario.
I tested them locally, all tests pass.

### Are there any user-facing changes?
No, I tried to keep the API as it is.
* GitHub Issue: #50348