### PR TITLE
MINOR: [CI] Install libncurses-dev from unstable on Debian experimental

### DIFF
--- a/ci/docker/debian-experimental-cpp.dockerfile
+++ b/ci/docker/debian-experimental-cpp.dockerfile
@@ -58,6 +58,7 @@ RUN if [ -n "${gcc}" ]; then \
         libkrb5-dev \
         libldap-dev \
         liblz4-dev \
+        libncurses-dev \
         libnghttp2-dev \
         libopentelemetry-proto-dev \
         libprotobuf-dev \


### PR DESCRIPTION
### Rationale for this change
Nightly job `test-debian-experimental-cpp-gcc-15` [fails with this new error](https://github.com/ursacomputing/crossbow/actions/runs/28637694160/job/84927348010#step:6:3635):
```bash
  #9 60.12 E: Unable to satisfy dependencies. Reached two conflicting assignments:
  #9 60.12    1. libncurses-dev:amd64=6.6+20260608-1 is selected for install because:
  #9 60.12       1. llvm-20-dev:amd64=1:20.1.8-1+b4 is selected for install
  ...
```
Unstable and experimental both had [ncurses](https://tracker.debian.org/pkg/ncurses) 6.6+20260608-1 but with [2nd July addition of ...-2 only to unstable](https://tracker.debian.org/news/1770242/accepted-ncurses-6620260608-2-source-into-unstable/) causes temp dependency version skew (`libtinfo6`).

### What changes are included in this PR?
Install `libncurses-dev` from the default (unstable) before the `-t experimental` LLVM install

### Are these changes tested?
To be run by CI job.

### Are there any user-facing changes?
No.