### PR TITLE
GH-50665: [Python] Assert s3fs selector result count

### DIFF
--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -803,7 +803,7 @@ def test_get_file_info_with_selector(fs, pathfn):
         infos = fs.get_file_info(selector)
         if fs.type_name == "py::fsspec+('s3', 's3a')":
             # s3fs only lists directories if they are not empty
-            len(infos) == 4
+            assert len(infos) == 4
         else:
             assert len(infos) == 5
 


### PR DESCRIPTION
### Rationale for this change

The fsspec S3 branch of `test_get_file_info_with_selector` evaluates `len(infos) == 4` without asserting it, so an incorrect recursive listing count can pass the test.

Closes #50665.

### What changes are included in this PR?

Add the missing `assert` to the existing comparison. No production code or expected value changes.

### Are these changes tested?

The Python CI matrix passed on the original one-line change. The rebased diff passes `git diff --check`.

### Are there any user-facing changes?

No.

This change was made with help from an AI coding assistant. I reviewed the one-line diff and verified it against the surrounding assertions.
* GitHub Issue: #50665
