### PR TITLE
MINOR: [Python][Docs] Remove reference to removed pyarrow.HdfsFile

### DIFF
--- a/docs/source/python/memory.rst
+++ b/docs/source/python/memory.rst
@@ -168,7 +168,6 @@ There are several kinds of :class:`~pyarrow.NativeFile` options available:
   Buffer at the end
 * :class:`~pyarrow.FixedSizeBufferWriter`, for writing data into an already
   allocated Buffer
-* :class:`~pyarrow.HdfsFile`, for reading and writing data to the Hadoop Filesystem
 * :class:`~pyarrow.PythonFile`, for interfacing with Python file objects in C++
 * :class:`~pyarrow.CompressedInputStream` and
   :class:`~pyarrow.CompressedOutputStream`, for on-the-fly compression or


### PR DESCRIPTION
### Rationale for this change

The Python memory/IO docs list `pyarrow.HdfsFile` as a `NativeFile` subclass, but that class no longer exists (legacy HDFS was deprecated in 2.0 and later removed). The `:class:` reference has no target, and HDFS access now uses `pyarrow.fs.HadoopFileSystem`, which returns regular `NativeFile` objects. It's the only unresolved pyarrow cross-reference on the page.

### What changes are included in this PR?

Removes the stale `pyarrow.HdfsFile` bullet in docs/source/python/memory.rst. One line, docs only.

### Are these changes tested?

Confirmed `pyarrow.HdfsFile` isn't in pyarrow, the ref appears only once, and all remaining `:class:` refs on the page resolve after removal.

### Are there any user-facing changes?

Documentation only.