### PR TITLE
GH-50383: [Release] Remove deprecated -f flag on conda create environment

### DIFF
--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -78,7 +78,7 @@ set PY_VERSION_NO_PERIOD=%PY_VERSION:.=%
 
 set CONDA_ENV_PATH=%_VERIFICATION_DIR%\_verify-wheel-%PY_VERSION%
 call conda create -p %CONDA_ENV_PATH% ^
-    --no-shortcuts -f -q -y python=%PY_VERSION% ^
+    --no-shortcuts -q -y python=%PY_VERSION% ^
     || EXIT /B 1
 call activate %CONDA_ENV_PATH%
 


### PR DESCRIPTION
### Rationale for this change

The Windows Wheels verification job is currently failing due to a change of API on the conda create call.

### What changes are included in this PR?

Remove the deprecated `-f` flag.

### Are these changes tested?

Yes, I have pushed the branch to the Apache Arrow repository instead of my fork to be able to manually trigger the workflow for the RC via workflow dispatch in order to validate the changes.

### Are there any user-facing changes?

No

* GitHub Issue: #50383