### PR TITLE
GH-30894: [C++][Python] Fix Table::Slice returning incorrect length f…

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -101,7 +101,7 @@ class SimpleTable : public Table {
 
   std::shared_ptr<Table> Slice(int64_t offset, int64_t length) const override {
     auto sliced = columns_;
-    int64_t num_rows = length;
+    int64_t num_rows = std::max<int64_t>(0, std::min(length, this->num_rows() - offset));
     for (auto& column : sliced) {
       column = column->Slice(offset, length);
       num_rows = column->length();

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -1321,7 +1321,8 @@ TEST_F(TestTable, Slice) {
 
 TEST_F(TestTable, SliceZeroColumns) {
   const int64_t length = 10;
-  auto empty_columns_table = Table::Make(::arrow::schema({}),std::vector<std::shared_ptr<ChunkedArray>>{}, length);
+  auto empty_columns_table = Table::Make(
+      ::arrow::schema({}), std::vector<std::shared_ptr<ChunkedArray>>{}, length);
   ASSERT_EQ(empty_columns_table->num_rows(), length);
   ASSERT_EQ(empty_columns_table->Slice(3)->num_rows(), length - 3);
   ASSERT_EQ(empty_columns_table->Slice(0)->num_rows(), length);

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -1319,6 +1319,23 @@ TEST_F(TestTable, Slice) {
                     *three->Slice(length + length / 3, 2 * (length - length / 3)));
 }
 
+TEST_F(TestTable, SliceZeroColumns) {
+  const int64_t length = 10;
+  auto empty_columns_table = Table::Make(::arrow::schema({}),std::vector<std::shared_ptr<ChunkedArray>>{}, length);
+  ASSERT_EQ(empty_columns_table->num_rows(), length);
+  ASSERT_EQ(empty_columns_table->Slice(3)->num_rows(), length - 3);
+  ASSERT_EQ(empty_columns_table->Slice(0)->num_rows(), length);
+  ASSERT_EQ(empty_columns_table->Slice(3, 100)->num_rows(), length - 3);
+  ASSERT_EQ(empty_columns_table->Slice(3, 4)->num_rows(), 4);
+  ASSERT_EQ(empty_columns_table->Slice(length + 5)->num_rows(), 0);
+
+  MakeExample1(length);
+  auto table = Table::Make(schema_, columns_);
+  ASSERT_OK_AND_ASSIGN(auto no_columns, table->SelectColumns({}));
+  ASSERT_EQ(no_columns->Slice(1)->num_rows(), table->Slice(1)->num_rows());
+  ASSERT_EQ(no_columns->Slice(1, 4)->num_rows(), 4);
+}
+
 TEST_F(TestTable, RemoveColumn) {
   const int64_t length = 10;
   MakeExample1(length);

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1361,6 +1361,22 @@ def test_table_slice_getitem():
     return _table_like_slice_tests(pa.table)
 
 
+def test_table_slice_no_columns():
+    table = pa.table({'col': range(3)})
+    empty = table.select([])
+    assert empty.num_rows == 3
+
+    # slice(offset) clamps to the remaining rows
+    assert empty.slice(1).num_rows == 2
+    assert empty.slice(0).num_rows == 3
+    # slice(offset, length) must not exceed the remaining rows
+    assert empty.slice(1, 4).num_rows == 2
+    # consistent with __getitem__ slicing, which already worked
+    assert empty[1:].num_rows == 2
+    # offset past the end yields an empty table
+    assert empty.slice(5).num_rows == 0
+
+
 @pytest.mark.pandas
 def test_slice_zero_length_table():
     # ARROW-7907: a segfault on this code was fixed after 0.16.0


### PR DESCRIPTION
### Rationale for this change
`Table::Slice` on a table with **no columns** does not adjust the row count. `SimpleTable::Slice` computes `num_rows` inside the per-column loop, so with zero columns the loop never runs and `num_rows` keeps the raw `length` argument instead of being clamped to the rows actually available.

```python
import pyarrow as pa
table = pa.table({'col': range(3)})

table.slice(1).num_rows               # 2  (correct)
table.select([])[1:].num_rows         # 2  (correct - __getitem__ normalizes)
table.select([]).slice(1).num_rows    # 3  (WRONG, should be 2)
table.select([]).slice(1, 4).num_rows # 4  (WRONG, should be 2)
```

This violates the contract documented in table.h: "If there are not enough rows in the table, the length will be adjusted accordingly."

### What changes are included in this PR?

- cpp/src/arrow/table.cc :  in SimpleTable::Slice, seed num_rows with a clamped value, std::max<int64_t>(0, std::min(length, num_rows() - offset)), so it is correct even when the column vector is empty. When columns exist the loop still overwrites num_rows with column->length(), so behavior for tables with columns is unchanged. The single-arg Table::Slice(offset) routes through this method, so it is fixed as well.
- cpp/src/arrow/table_test.cc: new TEST_F(TestTable, SliceZeroColumns).
- python/pyarrow/tests/test_table.py: new test_table_slice_no_columns

### Are these changes tested?
Yes. The new C++ and Python regression tests cover slicing a zero-column table with offset only, offset + length, an offset past the end , and consistency with a table whose columns were all removed using SelectColumns({}).


### Are there any user-facing changes?
Yes. Table.slice() on a table with no columns now returns the correct num_rows  instead of echoing back the raw length argument. This is a bug fix, there are no API changes.


Closes #30894


* GitHub Issue: #30894