### PR TITLE
GH-37853: [Python] Remove test and fixture involving fastparquet

### DIFF
--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -33,7 +33,6 @@ groups = [
     'cython',
     'dataset',
     'hypothesis',
-    'fastparquet',
     'flight',
     'gandiva',
     'gcs',
@@ -69,7 +68,6 @@ defaults = {
     'bz2': Codec.is_available('bz2'),
     'cython': False,
     'dataset': False,
-    'fastparquet': False,
     'flight': False,
     'gandiva': False,
     'gcs': False,
@@ -113,12 +111,6 @@ if sys.platform == "emscripten":
 try:
     import cython  # noqa
     defaults['cython'] = True
-except ImportError:
-    pass
-
-try:
-    import fastparquet  # noqa
-    defaults['fastparquet'] = True
 except ImportError:
     pass
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -817,49 +817,6 @@ def test_parquet_file_too_small(tempdir):
         pq.read_table(path)
 
 
-@pytest.mark.pandas
-@pytest.mark.fastparquet
-@pytest.mark.filterwarnings("ignore:RangeIndex:FutureWarning")
-@pytest.mark.filterwarnings("ignore:tostring:DeprecationWarning:fastparquet")
-@pytest.mark.filterwarnings("ignore:unclosed file:ResourceWarning")
-def test_fastparquet_cross_compatibility(tempdir):
-    fp = pytest.importorskip('fastparquet')
-
-    df = pd.DataFrame(
-        {
-            "a": list("abc"),
-            "b": list(range(1, 4)),
-            "c": np.arange(4.0, 7.0, dtype="float64"),
-            "d": [True, False, True],
-            "e": pd.date_range("20130101", periods=3),
-            "f": pd.Categorical(["a", "b", "a"]),
-            # fastparquet writes list as BYTE_ARRAY JSON, so no roundtrip
-            # "g": [[1, 2], None, [1, 2, 3]],
-        }
-    )
-    table = pa.table(df)
-
-    # Arrow -> fastparquet
-    file_arrow = str(tempdir / "cross_compat_arrow.parquet")
-    pq.write_table(table, file_arrow, compression=None)
-
-    fp_file = fp.ParquetFile(file_arrow)
-    df_fp = fp_file.to_pandas()
-    # pandas 3 defaults to StringDtype for strings, fastparquet still returns object
-    # TODO: remove astype casts once fastparquet supports pandas 3 StringDtype
-    tm.assert_frame_equal(df_fp, df.astype({"a": object}))
-
-    # Fastparquet -> arrow
-    file_fastparquet = str(tempdir / "cross_compat_fastparquet.parquet")
-    # fastparquet doesn't support writing pandas 3 StringDtype yet
-    fp.write(file_fastparquet, df.astype({"a": object}))
-
-    table_fp = pq.read_pandas(file_fastparquet)
-    # for fastparquet written file, categoricals comes back as strings
-    # (no arrow schema in parquet metadata)
-    tm.assert_frame_equal(table_fp.to_pandas(), df.astype({"f": object}))
-
-
 @pytest.mark.parametrize('array_factory', [
     lambda: pa.array([0, None] * 10),
     lambda: pa.array([0, None] * 10).dictionary_encode(),


### PR DESCRIPTION
### Rationale for this change

`test_fastparquet_cross_compatibility` is not exercised and when exercised with latest versions it fails because it's not compatible with pandas 3 and it won't be as the project is retired, see:
- https://github.com/dask/fastparquet/pull/973

### What changes are included in this PR?

Removal of fixture to mark test as `fastparquet` and remove single test that still required fastarquet.

### Are these changes tested?

Yes and no. CI is exercised as expected but `fastparquet`  tests weren't exercised on CI in the first place.

### Are there any user-facing changes?

No

* GitHub Issue: #37853