### PR TITLE
MINOR: [CI] remove westonpace from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,9 +55,7 @@ compose.yaml @assignUser @jonkeane @kou @raulcd
 
 ## C++
 /cpp/src/arrow/ @pitrou
-/cpp/src/arrow/acero @westonpace
 /cpp/src/arrow/adapters/orc @wgtmac
-/cpp/src/arrow/engine @westonpace
 /cpp/src/arrow/flight/ @lidavidm
 /cpp/src/gandiva @dmitry-chirkov-dremio @lriggs @akravchukdremio @xxlaykxx
 /cpp/src/parquet @wgtmac @pitrou


### PR DESCRIPTION
### Rationale for this change

I am not actively reviewing PRs for Arrow :frowning_face: 

### What changes are included in this PR?

I removed myself from the CODEOWNERS files in the `acero` and `engine` subfolders.  Based on the current structure these will fall back to pitrou.

### Are these changes tested?

No

### Are there any user-facing changes?

No