### PR TITLE
GH-38217: [R] Map format = "text" to format = "csv" in write_dataset()

### DIFF
--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -146,6 +146,9 @@ write_dataset <- function(
   if (format %in% c("feather", "ipc")) {
     format <- "arrow"
   }
+  if (format == "text") {
+    format <- "csv"
+  }
   if (inherits(dataset, "arrow_dplyr_query")) {
     # partitioning vars need to be in the `select` schema
     dataset <- ensure_group_vars(dataset)
@@ -189,7 +192,7 @@ write_dataset <- function(
   path_and_fs <- get_path_and_filesystem(path)
 
   dots <- list(...)
-  if (format %in% c("txt", "text") && !any(c("delimiter", "delim") %in% names(dots))) {
+  if (format == "txt" && !any(c("delimiter", "delim") %in% names(dots))) {
     stop("A delimiter must be given for a txt format.")
   }
   if (format == "tsv" && any(c("delimiter", "delim") %in% names(dots))) {

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -151,6 +151,9 @@ write_dataset <- function(
   if (format %in% c("feather", "ipc")) {
     format <- "arrow"
   }
+  if (format == "text") {
+    format <- "csv"
+  }
   if (inherits(dataset, "arrow_dplyr_query")) {
     # partitioning vars need to be in the `select` schema
     dataset <- ensure_group_vars(dataset)
@@ -194,7 +197,7 @@ write_dataset <- function(
   path_and_fs <- get_path_and_filesystem(path)
 
   dots <- list(...)
-  if (format %in% c("txt", "text") && !any(c("delimiter", "delim") %in% names(dots))) {
+  if (format == "txt" && !any(c("delimiter", "delim") %in% names(dots))) {
     stop("A delimiter must be given for a txt format.")
   }
   if (format == "tsv" && any(c("delimiter", "delim") %in% names(dots))) {

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -913,11 +913,6 @@ test_that("Writing a flat file dataset without a delimiter throws an error.", {
     write_dataset(df, dst_dir, format = "txt"),
     "A delimiter must be given for a txt format."
   )
-
-  expect_error(
-    write_dataset(df, dst_dir, format = "text"),
-    "A delimiter must be given for a txt format."
-  )
 })
 
 test_that("Dataset can write flat files using readr::write_csv() options.", {
@@ -1047,4 +1042,24 @@ test_that("Row order is preserved when writing large parquet dataset", {
 
   # But ordered is exactly equal.
   expect_equal(ordered_ds$x, df$x)
+})
+
+test_that("write_dataset maps format 'text' to 'csv' (GH-38217)", {
+  df <- tibble(
+    int = 1:10,
+    dbl = as.numeric(1:10),
+    chr = letters[1:10],
+  )
+
+  dst_dir <- make_temp_dir()
+  write_dataset(df, dst_dir, format = "text")
+  expect_true(dir.exists(dst_dir))
+
+  # Files should have .csv extension, not .text
+  written_files <- list.files(dst_dir)
+  expect_match(written_files, "\\.csv$")
+
+  # Data should round-trip correctly
+  result <- open_dataset(dst_dir, format = "csv") |> collect()
+  expect_equal(result, df)
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -1051,21 +1051,11 @@ test_that("Row order is preserved when writing large parquet dataset", {
 })
 
 test_that("write_dataset maps format 'text' to 'csv' (GH-38217)", {
-  df <- tibble(
-    int = 1:10,
-    dbl = as.numeric(1:10),
-    chr = letters[1:10],
-  )
+  df <- example_data[c("int", "dbl", "chr")]
 
   dst_dir <- make_temp_dir()
   write_dataset(df, dst_dir, format = "text")
-  expect_true(dir.exists(dst_dir))
 
-  # Files should have .csv extension, not .text
-  written_files <- list.files(dst_dir)
-  expect_match(written_files, "\\.csv$")
-
-  # Data should round-trip correctly
-  result <- open_dataset(dst_dir, format = "csv") |> collect()
-  expect_equal(result, df)
+  expect_identical(dir(dst_dir), "part-0.csv")
+  expect_equal(open_dataset(dst_dir, format = "csv") |> collect(), df)
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -919,11 +919,6 @@ test_that("Writing a flat file dataset without a delimiter throws an error.", {
     write_dataset(df, dst_dir, format = "txt"),
     "A delimiter must be given for a txt format."
   )
-
-  expect_error(
-    write_dataset(df, dst_dir, format = "text"),
-    "A delimiter must be given for a txt format."
-  )
 })
 
 test_that("Dataset can write flat files using readr::write_csv() options.", {
@@ -1053,4 +1048,24 @@ test_that("Row order is preserved when writing large parquet dataset", {
 
   # But ordered is exactly equal.
   expect_equal(ordered_ds$x, df$x)
+})
+
+test_that("write_dataset maps format 'text' to 'csv' (GH-38217)", {
+  df <- tibble(
+    int = 1:10,
+    dbl = as.numeric(1:10),
+    chr = letters[1:10],
+  )
+
+  dst_dir <- make_temp_dir()
+  write_dataset(df, dst_dir, format = "text")
+  expect_true(dir.exists(dst_dir))
+
+  # Files should have .csv extension, not .text
+  written_files <- list.files(dst_dir)
+  expect_match(written_files, "\\.csv$")
+
+  # Data should round-trip correctly
+  result <- open_dataset(dst_dir, format = "csv") |> collect()
+  expect_equal(result, df)
 })

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -1049,13 +1049,3 @@ test_that("Row order is preserved when writing large parquet dataset", {
   # But ordered is exactly equal.
   expect_equal(ordered_ds$x, df$x)
 })
-
-test_that("write_dataset maps format 'text' to 'csv' (GH-38217)", {
-  df <- example_data[c("int", "dbl", "chr")]
-
-  dst_dir <- make_temp_dir()
-  write_dataset(df, dst_dir, format = "text")
-
-  expect_identical(dir(dst_dir), "part-0.csv")
-  expect_equal(open_dataset(dst_dir, format = "csv") |> collect(), df)
-})

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -1049,3 +1049,13 @@ test_that("Row order is preserved when writing large parquet dataset", {
   # But ordered is exactly equal.
   expect_equal(ordered_ds$x, df$x)
 })
+
+test_that("write_dataset maps format 'text' to 'csv' (GH-38217)", {
+  df <- tibble(int = 1:10, dbl = as.numeric(1:10), chr = letters[1:10])
+
+  dst_dir <- make_temp_dir()
+  write_dataset(df, dst_dir, format = "text")
+
+  expect_identical(dir(dst_dir), "part-0.csv")
+  expect_equal(open_dataset(dst_dir, format = "csv") |> collect(), df)
+})


### PR DESCRIPTION
### Rationale for this change

`write_dataset()` errors on `format="text"` even though `open_dataset()` allows it.

### What changes are included in this PR?

Map "text" to "csv" so `write_dataset()` mirrors `open_dataset()`

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #38217