### PR TITLE
GH-50417: [CI][Dev] Fix shellcheck error in ci/scripts/install_bison.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -298,6 +298,7 @@ repos:
           ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/download_tz_database\.sh$|
           ?^ci/scripts/install_azurite\.sh$|
+          ?^ci/scripts/install_bison\.sh$|
           ?^ci/scripts/install_ccache\.sh$|
           ?^ci/scripts/install_chromedriver\.sh$|
           ?^ci/scripts/install_cmake\.sh$|

--- a/ci/scripts/install_bison.sh
+++ b/ci/scripts/install_bison.sh
@@ -34,7 +34,7 @@ wget -q "${url}" -O - | tar -xzf - --directory /tmp/bison --strip-components=1
 
 pushd /tmp/bison
 ./configure --prefix="${prefix}"
-make -j$(nproc)
+make -j"$(nproc)"
 make install
 popd
 


### PR DESCRIPTION
### Rationale for this change

Fix shellcheck errors in `ci/scripts/install_bison.sh`

This is the sub issue #44748.

* SC2046: Quote this to prevent word splitting


```
In ci/scripts/install_bison.sh line 37:
make -j$(nproc)
       ^------^ SC2046 (warning): Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
```  

### What changes are included in this PR?

* SC2046: Quota variable.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #50417