### PR TITLE
GH-50358: [Release] Fix permission issues when binary signing release candidate artifacts

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1933,7 +1933,8 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
          "--export", gpg_key_id,
          out: gpg_key.path,
          verbose: verbose?)
-      sh("rpm",
+      sh("sudo",
+         "rpm",
          "--import", gpg_key.path,
          out: default_output,
          verbose: verbose?)

--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -40,6 +40,8 @@ RUN \
 
 RUN gem install apt-dists-merge -v ">= 1.0.2"
 
+RUN chmod 1777 /var/lib/rpm
+
 RUN locale-gen en_US.UTF-8
 
 RUN mkdir -p /run/sshd

--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -40,8 +40,6 @@ RUN \
 
 RUN gem install apt-dists-merge -v ">= 1.0.2"
 
-RUN chmod 1777 /var/lib/rpm
-
 RUN locale-gen en_US.UTF-8
 
 RUN mkdir -p /run/sshd


### PR DESCRIPTION
### Rationale for this change

We updated from bookworm to trixie our binary signing image. When trying to sign the packages it failed with the following error:
```
Downloading: centos - 100.0% [63/63] 00:01:26 00:00:00  0/s
error: Unable to open sqlite database /var/lib/rpm/rpmdb.sqlite: unable to open database file
error: cannot open Packages index using sqlite - Operation not permitted (1)
error: cannot open Packages database in /var/lib/rpm
error: can't create transaction lock on /var/lib/rpm/.rpm.lock (No such file or directory)
error: /tmp/apache-arrow-binary20260703-49-htq2me.asc: key 1 import failed.
```

### What changes are included in this PR?

Use `sudo rpm` when signing binaries on the container.

### Are these changes tested?

Yes, I've used that to upload and sign binaries for 25.0.1

### Are there any user-facing changes?
No

* GitHub Issue: #50358