### PR TITLE
GH-50394: [Docs][C++] Reduce Sphinx warnings when building HTML

### DIFF
--- a/cpp/apidoc/Doxyfile
+++ b/cpp/apidoc/Doxyfile
@@ -2484,6 +2484,8 @@ PREDEFINED             = __attribute__(x)= \
                          ARROW_EXTERN_TEMPLATE= \
                          ARROW_FLIGHT_EXPORT= \
                          ARROW_FLIGHT_SQL_EXPORT= \
+                         ARROW_SUPPRESS_DEPRECATION_WARNING= \
+                         ARROW_UNSUPPRESS_DEPRECATION_WARNING= \
                          GANDIVA_EXPORT= \
                          PARQUET_EXPORT=
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -451,12 +451,14 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
 
   /// Callback to be invoked against all FileWriters before
   /// they are finalized with FileWriter::Finish().
+  /// \hideinitializer
   std::function<Status(FileWriter*)> writer_pre_finish = [](FileWriter*) {
     return Status::OK();
   };
 
   /// Callback to be invoked against all FileWriters after they have
   /// called FileWriter::Finish().
+  /// \hideinitializer
   std::function<Status(FileWriter*)> writer_post_finish = [](FileWriter*) {
     return Status::OK();
   };

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -150,6 +150,7 @@ struct ARROW_DS_EXPORT ScanOptions {
   std::vector<FieldRef> MaterializedFields() const;
 
   /// Parameters which control when the plan should pause for a slow consumer
+  /// \hideinitializer
   acero::BackpressureOptions backpressure =
       acero::BackpressureOptions::DefaultBackpressure();
 };


### PR DESCRIPTION
### Rationale for this change
Fixes Sphinx warnings during the docs build. Doxygen/Breathe expose the multi-line lambda initializers on `writer_pre_finish`/`writer_post_finish` and the macros `ARROW_SUPPRESS_DEPRECATION_WARNING` / `ARROW_UNSUPPRESS_DEPRECATION_WARNING` to Sphinx C++ parses which can't parse them.

### What changes are included in this PR?
Added `\hideinitializer` to `dataset/file_base.h` and `dataset/scanner.h`.
Added `ARROW_SUPPRESS_DEPRECATION_WARNING` and `ARROW_UNSUPPRESS_DEPRECATION_WARNING` to `apidoc/Doxyfile` PREDEFINED list so Doxygen strips them from declarations.

### Are these changes tested?
Yes, locally and on fork CI - logs [AMD64 Debian 12 Complete Documentation](https://github.com/tadeja/arrow/actions/runs/28794724664/job/85382053293#step:7:5577):
`build succeeded, 15 warnings.`
(down from [26 warnings on main](https://github.com/apache/arrow/actions/runs/28808141817/job/85428862231#step:7:5654))

### Are there any user-facing changes?
No.

* GitHub Issue: #50394