### PR TITLE
GH-50360: [Release] Remove stray Apache-Arrow-Flight-SQL-ODBC-*-win64.msi from 04-binary-download.sh and 05-binary-upload.sh

### DIFF
--- a/dev/release/04-binary-download.sh
+++ b/dev/release/04-binary-download.sh
@@ -46,7 +46,7 @@ tag="apache-arrow-${version_with_rc}"
 
 archery crossbow download-artifacts --no-fetch ${CROSSBOW_JOB_ID} "$@"
 
-# Download Linux packages and ODBC MSI.
+# Download Linux packages.
 gh release download "${tag}" \
   --dir "packages/${CROSSBOW_JOB_ID}" \
   --pattern "almalinux-*.tar.gz" \

--- a/dev/release/04-binary-download.sh
+++ b/dev/release/04-binary-download.sh
@@ -54,6 +54,5 @@ gh release download "${tag}" \
   --pattern "centos-*.tar.gz" \
   --pattern "debian-*.tar.gz" \
   --pattern "ubuntu-*.tar.gz" \
-  --pattern "Apache-Arrow-Flight-SQL-ODBC-*-win64.msi" \
   --repo "${REPOSITORY:-apache/arrow}" \
   --skip-existing

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -67,7 +67,6 @@ cd "${SOURCE_DIR}"
 : "${UPLOAD_CENTOS:=${UPLOAD_DEFAULT}}"
 : "${UPLOAD_DEBIAN:=${UPLOAD_DEFAULT}}"
 : "${UPLOAD_DOCS:=${UPLOAD_DEFAULT}}"
-: "${UPLOAD_ODBC:=${UPLOAD_DEFAULT}}"
 : "${UPLOAD_PYTHON:=${UPLOAD_DEFAULT}}"
 : "${UPLOAD_R:=${UPLOAD_DEFAULT}}"
 : "${UPLOAD_UBUNTU:=${UPLOAD_DEFAULT}}"
@@ -108,10 +107,6 @@ upload_to_github_release() {
 
 if [ "${UPLOAD_DOCS}" -gt 0 ]; then
   upload_to_github_release docs "${ARROW_ARTIFACTS_DIR}"/*-docs/*
-fi
-if [ "${UPLOAD_ODBC}" -gt 0 ]; then
-  upload_to_github_release odbc \
-    "${ARROW_ARTIFACTS_DIR}"/Apache-Arrow-Flight-SQL-ODBC-*-win64.msi
 fi
 if [ "${UPLOAD_PYTHON}" -gt 0 ]; then
   upload_to_github_release python \


### PR DESCRIPTION
### Rationale for this change

When executing `05-binary-upload.sh` the process failed because the `Apache-Arrow-Flight-SQL-ODBC-*-win64.msi` isn't present.

The process changed and now `dev/release/07-flightsqlodbc-upload.sh` will download the following unsigned file:
[arrow_flight_sql_odbc_unsigned.dll](https://github.com/apache/arrow/releases/download/untagged-f0e9f29aea11207ee944/arrow_flight_sql_odbc_unsigned.dll) from the GitHub release, sign and generated the `Apache-Arrow-Flight-SQL-ODBC-*-win64.msi` file.

### What changes are included in this PR?

Remove trying to download and sign from steps 04 and 05 the ODBC driver msi.

### Are these changes tested?

No

### Are there any user-facing changes?

No

* GitHub Issue: #50360