### PR TITLE
GH-50249: [C++] Add ArrayBuilder::IsValid and ArrayBuilder::IsNull

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1252,6 +1252,33 @@ TEST_F(TestBuilder, TestResizeDownsize) {
   ASSERT_GE(500, builder.capacity());
   ASSERT_EQ(500, builder.length());
 }
+namespace {
+
+void AssertBuilderValidityAtIndices(const ArrayBuilder& builder,
+                                    const std::vector<int64_t>& indices,
+                                    const std::vector<bool>& expected_validity) {
+  for (size_t i = 0; i < indices.size(); ++i) {
+    ASSERT_EQ(expected_validity[i], builder.IsValid(indices[i]));
+  }
+}
+
+}  // namespace
+
+TEST_F(TestBuilder, TestIsNull) {
+  NullBuilder null_builder(pool_);
+  ASSERT_OK(null_builder.AppendNull());
+  ASSERT_OK(null_builder.Append(nullptr));
+  AssertBuilderValidityAtIndices(null_builder, {0, 1}, {false, false});
+
+  Int32Builder int32_builder(pool_);
+  ASSERT_OK(int32_builder.Append(0));
+  ASSERT_OK(int32_builder.AppendNull());
+  ASSERT_OK(int32_builder.Append(2));
+  ASSERT_OK(int32_builder.AppendNulls(3));
+  ASSERT_OK(int32_builder.Append(6));
+  ASSERT_OK(int32_builder.AppendEmptyValues(3));
+  AssertBuilderValidityAtIndices(int32_builder, {0, 1, 4, 7}, {true, false, false, true});
+}
 
 template <typename Attrs>
 class TestPrimitiveBuilder : public TestBuilder {

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -111,6 +111,31 @@ class ARROW_EXPORT ArrayBuilder {
 
   int num_children() const { return static_cast<int>(children_.size()); }
 
+  /// \brief Return true if value at index is null. Does not boundscheck
+  bool IsNull(int64_t i) const { return !IsValid(i); }
+
+  /// \brief Return true if value at index is valid (not null). Does not
+  /// boundscheck.
+  /// Note that this method does not work for types that do not have a
+  /// top-level validity bitmap ( Union and Run-End Encoded (RLE) types).
+  bool IsValid(int64_t i) const {
+    if (type()->id() == Type::NA) {
+      return false;
+    } else if (type()->id() == Type::SPARSE_UNION) {
+      // Not implemented
+      return false;
+    } else if (type()->id() == Type::DENSE_UNION) {
+      // Not implemented
+      return false;
+    } else if (type()->id() == Type::RUN_END_ENCODED) {
+      // Not implemented
+      return false;
+    } else {
+      // NullType
+      return bit_util::GetBit(null_bitmap_builder_.data(), i);
+    }
+  }
+
   virtual int64_t length() const { return length_; }
   int64_t null_count() const { return null_count_; }
   int64_t capacity() const { return capacity_; }

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -117,22 +117,16 @@ class ARROW_EXPORT ArrayBuilder {
   /// \brief Return true if value at index is valid (not null). Does not
   /// boundscheck.
   /// Note that this method does not work for types that do not have a
-  /// top-level validity bitmap ( Union and Run-End Encoded (RLE) types).
+  /// top-level validity bitmap (Union and Run-End Encoded (RLE) types).
   bool IsValid(int64_t i) const {
-    if (type()->id() == Type::NA) {
-      return false;
-    } else if (type()->id() == Type::SPARSE_UNION) {
-      // Not implemented
-      return false;
-    } else if (type()->id() == Type::DENSE_UNION) {
-      // Not implemented
-      return false;
-    } else if (type()->id() == Type::RUN_END_ENCODED) {
-      // Not implemented
-      return false;
-    } else {
-      // NullType
-      return bit_util::GetBit(null_bitmap_builder_.data(), i);
+    switch (type()->id()) {
+      case Type::NA:
+      case Type::SPARSE_UNION:
+      case Type::DENSE_UNION:
+      case Type::RUN_END_ENCODED:
+        return false;
+      default:
+        return bit_util::GetBit(null_bitmap_builder_.data(), i);
     }
   }
 


### PR DESCRIPTION
### Rationale for this change

`ArrayBuilder` does not provide a public API to check whether an element is null.

### What changes are included in this PR?

Add `ArrayBuilder::IsNull` and `ArrayBuilder::IsValid`.

### Are these changes tested?

Yes, I ran the relevant unit tests.

### Are there any user-facing changes?

Yes. This PR adds the public APIs `ArrayBuilder::IsNull` and `ArrayBuilder::IsValid`.

* GitHub Issue: #50249