### PR TITLE
GH-50531: [Python][Packaging] Set macOS deployment target before building wheel platform tag

### DIFF
--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -33,8 +33,8 @@ rm -rf "${source_dir}"/python/pyarrow/*.so
 rm -rf "${source_dir}"/python/pyarrow/*.so.*
 
 echo "=== (${PYTHON_VERSION}) Set SDK, C++ and Wheel flags ==="
-export _PYTHON_HOST_PLATFORM="macosx-${MACOSX_DEPLOYMENT_TARGET}-${arch}"
 export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-12.0}"
+export _PYTHON_HOST_PLATFORM="macosx-${MACOSX_DEPLOYMENT_TARGET}-${arch}"
 export SDKROOT="${SDKROOT:-$(xcrun --sdk macosx --show-sdk-path)}"
 
 if [ "$arch" = "arm64" ]; then


### PR DESCRIPTION
### Rationale for this change

`ci/scripts/python_wheel_macos_build.sh` builds `_PYTHON_HOST_PLATFORM` from `MACOSX_DEPLOYMENT_TARGET` before the script applies its default of `12.0`. When the variable is unset, the tag becomes `macosx--<arch>` even though the rest of the build still targets macOS 12.0.

### What changes are included in this PR?

Move the deployment-target default above the platform-tag export so the tag always uses the resolved value. An explicit `MACOSX_DEPLOYMENT_TARGET` is still honored.

### Are these changes tested?

I checked the two host-platform outcomes from the same assignment the script uses:

- unset `MACOSX_DEPLOYMENT_TARGET` yields `macosx-12.0-x86_64`
- `MACOSX_DEPLOYMENT_TARGET=13.0` yields `macosx-13.0-x86_64`

Crossbow macOS wheel jobs were also submitted on this branch after the rebase.

### Are there any user-facing changes?

No public API change. Local or manual macOS wheels that rely on the default now get a valid platform tag instead of `macosx--<arch>`.

* GitHub Issue: #50531
