### PR TITLE
GH-50351: [C++] Fix KeyValueMetadata::DeleteMany crash with duplicate indices

### DIFF
--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -114,6 +114,17 @@ Status KeyValueMetadata::Delete(int64_t index) {
 Status KeyValueMetadata::DeleteMany(std::vector<int64_t> indices) {
   std::sort(indices.begin(), indices.end());
   const int64_t size = static_cast<int64_t>(keys_.size());
+  if (ARROW_PREDICT_FALSE(!indices.empty() &&
+                          (indices.front() < 0 || indices.back() >= size))) {
+    const int64_t out_of_bounds = indices.front() < 0 ? indices.front() : indices.back();
+    return Status::IndexError("KeyValueMetadata::DeleteMany: index ", out_of_bounds,
+                              " is out of bounds for metadata "
+                              "of size ",
+                              size);
+  }
+  // Remove duplicate indices, otherwise the shifting logic below would move
+  // entries to incorrect (potentially negative) positions (GH-50351)
+  indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
   indices.push_back(size);
 
   int64_t shift = 0;

--- a/cpp/src/arrow/util/key_value_metadata_test.cc
+++ b/cpp/src/arrow/util/key_value_metadata_test.cc
@@ -226,6 +226,36 @@ TEST(KeyValueMetadataTest, Delete) {
     ASSERT_OK(metadata.DeleteMany({}));
     ASSERT_TRUE(metadata.Equals(KeyValueMetadata({"bb", "dd", "ee"}, {"2", "4", "5"})));
   }
+  {
+    // GH-50351: duplicate indices must not crash and are treated as one
+    KeyValueMetadata metadata(keys, values);
+    ASSERT_OK(metadata.DeleteMany({0, 0}));
+    ASSERT_TRUE(metadata.Equals(KeyValueMetadata({"bb", "cc", "dd", "ee", "ff", "gg"},
+                                                 {"2", "3", "4", "5", "6", "7"})));
+
+    ASSERT_OK(metadata.DeleteMany({1, 3, 1, 3, 1}));
+    ASSERT_TRUE(metadata.Equals(
+        KeyValueMetadata({"bb", "dd", "ff", "gg"}, {"2", "4", "6", "7"})));
+  }
+  {
+    // GH-50351: out-of-bounds indices must error without modifying metadata
+    KeyValueMetadata metadata(keys, values);
+    std::string expected_error_message =
+        "Index error: KeyValueMetadata::DeleteMany: index 7 is out of bounds for "
+        "metadata "
+        "of size 7";
+    ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message,
+                               metadata.DeleteMany({7}));
+    expected_error_message =
+        "Index error: KeyValueMetadata::DeleteMany: index -1 is out of bounds for "
+        "metadata "
+        "of size 7";
+    ASSERT_RAISES_WITH_MESSAGE(IndexError, expected_error_message,
+                               metadata.DeleteMany({-1}));
+    ASSERT_RAISES(IndexError, metadata.DeleteMany({0, 3, 7}));
+    ASSERT_RAISES(IndexError, metadata.DeleteMany({-1, 0, 3}));
+    ASSERT_TRUE(metadata.Equals(KeyValueMetadata(keys, values)));
+  }
 }
 
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

`KeyValueMetadata::DeleteMany` crashes (out-of-bounds write) when the indices vector
contains duplicates, e.g. `DeleteMany({0, 0})`. The compaction loop increments its `shift`
counter once per entry, so duplicates cause writes at negative offsets.

Additionally, out-of-range indices were only checked by `DCHECK`, so in release builds
`DeleteMany({size})` silently deleted the last element and negative indices were UB.

### What changes are included in this PR?

- `DeleteMany` now validates indices after sorting and returns `Status::IndexError` for
  any index out of `[0, size)`, matching the behavior and message format of `Delete`.
  Metadata is left unmodified on error.
- Duplicate indices are removed with `std::unique` before compaction, so deleting the
  same index twice is equivalent to deleting it once.

### Are these changes tested?

Yes — added cases to `KeyValueMetadataTest.Delete` covering duplicate indices
(`{0,0}`, `{1,3,1,3,1}`), out-of-bounds positive and negative indices (exact error
messages), and that metadata is unchanged after a failed call.

### Are there any user-facing changes?

Yes, minor behavioral fix: `DeleteMany` now returns `IndexError` for out-of-range indices
instead of crashing (duplicates) or silently corrupting state (release builds). No API change.

* GitHub Issue: #50351