### PR TITLE
GH-50363: [Release] Fix PHASE_BUILD_MSI step in 07-flightsqlodbc-upload.sh

### DIFF
--- a/dev/release/07-flightsqlodbc-upload.sh
+++ b/dev/release/07-flightsqlodbc-upload.sh
@@ -137,14 +137,19 @@ fi
 
 if [ "${PHASE_BUILD_MSI}" -gt 0 ]; then
   echo "[4/8] Triggering odbc_release_step in package_odbc.yml workflow..."
-  gh workflow run package_odbc.yml \
+  workflow_url=$(gh workflow run package_odbc.yml \
     --repo "${GITHUB_REPOSITORY}" \
     --ref "${tag}" \
-    --field odbc_release_step=true
+    --field odbc_release_step=true)
+  echo "${workflow_url}"
+  # Extract run ID from `gh workflow run` output. The output is structured like,
+  # https://github.com/apache/arrow/actions/runs/28679576610 and we just need
+  # the id.
+  run_id=$(echo "${workflow_url}" | grep -Eo 'actions/runs/[0-9]+' | grep -Eo '[0-9]+$' || true)
 
   echo "[5/8] Waiting for workflow to complete. This can take a very long time..."
   REPOSITORY="${GITHUB_REPOSITORY}" \
-    "${SOURCE_DIR}/utils-watch-gh-workflow.sh" "${tag}" package_odbc.yml
+    "${SOURCE_DIR}/utils-watch-gh-workflow.sh" "${tag}" package_odbc.yml "${run_id}"
 fi
 
 if [ "${PHASE_SIGN_MSI}" -gt 0 ]; then

--- a/dev/release/07-flightsqlodbc-upload.sh
+++ b/dev/release/07-flightsqlodbc-upload.sh
@@ -146,6 +146,12 @@ if [ "${PHASE_BUILD_MSI}" -gt 0 ]; then
   # https://github.com/apache/arrow/actions/runs/28679576610 and we just need
   # the id.
   run_id=$(echo "${workflow_url}" | grep -Eo 'actions/runs/[0-9]+' | grep -Eo '[0-9]+$' || true)
+  if [ -z "${run_id}" ]; then
+    echo "Failed to extract run ID from the above output. This is probably a" \
+         "bug. If the workflow was started, you can watch it manually and" \
+         "move onto the PHASE_SIGN_MSI step once it's done."
+    exit 1
+  fi
 
   echo "[5/8] Waiting for workflow to complete. This can take a very long time..."
   REPOSITORY="${GITHUB_REPOSITORY}" \

--- a/dev/release/07-flightsqlodbc-upload.sh
+++ b/dev/release/07-flightsqlodbc-upload.sh
@@ -148,8 +148,8 @@ if [ "${PHASE_BUILD_MSI}" -gt 0 ]; then
   run_id=$(echo "${workflow_url}" | grep -Eo 'actions/runs/[0-9]+' | grep -Eo '[0-9]+$' || true)
   if [ -z "${run_id}" ]; then
     echo "Failed to extract run ID from the above output. This is probably a" \
-         "bug. If the workflow was started, you can watch it manually and" \
-         "move onto the PHASE_SIGN_MSI step once it's done."
+      "bug. If the workflow was started, you can watch it manually and" \
+      "move onto the PHASE_SIGN_MSI step once it's done."
     exit 1
   fi
 

--- a/dev/release/utils-watch-gh-workflow.sh
+++ b/dev/release/utils-watch-gh-workflow.sh
@@ -21,33 +21,43 @@ set -e
 set -u
 set -o pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <tag> <workflow>"
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <tag> <workflow> [run-id]"
   exit 1
 fi
 
 TAG=$1
 WORKFLOW=$2
+RUN_ID="${3:-}"
 : "${REPOSITORY:=${GITHUB_REPOSITORY:-apache/arrow}}"
 
-echo "Looking for GitHub Actions workflow on ${REPOSITORY}:${TAG}"
-RUN_ID=""
-while true; do
-  echo "Waiting for run to start..."
-  RUN_ID=$(gh run list \
-              --branch "${TAG}" \
-              --jq '.[].databaseId' \
-              --json databaseId \
-              --limit 1 \
-              --repo "${REPOSITORY}" \
-              --workflow "${WORKFLOW}")
-  if [ -n "${RUN_ID}" ]; then
-    break
-  fi
-  sleep 60
-done
+if [ -z "${RUN_ID}" ]; then
+  echo "Looking for GitHub Actions workflow on ${REPOSITORY}:${TAG} (any ID)"
+else
+  echo "Looking for GitHub Actions workflow on ${REPOSITORY}:${TAG} with run ID ${RUN_ID}"
+fi
+if [ -z "${RUN_ID}" ]; then
+  while true; do
+    echo "Waiting for run to start..."
+    RUN_ID=$(gh run list \
+                --branch "${TAG}" \
+                --jq '.[].databaseId' \
+                --json databaseId \
+                --limit 1 \
+                --repo "${REPOSITORY}" \
+                --status "in_progress" \
+                --workflow "${WORKFLOW}")
+    if [ -n "${RUN_ID}" ]; then
+      break
+    fi
+    sleep 60
+  done
+  echo "Found GitHub Actions workflow with ID: ${RUN_ID}"
+else
+  echo "Using provided run ID: ${RUN_ID}. Sleeping for 10 seconds to let the job become available..."
+  sleep 10
+fi
 
-echo "Found GitHub Actions workflow with ID: ${RUN_ID}"
 gh run watch \
    --exit-status \
    --interval 60 \

--- a/dev/release/utils-watch-gh-workflow.sh
+++ b/dev/release/utils-watch-gh-workflow.sh
@@ -45,7 +45,6 @@ if [ -z "${RUN_ID}" ]; then
                 --json databaseId \
                 --limit 1 \
                 --repo "${REPOSITORY}" \
-                --status "in_progress" \
                 --workflow "${WORKFLOW}")
     if [ -n "${RUN_ID}" ]; then
       break


### PR DESCRIPTION
### Rationale for this change

The PHASE_BUILD_MSI step in 07-flightsqlodbc-upload.sh didn't wait for the right job when I ran it during the 25.0.0 release. It found another job and exited saying the job was completed. See my output in #50363.

### What changes are included in this PR?

Changes how the PHASE_BUILD_MSI step works so the exact run ID that was triggered gets captured and then gets passed to the wait step. The wait step then waits for a specific job ID to complete. This PR also includes an enhancement to the existing utils-watch-gh-workflow.sh script to let it take an optional run ID.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #50363