### PR TITLE
GH-50251: [C++] Add GetSpan to ArrayData

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1138,38 +1138,55 @@ TEST_F(TestArray, TestBinaryViewAppendArraySlice) {
   AssertArraysEqual(*src, *dst);
 }
 TEST_F(TestArray, GetSpanRespectsOffset) {
-  auto data_buffer = Buffer::FromString("123456789abcdef0");
-  auto data = ArrayData::Make(uint8(), 3, {nullptr, data_buffer}, 0, 1);
-  auto span = data->GetSpan<uint8_t>(1, 3);
+  std::vector<uint16_t> values = {1, 2, 3, 4, 5};
+
+  auto data_buffer = Buffer::Wrap(values);
+  auto data = ArrayData::Make(uint16(), 3, {nullptr, data_buffer}, 0, 1);
+  auto span = data->GetSpan<uint16_t>(1, 3);
 
   EXPECT_EQ(span.size(), 3);
-  EXPECT_EQ(span[0], '2');
-  EXPECT_EQ(span[1], '3');
-  EXPECT_EQ(span[2], '4');
+
+  EXPECT_EQ(span[0], 2);
+
+  EXPECT_EQ(span[1], 3);
+
+  EXPECT_EQ(span[2], 4);
 }
+
 TEST_F(TestArray, GetMutableSpanRespectsOffset) {
-  const int64_t nbytes = 16;
+  std::vector<uint16_t> values = {10, 20, 30, 40, 50};
+
+  const int64_t nbytes = values.size() * sizeof(uint16_t);
   ASSERT_OK_AND_ASSIGN(auto uniq_buffer, AllocateResizableBuffer(nbytes, pool_));
-  memset(uniq_buffer->mutable_data(), '0', nbytes);
+  memcpy(uniq_buffer->mutable_data(), values.data(), nbytes);
+
   std::shared_ptr<Buffer> buffer(std::move(uniq_buffer));
   std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, buffer};
-  auto data = ArrayData::Make(uint8(), 3, buffers, 0, 1);
-  auto span = data->template GetMutableSpan<uint8_t>(1, 3);
+
+  auto data = ArrayData::Make(uint16(), 3, buffers, 0, 1);
+  auto span = data->GetMutableSpan<uint16_t>(1, 3);
 
   EXPECT_EQ(span.size(), 3);
-  EXPECT_EQ(span[0], '0');
-  EXPECT_EQ(span[1], '0');
-  EXPECT_EQ(span[2], '0');
 
-  span[0] = 'X';
-  span[1] = 'Y';
-  span[2] = 'Z';
+  EXPECT_EQ(span[0], 20);
 
-  auto raw = buffer->mutable_data();
-  EXPECT_EQ(raw[1], 'X');
-  EXPECT_EQ(raw[2], 'Y');
-  EXPECT_EQ(raw[3], 'Z');
+  EXPECT_EQ(span[1], 30);
+
+  EXPECT_EQ(span[2], 40);
+
+  span[0] = 200;
+  span[1] = 300;
+  span[2] = 400;
+
+  auto raw = reinterpret_cast<uint16_t*>(buffer->mutable_data());
+  
+  EXPECT_EQ(raw[1], 200);
+
+  EXPECT_EQ(raw[2], 300);
+
+  EXPECT_EQ(raw[3], 400);
 }
+
 TEST_F(TestArray, ValidateBuffersPrimitive) {
   auto empty_buffer = std::make_shared<Buffer>("");
   auto null_buffer = Buffer::FromString("\xff");

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1137,41 +1137,33 @@ TEST_F(TestArray, TestBinaryViewAppendArraySlice) {
 
   AssertArraysEqual(*src, *dst);
 }
+
 TEST_F(TestArray, GetSpanRespectsOffset) {
   std::vector<uint16_t> values = {1, 2, 3, 4, 5};
 
-  auto data_buffer = Buffer::Wrap(values);
-  auto data = ArrayData::Make(uint16(), 3, {nullptr, data_buffer}, 0, 1);
+  auto buffer = Buffer::FromVector(std::move(values));
+  auto data = ArrayData::Make(uint16(), 3, {nullptr, buffer}, 0, 1);
   auto span = data->GetSpan<uint16_t>(1, 3);
 
   EXPECT_EQ(span.size(), 3);
-
   EXPECT_EQ(span[0], 2);
-
   EXPECT_EQ(span[1], 3);
-
   EXPECT_EQ(span[2], 4);
 }
 
 TEST_F(TestArray, GetMutableSpanRespectsOffset) {
   std::vector<uint16_t> values = {10, 20, 30, 40, 50};
 
-  const int64_t nbytes = values.size() * sizeof(uint16_t);
-  ASSERT_OK_AND_ASSIGN(auto uniq_buffer, AllocateResizableBuffer(nbytes, pool_));
-  memcpy(uniq_buffer->mutable_data(), values.data(), nbytes);
-
-  std::shared_ptr<Buffer> buffer(std::move(uniq_buffer));
+  auto buffer = std::make_shared<MutableBuffer>(reinterpret_cast<uint8_t*>(values.data()),
+                                                values.size() * sizeof(uint16_t));
   std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, buffer};
 
   auto data = ArrayData::Make(uint16(), 3, buffers, 0, 1);
   auto span = data->GetMutableSpan<uint16_t>(1, 3);
 
   EXPECT_EQ(span.size(), 3);
-
   EXPECT_EQ(span[0], 20);
-
   EXPECT_EQ(span[1], 30);
-
   EXPECT_EQ(span[2], 40);
 
   span[0] = 200;
@@ -1181,9 +1173,7 @@ TEST_F(TestArray, GetMutableSpanRespectsOffset) {
   auto raw = reinterpret_cast<uint16_t*>(buffer->mutable_data());
 
   EXPECT_EQ(raw[1], 200);
-
   EXPECT_EQ(raw[2], 300);
-
   EXPECT_EQ(raw[3], 400);
 }
 

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1139,9 +1139,7 @@ TEST_F(TestArray, TestBinaryViewAppendArraySlice) {
 }
 TEST_F(TestArray, GetSpanRespectsOffset) {
   auto data_buffer = Buffer::FromString("123456789abcdef0");
-
   auto data = ArrayData::Make(uint8(), 3, {nullptr, data_buffer}, 0, 1);
-
   auto span = data->GetSpan<uint8_t>(1, 3);
 
   EXPECT_EQ(span.size(), 3);
@@ -1149,7 +1147,29 @@ TEST_F(TestArray, GetSpanRespectsOffset) {
   EXPECT_EQ(span[1], '3');
   EXPECT_EQ(span[2], '4');
 }
+TEST_F(TestArray, GetMutableSpanRespectsOffset) {
+  const int64_t nbytes = 16;
+  ASSERT_OK_AND_ASSIGN(auto uniq_buffer, AllocateResizableBuffer(nbytes, pool_));
+  memset(uniq_buffer->mutable_data(), '0', nbytes);
+  std::shared_ptr<Buffer> buffer(std::move(uniq_buffer));
+  std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, buffer};
+  auto data = ArrayData::Make(uint8(), 3, buffers, 0, 1);
+  auto span = data->template GetMutableSpan<uint8_t>(1, 3);
 
+  EXPECT_EQ(span.size(), 3);
+  EXPECT_EQ(span[0], '0');
+  EXPECT_EQ(span[1], '0');
+  EXPECT_EQ(span[2], '0');
+
+  span[0] = 'X';
+  span[1] = 'Y';
+  span[2] = 'Z';
+
+  auto raw = buffer->mutable_data();
+  EXPECT_EQ(raw[1], 'X');
+  EXPECT_EQ(raw[2], 'Y');
+  EXPECT_EQ(raw[3], 'Z');
+}
 TEST_F(TestArray, ValidateBuffersPrimitive) {
   auto empty_buffer = std::make_shared<Buffer>("");
   auto null_buffer = Buffer::FromString("\xff");

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1179,7 +1179,7 @@ TEST_F(TestArray, GetMutableSpanRespectsOffset) {
   span[2] = 400;
 
   auto raw = reinterpret_cast<uint16_t*>(buffer->mutable_data());
-  
+
   EXPECT_EQ(raw[1], 200);
 
   EXPECT_EQ(raw[2], 300);

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1138,45 +1138,6 @@ TEST_F(TestArray, TestBinaryViewAppendArraySlice) {
   AssertArraysEqual(*src, *dst);
 }
 
-TEST_F(TestArray, GetSpanRespectsOffset) {
-  std::vector<uint16_t> values = {1, 2, 3, 4, 5};
-
-  auto buffer = Buffer::FromVector(std::move(values));
-  auto data = ArrayData::Make(uint16(), 3, {nullptr, buffer}, 0, 1);
-  auto span = data->GetSpan<uint16_t>(1, 3);
-
-  EXPECT_EQ(span.size(), 3);
-  EXPECT_EQ(span[0], 2);
-  EXPECT_EQ(span[1], 3);
-  EXPECT_EQ(span[2], 4);
-}
-
-TEST_F(TestArray, GetMutableSpanRespectsOffset) {
-  std::vector<uint16_t> values = {10, 20, 30, 40, 50};
-
-  auto buffer = std::make_shared<MutableBuffer>(reinterpret_cast<uint8_t*>(values.data()),
-                                                values.size() * sizeof(uint16_t));
-  std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, buffer};
-
-  auto data = ArrayData::Make(uint16(), 3, buffers, 0, 1);
-  auto span = data->GetMutableSpan<uint16_t>(1, 3);
-
-  EXPECT_EQ(span.size(), 3);
-  EXPECT_EQ(span[0], 20);
-  EXPECT_EQ(span[1], 30);
-  EXPECT_EQ(span[2], 40);
-
-  span[0] = 200;
-  span[1] = 300;
-  span[2] = 400;
-
-  auto raw = reinterpret_cast<uint16_t*>(buffer->mutable_data());
-
-  EXPECT_EQ(raw[1], 200);
-  EXPECT_EQ(raw[2], 300);
-  EXPECT_EQ(raw[3], 400);
-}
-
 TEST_F(TestArray, ValidateBuffersPrimitive) {
   auto empty_buffer = std::make_shared<Buffer>("");
   auto null_buffer = Buffer::FromString("\xff");

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1137,6 +1137,18 @@ TEST_F(TestArray, TestBinaryViewAppendArraySlice) {
 
   AssertArraysEqual(*src, *dst);
 }
+TEST_F(TestArray, GetSpanRespectsOffset) {
+  auto data_buffer = Buffer::FromString("123456789abcdef0");
+
+  auto data = ArrayData::Make(uint8(), 3, {nullptr, data_buffer}, 0, 1);
+
+  auto span = data->GetSpan<uint8_t>(1, 3);
+
+  EXPECT_EQ(span.size(), 3);
+  EXPECT_EQ(span[0], '2');
+  EXPECT_EQ(span[1], '3');
+  EXPECT_EQ(span[2], '4');
+}
 
 TEST_F(TestArray, ValidateBuffersPrimitive) {
   auto empty_buffer = std::make_shared<Buffer>("");

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -266,6 +266,10 @@ struct ARROW_EXPORT ArrayData {
   /// \return A span<const T> of the requested length
   template <typename T>
   std::span<const T> GetSpan(int i, int64_t length) const {
+    if (!buffers[i]) {
+      assert(length == 0);
+      return {};
+    }
     const int64_t buffer_length = buffers[i]->size() / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
     ARROW_UNUSED(buffer_length);
@@ -282,6 +286,10 @@ struct ARROW_EXPORT ArrayData {
   /// \return A span<T> of the requested length
   template <typename T>
   std::span<T> GetMutableSpan(int i, int64_t length) {
+    if (!buffers[i]) {
+      assert(length == 0);
+      return {};
+    }
     const int64_t buffer_length = buffers[i]->size() / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
     ARROW_UNUSED(buffer_length);

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -256,7 +256,7 @@ struct ARROW_EXPORT ArrayData {
       return NULLPTR;
     }
   }
-/// \brief Access a buffer's data as a span
+  /// \brief Access a buffer's data as a span
   ///
   /// \param i The buffer index
   /// \param length The required length (in number of typed values) of the requested span

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -256,6 +256,37 @@ struct ARROW_EXPORT ArrayData {
       return NULLPTR;
     }
   }
+/// \brief Access a buffer's data as a span
+  ///
+  /// \param i The buffer index
+  /// \param length The required length (in number of typed values) of the requested span
+  /// \pre i > 0
+  /// \pre length <= the length of the buffer (in number of values) that's expected for
+  /// this array type
+  /// \return A span<const T> of the requested length
+  template <typename T>
+  std::span<const T> GetSpan(int i, int64_t length) const {
+    const int64_t buffer_length = buffers[i]->size() / static_cast<int64_t>(sizeof(T));
+    assert(i > 0 && length + offset <= buffer_length);
+    ARROW_UNUSED(buffer_length);
+    return std::span<const T>(buffers[i]->data_as<T>() + this->offset, length);
+  }
+
+  /// \brief Access a buffer's data as a span
+  ///
+  /// \param i The buffer index
+  /// \param length The required length (in number of typed values) of the requested span
+  /// \pre i > 0
+  /// \pre length <= the length of the buffer (in number of values) that's expected for
+  /// this array type
+  /// \return A span<T> of the requested length
+  template <typename T>
+  std::span<T> GetMutableSpan(int i, int64_t length) {
+    const int64_t buffer_length = buffers[i]->size() / static_cast<int64_t>(sizeof(T));
+    assert(i > 0 && length + offset <= buffer_length);
+    ARROW_UNUSED(buffer_length);
+    return std::span<T>(buffers[i]->mutable_data_as<T>() + this->offset, length);
+  }
 
   /// \brief Access a buffer's data as a typed C pointer
   ///

--- a/cpp/src/arrow/array/data_test.cc
+++ b/cpp/src/arrow/array/data_test.cc
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <type_traits>
+
 #include <gtest/gtest.h>
 
-#include "arrow/array.h"
+#include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
 #include "arrow/testing/gtest_util.h"
 
@@ -41,6 +43,67 @@ TEST(ArraySpan, SetSlice) {
   ASSERT_EQ(span.null_count, kUnknownNullCount);
   ASSERT_EQ(span.offset, 7);
   ASSERT_EQ(span.GetNullCount(), 1);
+}
+
+TEST(ArrayData, GetSpanRespectsOffset) {
+  std::vector<uint16_t> values = {1, 2, 3, 4, 5};
+
+  auto buffer = Buffer::FromVector(std::move(values));
+  auto data = ArrayData::Make(uint16(), /*length=*/3, {nullptr, buffer}, /*null_count=*/0,
+                              /*offset=*/1);
+  auto span = data->GetSpan<uint16_t>(1, 3);
+
+  const bool is_const_pointer = std::is_same_v<decltype(span)::pointer, const uint16_t*>;
+  ASSERT_TRUE(is_const_pointer);
+
+  EXPECT_EQ(span.size(), 3);
+  EXPECT_EQ(span[0], 2);
+  EXPECT_EQ(span[1], 3);
+  EXPECT_EQ(span[2], 4);
+}
+
+TEST(ArrayData, GetMutableSpanRespectsOffset) {
+  std::vector<uint16_t> values = {10, 20, 30, 40, 50};
+
+  auto buffer = std::make_shared<MutableBuffer>(reinterpret_cast<uint8_t*>(values.data()),
+                                                values.size() * sizeof(uint16_t));
+  std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, buffer};
+
+  auto data =
+      ArrayData::Make(uint16(), /*length=*/3, buffers, /*null_count=*/0, /*offset=*/1);
+  auto span = data->GetMutableSpan<uint16_t>(1, 3);
+
+  const bool is_mut_pointer = std::is_same_v<decltype(span)::pointer, uint16_t*>;
+  ASSERT_TRUE(is_mut_pointer);
+
+  EXPECT_EQ(span.size(), 3);
+  EXPECT_EQ(span[0], 20);
+  EXPECT_EQ(span[1], 30);
+  EXPECT_EQ(span[2], 40);
+
+  span[0] = 200;
+  span[1] = 300;
+  span[2] = 400;
+
+  auto raw = reinterpret_cast<uint16_t*>(buffer->mutable_data());
+
+  EXPECT_EQ(raw[1], 200);
+  EXPECT_EQ(raw[2], 300);
+  EXPECT_EQ(raw[3], 400);
+}
+
+TEST(ArrayData, GetSpanNullBuffer) {
+  auto data = ArrayData::Make(uint16(), /*length=*/0, /*buffers=*/{nullptr, nullptr},
+                              /*null_count=*/0, /*offset=*/0);
+  auto span = data->GetSpan<uint16_t>(1, 0);
+  EXPECT_EQ(span.size(), 0);
+}
+
+TEST(ArrayData, GetMutableSpanNullBuffer) {
+  auto data = ArrayData::Make(uint16(), /*length=*/0, /*buffers=*/{nullptr, nullptr},
+                              /*null_count=*/0, /*offset=*/0);
+  auto span = data->GetMutableSpan<uint16_t>(1, 0);
+  EXPECT_EQ(span.size(), 0);
 }
 
 }  // namespace arrow


### PR DESCRIPTION
### What changes are included in this PR?

Add `GetSpan<T>(int i, int64_t length)` for read-only typed access to ArrayData.
Add `GetMutableSpan<T>(int i, int64_t length)` for writable typed access to ArrayData.

### Are these changes tested?

Yes, new unit tests were added in `array/data_test.cc`

* GitHub Issue: #50251