### PR TITLE
GH-50403: [C++] Remove ArrayBuilder::AppendToBitmap

### DIFF
--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -67,24 +67,6 @@ Status ArrayBuilder::TrimBuffer(const int64_t bytes_filled, ResizableBuffer* buf
   return Status::OK();
 }
 
-Status ArrayBuilder::AppendToBitmap(bool is_valid) {
-  RETURN_NOT_OK(Reserve(1));
-  UnsafeAppendToBitmap(is_valid);
-  return Status::OK();
-}
-
-Status ArrayBuilder::AppendToBitmap(const uint8_t* valid_bytes, int64_t length) {
-  RETURN_NOT_OK(Reserve(length));
-  UnsafeAppendToBitmap(valid_bytes, length);
-  return Status::OK();
-}
-
-Status ArrayBuilder::AppendToBitmap(int64_t num_bits, bool value) {
-  RETURN_NOT_OK(Reserve(num_bits));
-  UnsafeAppendToBitmap(num_bits, value);
-  return Status::OK();
-}
-
 Status ArrayBuilder::Resize(int64_t capacity) {
   RETURN_NOT_OK(CheckCapacity(capacity));
   capacity_ = capacity;

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -207,16 +207,6 @@ class ARROW_EXPORT ArrayBuilder {
   virtual std::shared_ptr<DataType> type() const = 0;
 
  protected:
-  /// Append to null bitmap
-  Status AppendToBitmap(bool is_valid);
-
-  /// Vector append. Treat each zero byte as a null.   If valid_bytes is null
-  /// assume all of length bits are valid.
-  Status AppendToBitmap(const uint8_t* valid_bytes, int64_t length);
-
-  /// Uniform append.  Append N times the same validity bit.
-  Status AppendToBitmap(int64_t num_bits, bool value);
-
   /// Set the next length bits to not null (i.e. valid).
   Status SetNotNull(int64_t length);
 


### PR DESCRIPTION
### Rationale for this change

The protected method`ArrayBuilder::AppendToBitmap` has neither a correct implementation nor any usage.

### What changes are included in this PR?

Remove `ArrayBuilder::AppendToBitmap`.

### Are these changes tested?

By existing CI tests.

### Are there any user-facing changes?

Removal of the protected method `ArrayBuilder::AppendToBitmap`.
This would only affect users in the unlikely case that they define their own `ArrayBuilder` subclass and make use of the removed method there.

* GitHub Issue: #50403