### PR TITLE
GH-30800: [Python][Docs] Document partition fields with explicit dataset schemas

### DIFF
--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -374,6 +374,24 @@ altogether if they do not match the filter:
     3  8  0.313068  1    b
     4  9 -0.854096  2    b
 
+When passing an explicit ``schema`` to :func:`dataset`, include the partition
+fields in the schema if they are used in filters or projections. The partition
+fields are not stored in the physical files, so they need to be present in the
+dataset schema when schema inference is bypassed:
+
+.. code-block:: python
+
+    >>> schema = pa.schema([
+    ...     ("a", pa.int64()),
+    ...     ("b", pa.float64()),
+    ...     ("c", pa.int64()),
+    ...     ("part", pa.string()),
+    ... ])
+    >>> dataset = ds.dataset("parquet_dataset_partitioned", format="parquet",
+    ...                      partitioning="hive", schema=schema)
+    >>> dataset.count_rows(filter=ds.field("part") == "b")
+    5
+
 
 Different partitioning schemes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary:
- Document that explicit dataset schemas for partitioned datasets must include partition fields used in filters or projections.
- Add a doctest-backed example showing a Hive partition field used with `count_rows`.

Validation:
- `/tmp/arrow-doccheck-30800/bin/python -m pytest --doctest-glob="*.rst" docs/source/python/dataset.rst -q` — passed, `1 passed`
- `git diff --check HEAD~1 HEAD` — passed

* GitHub Issue: #30800