### PR TITLE
GH-50412: [CI][GLib][Ruby] Remove some unnecessary Ubuntu 20.04 cases

### DIFF
--- a/c_glib/doc/meson.build
+++ b/c_glib/doc/meson.build
@@ -22,6 +22,7 @@ gi_docgen_toml_conf = configuration_data()
 gi_docgen_toml_conf.set('SOURCE_REFERENCE', source_reference)
 # We can't use "version.replace('-SNAPSHOT', '.dev')" here because
 # Ubuntu 20.04's Meson is < 0.58.0.
+# Is the above comment still relevant?
 if version_tag == ''
     gi_docgen_version_tag = ''
 else

--- a/c_glib/doc/meson.build
+++ b/c_glib/doc/meson.build
@@ -20,21 +20,7 @@ gi_docgen = find_program('gi-docgen')
 
 gi_docgen_toml_conf = configuration_data()
 gi_docgen_toml_conf.set('SOURCE_REFERENCE', source_reference)
-# We can't use "version.replace('-SNAPSHOT', '.dev')" here because
-# Ubuntu 20.04's Meson is < 0.58.0.
-# Is the above comment still relevant?
-if version_tag == ''
-    gi_docgen_version_tag = ''
-else
-    # GI-DocGen doesn't like MAJOR.MINOR.PATCH-SNAPSHOT format.
-    gi_docgen_version_tag = '.dev'
-endif
-gi_docgen_version = '@0@.@1@.@2@@3@'.format(
-    version_major,
-    version_minor,
-    version_micro,
-    gi_docgen_version_tag,
-)
+gi_docgen_version = version.replace('-SNAPSHOT', '.dev')
 gi_docgen_toml_conf.set('VERSION', gi_docgen_version)
 
 gir_top_build_dir = meson.current_build_dir() / '..'

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -157,10 +157,6 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   CC="${ORIGINAL_CC}"
   CXX="${ORIGINAL_CXX}"
 elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
-  if [ "${UBUNTU}" = "20.04" ]; then
-    echo "arrow emscripten build is not supported on Ubuntu 20.04, run with UBUNTU=22.04"
-    exit -1
-  fi
   n_jobs=2 # Emscripten build fails on docker unless this is set really low
   source ~/emsdk/emsdk_env.sh
   export CMAKE_INSTALL_PREFIX=$(em-config CACHE)/sysroot

--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -62,13 +62,6 @@ See https://github.com/ruby-gnome/rubygems-requirements-system/ how to enable it
   MESSAGE
 end
 
-# Old re2.pc (e.g. re2.pc on Ubuntu 20.04) may add -std=c++11. It
-# causes a build error because Apache Arrow C++ requires C++17 or
-# later.
-#
-# We can remove this when we drop support for Ubuntu 20.04.
-$CXXFLAGS.gsub!("-std=c++11", "")
-
 [
   ["glib2", "ext/glib2"],
 ].each do |name, relative_source_dir|


### PR DESCRIPTION
### Rationale for this change

We did drop support for Ubuntu 20.04 almost a year ago. We should remove cases that cater for it.

### What changes are included in this PR?

Found a couple places where we still seem to be doing some minor fixes for Ubuntu 20.04. Clean those up.

### Are these changes tested?

CI has been run

### Are there any user-facing changes?

No

* GitHub Issue: #50412