### PR TITLE
GH-50399: [C++][Gandiva] Use timegm in DaysSince helper in Gandiva date_time_test

### DIFF
--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -105,9 +105,9 @@ int32_t DaysSince(time_t base_line, int32_t yy, int32_t mm, int32_t dd, int32_t 
   given_ts.tm_min = min;
   given_ts.tm_sec = sec;
 
-  time_t ts = mktime(&given_ts);
+  time_t ts = timegm(&given_ts);
   if (ts == static_cast<time_t>(-1)) {
-    ARROW_LOG(FATAL) << "mktime() failed";
+    ARROW_LOG(FATAL) << "timegm() failed";
   }
   // time_t is an arithmetic type on both POSIX and Windows, we can simply
   // subtract to get a duration in seconds.


### PR DESCRIPTION
### Rationale for this change

DateTimeTestProjector.TestDateTime fails for me locally and it looks like the issue is that it's comparing datetimes calculated with two different methods:

1. Epoch(): Uses timegm as of https://github.com/apache/arrow/pull/49953
2. DaysSince() was still using mktime

### What changes are included in this PR?

Updated DaysSince() helper to use timegm to match other helpers so comparisons can be made without local time one handling issues.

### Are these changes tested?

Yes. The test that fails locally now passes locally with this.

### Are there any user-facing changes?

No.
* GitHub Issue: #50399