### PR TITLE
GH-50355: [C++][Gandiva] fix out-of-bounds read in utf8_length_ignore_invalid

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -208,6 +208,11 @@ gdv_int32 utf8_length_ignore_invalid(const char* data, gdv_int32 data_len) {
     }
     for (int j = 1; j < char_len; ++j) {
       if ((data[i + j] & 0xC0) != 0x80) {  // bytes following head-byte of glyph
+        // Only the bytes up to the mismatch belong to this (invalid) glyph, so
+        // advance past them and let the outer loop re-parse the rest. Keeping
+        // char_len at its declared width would swallow valid characters that
+        // fall inside the truncated sequence's window.
+        char_len = j;
         break;
       }
     }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -206,7 +206,7 @@ gdv_int32 utf8_length_ignore_invalid(const char* data, gdv_int32 data_len) {
       // if invalid byte or incomplete glyph, ignore it
       char_len = 1;
     }
-    for (int j = 1; j < char_len; ++j) {
+    for (int j = 1; j < char_len && i + j < data_len; ++j) {
       if ((data[i + j] & 0xC0) != 0x80) {  // bytes following head-byte of glyph
         char_len += 1;
       }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -206,9 +206,9 @@ gdv_int32 utf8_length_ignore_invalid(const char* data, gdv_int32 data_len) {
       // if invalid byte or incomplete glyph, ignore it
       char_len = 1;
     }
-    for (int j = 1; j < char_len && i + j < data_len; ++j) {
+    for (int j = 1; j < char_len; ++j) {
       if ((data[i + j] & 0xC0) != 0x80) {  // bytes following head-byte of glyph
-        char_len += 1;
+        break;
       }
     }
     ++count;

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1620,16 +1620,18 @@ TEST(TestStringOps, TestPadMalformedUtf8NoOverread) {
   // held in an exactly-sized heap buffer so any over-read trips AddressSanitizer.
   std::vector<char> text = {'\xF0', 'a', 'a', 'a'};
   const auto text_len = static_cast<gdv_int32>(text.size());
+  const std::string text_str(text.begin(), text.end());
 
+  // The malformed sequence is counted as one glyph, so padding to width 6 adds
+  // five fill characters.
   const char* out_str =
       lpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
   EXPECT_EQ(out_len, 9);
-  EXPECT_EQ(std::string(out_str + out_len - text_len, text_len),
-            std::string(text.begin(), text.end()));
+  EXPECT_EQ(std::string(out_str, out_len), "     " + text_str);
 
   out_str = rpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
   EXPECT_EQ(out_len, 9);
-  EXPECT_EQ(std::string(out_str, text_len), std::string(text.begin(), text.end()));
+  EXPECT_EQ(std::string(out_str, out_len), text_str + "     ");
 }
 
 TEST(TestStringOps, TestRtrim) {

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1622,16 +1622,40 @@ TEST(TestStringOps, TestPadMalformedUtf8NoOverread) {
   const auto text_len = static_cast<gdv_int32>(text.size());
   const std::string text_str(text.begin(), text.end());
 
-  // The malformed sequence is counted as one glyph, so padding to width 6 adds
-  // five fill characters.
+  // The lone lead byte counts as one invalid glyph and the three 'a's as one
+  // each, so the length is 4 and padding to width 6 adds two fill characters.
   const char* out_str =
       lpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
-  EXPECT_EQ(out_len, 9);
-  EXPECT_EQ(std::string(out_str, out_len), "     " + text_str);
+  EXPECT_EQ(out_len, 6);
+  EXPECT_EQ(std::string(out_str, out_len), "  " + text_str);
 
   out_str = rpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
-  EXPECT_EQ(out_len, 9);
-  EXPECT_EQ(std::string(out_str, out_len), text_str + "     ");
+  EXPECT_EQ(out_len, 6);
+  EXPECT_EQ(std::string(out_str, out_len), text_str + "  ");
+}
+
+TEST(TestStringOps, TestPadMalformedUtf8KeepsValidGlyph) {
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+
+  // {0xF0, 'a', 0xE2, 0x82, 0xAC}: malformed 4-byte lead + ASCII 'a' + U+20AC €.
+  // 0xF0 alone counts as one invalid glyph, then 'a' and € follow on their own,
+  // so the count is 3. If the inner scan kept char_len at 4 it would advance the
+  // outer loop past 'a', 0xE2, 0x82 and only see the orphaned 0xAC, giving 2.
+  std::vector<char> text = {'\xF0', 'a', '\xE2', '\x82', '\xAC'};
+  const auto text_len = static_cast<gdv_int32>(text.size());
+  const std::string text_str(text.begin(), text.end());
+
+  // 3 glyphs padded to width 5 adds two fill characters, out_len = 2 + 5 = 7.
+  const char* out_str =
+      lpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 5, " ", 1, &out_len);
+  EXPECT_EQ(out_len, 7);
+  EXPECT_EQ(std::string(out_str, out_len), "  " + text_str);
+
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 5, " ", 1, &out_len);
+  EXPECT_EQ(out_len, 7);
+  EXPECT_EQ(std::string(out_str, out_len), text_str + "  ");
 }
 
 TEST(TestStringOps, TestRtrim) {

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <vector>
 
 #include "gandiva/execution_context.h"
 #include "gandiva/precompiled/types.h"
@@ -1606,6 +1607,29 @@ TEST(TestStringOps, TestRpadString) {
   EXPECT_EQ(out_len, 5002);
   EXPECT_EQ(std::string(out_str, 5000), large_text);
   EXPECT_EQ(std::string(out_str + 5000, 2), "α");
+}
+
+TEST(TestStringOps, TestPadMalformedUtf8NoOverread) {
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+
+  // A 4-byte utf8 lead byte followed by non-continuation bytes and no trailing
+  // space. utf8_length_ignore_invalid() used to extend the glyph length past
+  // the end of the buffer while scanning the continuation bytes. The input is
+  // held in an exactly-sized heap buffer so any over-read trips AddressSanitizer.
+  std::vector<char> text = {'\xF0', 'a', 'a', 'a'};
+  const auto text_len = static_cast<gdv_int32>(text.size());
+
+  const char* out_str =
+      lpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
+  EXPECT_EQ(out_len, 9);
+  EXPECT_EQ(std::string(out_str + out_len - text_len, text_len),
+            std::string(text.begin(), text.end()));
+
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
+  EXPECT_EQ(out_len, 9);
+  EXPECT_EQ(std::string(out_str, text_len), std::string(text.begin(), text.end()));
 }
 
 TEST(TestStringOps, TestRtrim) {

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -21,7 +21,6 @@
 #include <cstring>
 #include <limits>
 #include <memory>
-#include <vector>
 
 #include "gandiva/execution_context.h"
 #include "gandiva/precompiled/types.h"

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -18,7 +18,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #include "gandiva/execution_context.h"
@@ -1618,18 +1620,20 @@ TEST(TestStringOps, TestPadMalformedUtf8NoOverread) {
   // space. utf8_length_ignore_invalid() used to extend the glyph length past
   // the end of the buffer while scanning the continuation bytes. The input is
   // held in an exactly-sized heap buffer so any over-read trips AddressSanitizer.
-  std::vector<char> text = {'\xF0', 'a', 'a', 'a'};
-  const auto text_len = static_cast<gdv_int32>(text.size());
-  const std::string text_str(text.begin(), text.end());
+  const char bytes[] = {'\xF0', 'a', 'a', 'a'};
+  const auto text_len = static_cast<gdv_int32>(sizeof(bytes));
+  std::unique_ptr<char[]> text(new char[text_len]);
+  std::memcpy(text.get(), bytes, text_len);
+  const std::string text_str(text.get(), text_len);
 
   // The lone lead byte counts as one invalid glyph and the three 'a's as one
   // each, so the length is 4 and padding to width 6 adds two fill characters.
   const char* out_str =
-      lpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
+      lpad_utf8_int32_utf8(ctx_ptr, text.get(), text_len, 6, " ", 1, &out_len);
   EXPECT_EQ(out_len, 6);
   EXPECT_EQ(std::string(out_str, out_len), "  " + text_str);
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 6, " ", 1, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, text.get(), text_len, 6, " ", 1, &out_len);
   EXPECT_EQ(out_len, 6);
   EXPECT_EQ(std::string(out_str, out_len), text_str + "  ");
 }
@@ -1643,17 +1647,20 @@ TEST(TestStringOps, TestPadMalformedUtf8KeepsValidGlyph) {
   // 0xF0 alone counts as one invalid glyph, then 'a' and € follow on their own,
   // so the count is 3. If the inner scan kept char_len at 4 it would advance the
   // outer loop past 'a', 0xE2, 0x82 and only see the orphaned 0xAC, giving 2.
-  std::vector<char> text = {'\xF0', 'a', '\xE2', '\x82', '\xAC'};
-  const auto text_len = static_cast<gdv_int32>(text.size());
-  const std::string text_str(text.begin(), text.end());
+  // The input sits in an exactly-sized heap buffer so any over-read trips ASAN.
+  const char bytes[] = {'\xF0', 'a', '\xE2', '\x82', '\xAC'};
+  const auto text_len = static_cast<gdv_int32>(sizeof(bytes));
+  std::unique_ptr<char[]> text(new char[text_len]);
+  std::memcpy(text.get(), bytes, text_len);
+  const std::string text_str(text.get(), text_len);
 
   // 3 glyphs padded to width 5 adds two fill characters, out_len = 2 + 5 = 7.
   const char* out_str =
-      lpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 5, " ", 1, &out_len);
+      lpad_utf8_int32_utf8(ctx_ptr, text.get(), text_len, 5, " ", 1, &out_len);
   EXPECT_EQ(out_len, 7);
   EXPECT_EQ(std::string(out_str, out_len), "  " + text_str);
 
-  out_str = rpad_utf8_int32_utf8(ctx_ptr, text.data(), text_len, 5, " ", 1, &out_len);
+  out_str = rpad_utf8_int32_utf8(ctx_ptr, text.get(), text_len, 5, " ", 1, &out_len);
   EXPECT_EQ(out_len, 7);
   EXPECT_EQ(std::string(out_str, out_len), text_str + "  ");
 }


### PR DESCRIPTION
### Rationale for this change

`utf8_length_ignore_invalid` extends `char_len` while scanning the bytes after a lead byte and never rechecks the buffer end, so an input ending in a truncated multi-byte utf8 sequence (a `0xF0` lead byte followed by non-continuation bytes) reads past `data_len`. It is reached from untrusted string data through `lpad`/`rpad`, which count the input glyphs before padding. Reproduced against a verbatim copy of the function under AddressSanitizer with the 4-byte input `{0xF0, 'a', 'a', 'a'}` in an exactly-sized heap buffer, giving `heap-buffer-overflow READ ... 0 bytes after 4-byte region`.

### What changes are included in this PR?

Stop the inner scan with a `break` when a byte after the lead byte is not a continuation byte, instead of incrementing `char_len`. Growing `char_len` on each stray byte kept extending the loop past `data_len`; breaking leaves `char_len` bounded so the outer `i + char_len <= data_len` check keeps every read in range. Valid input counts the same, because a well-formed glyph has only continuation bytes after its lead byte and never hits the `break`.

### Are these changes tested?

Yes. Added `TestStringOps.TestPadMalformedUtf8NoOverread`, which runs `lpad`/`rpad` on the truncated multi-byte input placed in an exactly-sized heap buffer so the over-read trips ASAN, and asserts the full padded output. The existing pad tests still pass.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** It fixes an out-of-bounds read in the Gandiva utf8 length helper reachable from `lpad`/`rpad` on crafted string data.

* GitHub Issue: #50355
