### PR TITLE
GH-50424: [CI] install Chrome latest for test-conda-python-emscripten

### DIFF
--- a/ci/scripts/python_test_emscripten.sh
+++ b/ci/scripts/python_test_emscripten.sh
@@ -34,7 +34,5 @@ echo "-------------- Running emscripten tests in Node ----------------------"
 python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=node
 
 echo "-------------- Running emscripten tests in Chrome --------------------"
-# verify compose shm_size is applied inside the container (see compose.yaml)
-df -h /dev/shm
 python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=chrome
 

--- a/ci/scripts/python_test_emscripten.sh
+++ b/ci/scripts/python_test_emscripten.sh
@@ -34,5 +34,7 @@ echo "-------------- Running emscripten tests in Node ----------------------"
 python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=node
 
 echo "-------------- Running emscripten tests in Chrome --------------------"
+# verify compose shm_size is applied inside the container (see compose.yaml)
+df -h /dev/shm
 python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=chrome
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -982,7 +982,7 @@ services:
         clang_tools: ${CLANG_TOOLS}
         llvm: ${LLVM}
         pyodide_version: "0.26.0"
-        chrome_version: "148"
+        chrome_version: "latest"
         selenium_version: "4.41.0"
         required_python_min: "(3,12)"
         python: ${PYTHON}

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2075,7 +2075,7 @@ function(build_protobuf)
         -Dprotobuf_BUILD_TESTS=OFF
         -Dprotobuf_DEBUG_POSTFIX=
         # OFF so protobuf does not take conda's zlib and add its include dir
-        # globally, so vendored Abseil sources compile against env's old headers
+        # globally, causing vendored Abseil sources to include env's old headers
         -Dprotobuf_WITH_ZLIB=OFF)
     if(ABSL_VENDORED)
       # Force protobuf to reuse Arrow's already-extracted absl source

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2074,8 +2074,7 @@ function(build_protobuf)
         "-DCMAKE_INSTALL_PREFIX=${PROTOBUF_HOST_PREFIX}"
         -Dprotobuf_BUILD_TESTS=OFF
         -Dprotobuf_DEBUG_POSTFIX=
-        # OFF so protobuf does not take conda's zlib and add its include dir
-        # globally, causing vendored Abseil sources to include env's old headers
+        # OFF to avoid conda include dirs leaking into vendored Abseil
         -Dprotobuf_WITH_ZLIB=OFF)
     if(ABSL_VENDORED)
       # Force protobuf to reuse Arrow's already-extracted absl source

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2073,7 +2073,10 @@ function(build_protobuf)
         "-DCMAKE_C_FLAGS="
         "-DCMAKE_INSTALL_PREFIX=${PROTOBUF_HOST_PREFIX}"
         -Dprotobuf_BUILD_TESTS=OFF
-        -Dprotobuf_DEBUG_POSTFIX=)
+        -Dprotobuf_DEBUG_POSTFIX=
+        # OFF so protobuf does not take conda's zlib and add its include dir
+        # globally, so vendored Abseil sources compile against env's old headers
+        -Dprotobuf_WITH_ZLIB=OFF)
     if(ABSL_VENDORED)
       # Force protobuf to reuse Arrow's already-extracted absl source
       # so we don't re-download and we don't have issues with multiple abseil.

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -203,7 +203,7 @@ class BrowserDriver:
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
         # Chrome on CI takes longer than locally to compile.
-        self.driver.set_script_timeout(1200)
+        self.driver.set_script_timeout(1800)
 
     def load_pyodide(self, dist_dir):
         pass
@@ -263,7 +263,7 @@ class ChromeDriver(BrowserDriver):
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
         driver = webdriver.Chrome(options=options)
-        driver.command_executor._client_config.timeout = 1200
+        driver.command_executor._client_config.timeout = 1800
         super().__init__(hostname, port, driver)
 
 

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -203,7 +203,7 @@ class BrowserDriver:
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
         # Chrome on CI takes longer than locally to compile.
-        self.driver.set_script_timeout(1800)
+        self.driver.set_script_timeout(1200)
 
     def load_pyodide(self, dist_dir):
         pass
@@ -263,7 +263,7 @@ class ChromeDriver(BrowserDriver):
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
         driver = webdriver.Chrome(options=options)
-        driver.command_executor._client_config.timeout = 1800
+        driver.command_executor._client_config.timeout = 1200
         super().__init__(hostname, port, driver)
 
 

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -67,8 +67,20 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
                                 evt.data.print.forEach((x)=>{window.python_logs.push(x)});
                             }
                         }
-                        window.pyworker = new Worker("worker.js");
-                        window.pyworker.onmessage = capturelogs;
+                        function startPyWorker() {
+                            window.pyworker = new Worker("worker.js");
+                            window.pyworker.onmessage = capturelogs;
+                            window.pyworker.onerror = (evt) => {
+                                window.python_logs.push(...new TextEncoder().encode(
+                                    `Worker error: ${evt.message}\n`));
+                                if (window.python_done_callback) {
+                                    let callback = window.python_done_callback;
+                                    window.python_done_callback = undefined;
+                                    callback({result: 1});
+                                }
+                            };
+                        }
+                        startPyWorker();
                     </script>
                 </head>
                 <body></body>
@@ -82,22 +94,36 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
         elif self.path.endswith("/worker.js"):
             body = b"""
                 importScripts("./pyodide.js");
+                function do_print(arg) {
+                    let databytes = Array.from(arg);
+                    self.postMessage({print:databytes});
+                    return databytes.length;
+                }
+                function log(message) {
+                    do_print(new TextEncoder().encode(`[worker] ${message}\n`));
+                }
                 onmessage = async function (e) {
                     const data = e.data;
-                    if (!self.pyodide) {
-                        self.pyodide = await loadPyodide();
-                    }
-                    function do_print(arg) {
-                        let databytes = Array.from(arg);
-                        self.postMessage({print:databytes});
-                        return databytes.length;
-                    }
-                    self.pyodide.setStdout({write:do_print,isatty:data.isatty});
-                    self.pyodide.setStderr({write:do_print,isatty:data.isatty});
+                    try {
+                        if (!self.pyodide) {
+                            log("loading Pyodide");
+                            self.pyodide = await loadPyodide();
+                            log("loaded Pyodide");
+                        }
+                        self.pyodide.setStdout({write:do_print,isatty:data.isatty});
+                        self.pyodide.setStderr({write:do_print,isatty:data.isatty});
 
-                    await self.pyodide.loadPackagesFromImports(data.python);
-                    let results = await self.pyodide.runPythonAsync(data.python);
-                    self.postMessage({results});
+                        log("loading packages from imports");
+                        await self.pyodide.loadPackagesFromImports(data.python);
+                        log("running Python");
+                        let results = await self.pyodide.runPythonAsync(data.python);
+                        log("Python completed");
+                        self.postMessage({results});
+                    } catch (error) {
+                        do_print(new TextEncoder().encode(
+                            `Worker failed: ${error && error.stack || error}\n`));
+                        self.postMessage({results: 1});
+                    }
                 }
                 """
             self.send_response(200)
@@ -202,43 +228,48 @@ class BrowserDriver:
     def __init__(self, hostname, port, driver):
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
-        # Chrome on CI takes longer than locally to compile.
-        self.driver.set_script_timeout(1200)
 
     def load_pyodide(self, dist_dir):
         pass
 
     def load_arrow(self):
-        self.execute_python(
-            f"import pyodide_js as pjs\n"
-            f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n"
-        )
+        code = (f"import pyodide_js as pjs\n"
+                f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
+        for attempt in range(3):
+            try:
+                return self.execute_python(code, timeout=300)
+            except TimeoutError:
+                if attempt == 2:
+                    raise TimeoutError(
+                        "Timed out initializing Pyodide/PyArrow in browser")
+                print("Timed out initializing Pyodide/loading PyArrow. Restarting",
+                      flush=True)
+                self.restart_worker()
 
-    def execute_python(self, code, wait_for_terminate=True):
+    def execute_python(self, code, wait_for_terminate=True, timeout=None):
+        self.driver.execute_script(
+            f"""
+            let python = `{code}`;
+            delete window.python_script_done;
+            window.python_done_callback= (x) => {{window.python_script_done=x;}};
+            window.pyworker.postMessage(
+                {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
+            """
+        )
         if wait_for_terminate:
-            self.driver.execute_async_script(
-                f"""
-                let callback = arguments[arguments.length-1];
-                python = `{code}`;
-                window.python_done_callback = callback;
-                window.pyworker.postMessage(
-                    {{python, isatty: {'true' if sys.stdout.isatty() else 'false'}}});
-                """
-            )
-        else:
-            self.driver.execute_script(
-                f"""
-                let python = `{code}`;
-                window.python_done_callback= (x) => {{window.python_script_done=x;}};
-                window.pyworker.postMessage(
-                    {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
-                """
-            )
+            return self.wait_for_done(timeout=timeout)
+
+    def restart_worker(self):
+        self.driver.execute_script(
+            "window.pyworker.terminate(); startPyWorker(); "
+            "delete window.python_script_done; window.python_done_callback = undefined;"
+        )
 
     def clear_logs(self):
         self.driver.execute_script("window.python_logs = [];")
 
-    def wait_for_done(self):
+    def wait_for_done(self, timeout=None):
+        start = last_heartbeat = time.monotonic()
         while True:
             # poll for console.log messages from our webworker
             # which are the output of pytest
@@ -247,11 +278,18 @@ class BrowserDriver:
             )
             if len(lines) > 0:
                 sys.stdout.buffer.write(bytes(lines))
+                sys.stdout.buffer.flush()
             done = self.driver.execute_script("return window.python_script_done;")
             if done is not None:
                 value = done["result"]
                 self.driver.execute_script("delete window.python_script_done;")
                 return value
+            now = time.monotonic()
+            if timeout is not None and now - start > timeout:
+                raise TimeoutError
+            if now - last_heartbeat > 30:
+                print("Waiting for browser-side Python to finish...", flush=True)
+                last_heartbeat = now
             time.sleep(0.1)
 
 

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -283,7 +283,7 @@ def _load_pyarrow_in_runner(driver, wheel_name):
         """import sys
 import micropip
 if "pyarrow" not in sys.modules:
-    await micropip.install("hypothesis")
+    await micropip.install(["hypothesis", "pytest>=8.2"])
     import pyodide_js as pjs
     await pjs.loadPackage("tzdata")
     await pjs.loadPackage("numpy")

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -33,9 +33,6 @@ from io import BytesIO
 from selenium import webdriver
 
 
-BROWSER_TIMEOUT_SECONDS = 3600
-
-
 class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
     def log_request(self, code="-", size="-"):
         # don't log successful requests but log errors
@@ -220,7 +217,7 @@ class BrowserDriver:
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
         # Chrome on CI takes longer than locally to compile.
-        self.driver.set_script_timeout(BROWSER_TIMEOUT_SECONDS)
+        self.driver.set_script_timeout(1200)
 
     def load_pyodide(self, dist_dir):
         pass
@@ -279,7 +276,7 @@ class ChromeDriver(BrowserDriver):
         options.add_argument("--no-sandbox")
         options.add_argument("--disable-dev-shm-usage")
         driver = webdriver.Chrome(options=options)
-        driver.command_executor._client_config.timeout = BROWSER_TIMEOUT_SECONDS
+        driver.command_executor._client_config.timeout = 1200
         super().__init__(hostname, port, driver)
 
 

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -283,12 +283,20 @@ def _load_pyarrow_in_runner(driver, wheel_name):
         """import sys
 import micropip
 if "pyarrow" not in sys.modules:
-    await micropip.install(["hypothesis", "pytest>=8.2"])
+    await micropip.install("hypothesis")
     import pyodide_js as pjs
     await pjs.loadPackage("tzdata")
     await pjs.loadPackage("numpy")
     await pjs.loadPackage("pandas")
     import pytest
+    import inspect
+    if "exc_type" not in inspect.signature(pytest.importorskip).parameters:
+        _original_importorskip = pytest.importorskip
+        def _importorskip(modname, minversion=None, reason=None, *,
+                          exc_type=ImportError):
+            return _original_importorskip(modname, minversion=minversion,
+                                          reason=reason)
+        pytest.importorskip = _importorskip
     import pandas # import pandas after pyarrow package load for pandas/pyarrow
                   # functions to work
 import pyarrow

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -67,20 +67,8 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
                                 evt.data.print.forEach((x)=>{window.python_logs.push(x)});
                             }
                         }
-                        function startPyWorker() {
-                            window.pyworker = new Worker("worker.js");
-                            window.pyworker.onmessage = capturelogs;
-                            window.pyworker.onerror = (evt) => {
-                                window.python_logs.push(...new TextEncoder().encode(
-                                    `Worker error: ${evt.message}\n`));
-                                if (window.python_done_callback) {
-                                    let callback = window.python_done_callback;
-                                    window.python_done_callback = undefined;
-                                    callback({result: 1});
-                                }
-                            };
-                        }
-                        startPyWorker();
+                        window.pyworker = new Worker("worker.js");
+                        window.pyworker.onmessage = capturelogs;
                     </script>
                 </head>
                 <body></body>
@@ -94,36 +82,22 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
         elif self.path.endswith("/worker.js"):
             body = b"""
                 importScripts("./pyodide.js");
-                function do_print(arg) {
-                    let databytes = Array.from(arg);
-                    self.postMessage({print:databytes});
-                    return databytes.length;
-                }
-                function log(message) {
-                    do_print(new TextEncoder().encode(`[worker] ${message}\n`));
-                }
                 onmessage = async function (e) {
                     const data = e.data;
-                    try {
-                        if (!self.pyodide) {
-                            log("loading Pyodide");
-                            self.pyodide = await loadPyodide();
-                            log("loaded Pyodide");
-                        }
-                        self.pyodide.setStdout({write:do_print,isatty:data.isatty});
-                        self.pyodide.setStderr({write:do_print,isatty:data.isatty});
-
-                        log("loading packages from imports");
-                        await self.pyodide.loadPackagesFromImports(data.python);
-                        log("running Python");
-                        let results = await self.pyodide.runPythonAsync(data.python);
-                        log("Python completed");
-                        self.postMessage({results});
-                    } catch (error) {
-                        do_print(new TextEncoder().encode(
-                            `Worker failed: ${error && error.stack || error}\n`));
-                        self.postMessage({results: 1});
+                    if (!self.pyodide) {
+                        self.pyodide = await loadPyodide();
                     }
+                    function do_print(arg) {
+                        let databytes = Array.from(arg);
+                        self.postMessage({print:databytes});
+                        return databytes.length;
+                    }
+                    self.pyodide.setStdout({write:do_print,isatty:data.isatty});
+                    self.pyodide.setStderr({write:do_print,isatty:data.isatty});
+
+                    await self.pyodide.loadPackagesFromImports(data.python);
+                    let results = await self.pyodide.runPythonAsync(data.python);
+                    self.postMessage({results});
                 }
                 """
             self.send_response(200)
@@ -228,48 +202,43 @@ class BrowserDriver:
     def __init__(self, hostname, port, driver):
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
+        # Chrome on CI takes longer than locally to compile.
+        self.driver.set_script_timeout(1200)
 
     def load_pyodide(self, dist_dir):
         pass
 
     def load_arrow(self):
-        code = (f"import pyodide_js as pjs\n"
-                f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
-        for attempt in range(3):
-            try:
-                return self.execute_python(code, timeout=300)
-            except TimeoutError:
-                if attempt == 2:
-                    raise TimeoutError(
-                        "Timed out initializing Pyodide/PyArrow in browser")
-                print("Timed out initializing Pyodide/loading PyArrow. Restarting",
-                      flush=True)
-                self.restart_worker()
-
-    def execute_python(self, code, wait_for_terminate=True, timeout=None):
-        self.driver.execute_script(
-            f"""
-            let python = `{code}`;
-            delete window.python_script_done;
-            window.python_done_callback= (x) => {{window.python_script_done=x;}};
-            window.pyworker.postMessage(
-                {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
-            """
+        self.execute_python(
+            f"import pyodide_js as pjs\n"
+            f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n"
         )
+
+    def execute_python(self, code, wait_for_terminate=True):
         if wait_for_terminate:
-            return self.wait_for_done(timeout=timeout)
-
-    def restart_worker(self):
-        self.driver.execute_script(
-            "window.pyworker.terminate(); startPyWorker(); "
-            "delete window.python_script_done; window.python_done_callback = undefined;"
-        )
+            self.driver.execute_async_script(
+                f"""
+                let callback = arguments[arguments.length-1];
+                python = `{code}`;
+                window.python_done_callback = callback;
+                window.pyworker.postMessage(
+                    {{python, isatty: {'true' if sys.stdout.isatty() else 'false'}}});
+                """
+            )
+        else:
+            self.driver.execute_script(
+                f"""
+                let python = `{code}`;
+                window.python_done_callback= (x) => {{window.python_script_done=x;}};
+                window.pyworker.postMessage(
+                    {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
+                """
+            )
 
     def clear_logs(self):
         self.driver.execute_script("window.python_logs = [];")
 
-    def wait_for_done(self, timeout=None):
-        start = last_heartbeat = time.monotonic()
+    def wait_for_done(self):
         while True:
             # poll for console.log messages from our webworker
             # which are the output of pytest
@@ -278,18 +247,11 @@ class BrowserDriver:
             )
             if len(lines) > 0:
                 sys.stdout.buffer.write(bytes(lines))
-                sys.stdout.buffer.flush()
             done = self.driver.execute_script("return window.python_script_done;")
             if done is not None:
                 value = done["result"]
                 self.driver.execute_script("delete window.python_script_done;")
                 return value
-            now = time.monotonic()
-            if timeout is not None and now - start > timeout:
-                raise TimeoutError
-            if now - last_heartbeat > 30:
-                print("Waiting for browser-side Python to finish...", flush=True)
-                last_heartbeat = now
             time.sleep(0.1)
 
 

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -68,9 +68,11 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
                             }
                         }
                         function startPyWorker() {
+                            window.pyworker_failed = false;
                             window.pyworker = new Worker("worker.js");
                             window.pyworker.onmessage = capturelogs;
                             window.pyworker.onerror = (evt) => {
+                                window.pyworker_failed = true;
                                 window.python_logs.push(...new TextEncoder().encode(
                                     `Worker error: ${evt.message}\n`));
                                 if (window.python_done_callback) {
@@ -99,25 +101,17 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
                     self.postMessage({print:databytes});
                     return databytes.length;
                 }
-                function log(message) {
-                    do_print(new TextEncoder().encode(`[worker] ${message}\n`));
-                }
                 onmessage = async function (e) {
                     const data = e.data;
                     try {
                         if (!self.pyodide) {
-                            log("loading Pyodide");
                             self.pyodide = await loadPyodide();
-                            log("loaded Pyodide");
                         }
                         self.pyodide.setStdout({write:do_print,isatty:data.isatty});
                         self.pyodide.setStderr({write:do_print,isatty:data.isatty});
 
-                        log("loading packages from imports");
                         await self.pyodide.loadPackagesFromImports(data.python);
-                        log("running Python");
                         let results = await self.pyodide.runPythonAsync(data.python);
-                        log("Python completed");
                         self.postMessage({results});
                     } catch (error) {
                         do_print(new TextEncoder().encode(
@@ -228,8 +222,6 @@ class BrowserDriver:
     def __init__(self, hostname, port, driver):
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
-        # Chrome on CI takes longer than locally to compile.
-        self.driver.set_script_timeout(1200)
 
     def load_pyodide(self, dist_dir):
         pass
@@ -239,7 +231,12 @@ class BrowserDriver:
                 f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
         for attempt in range(3):
             try:
-                return self.execute_python(code, timeout=300)
+                result = self.execute_python(code, timeout=300)
+                if result:
+                    raise RuntimeError(
+                        "PyArrow wheel failed to load in browser "
+                        f"(exit status {result}), see log above")
+                return result
             except TimeoutError:
                 if attempt == 2:
                     raise TimeoutError(
@@ -274,18 +271,23 @@ class BrowserDriver:
         start = last_heartbeat = time.monotonic()
         while True:
             # poll for console.log messages from our webworker
-            # which are the output of pytest
-            lines = self.driver.execute_script(
-                "let temp = window.python_logs;window.python_logs=[];return temp;"
+            # (output of pytest), completion and worker death
+            state = self.driver.execute_script(
+                "let logs = window.python_logs; window.python_logs = [];"
+                "return {logs: logs, done: window.python_script_done,"
+                "        failed: window.pyworker_failed === true};"
             )
+            lines = state.get("logs") or []
             if len(lines) > 0:
                 sys.stdout.buffer.write(bytes(lines))
                 sys.stdout.buffer.flush()
-            done = self.driver.execute_script("return window.python_script_done;")
+            done = state.get("done")
             if done is not None:
-                value = done["result"]
                 self.driver.execute_script("delete window.python_script_done;")
-                return value
+                return done["result"]
+            if state.get("failed"):
+                raise RuntimeError(
+                    "Browser-side worker died. See 'Worker error:' in log above")
             now = time.monotonic()
             if timeout is not None and now - start > timeout:
                 raise TimeoutError

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -67,22 +67,8 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
                                 evt.data.print.forEach((x)=>{window.python_logs.push(x)});
                             }
                         }
-                        function startPyWorker() {
-                            window.pyworker_failed = false;
-                            window.pyworker = new Worker("worker.js");
-                            window.pyworker.onmessage = capturelogs;
-                            window.pyworker.onerror = (evt) => {
-                                window.pyworker_failed = true;
-                                window.python_logs.push(...new TextEncoder().encode(
-                                    `Worker error: ${evt.message}\n`));
-                                if (window.python_done_callback) {
-                                    let callback = window.python_done_callback;
-                                    window.python_done_callback = undefined;
-                                    callback({result: 1});
-                                }
-                            };
-                        }
-                        startPyWorker();
+                        window.pyworker = new Worker("worker.js");
+                        window.pyworker.onmessage = capturelogs;
                     </script>
                 </head>
                 <body></body>
@@ -96,28 +82,22 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
         elif self.path.endswith("/worker.js"):
             body = b"""
                 importScripts("./pyodide.js");
-                function do_print(arg) {
-                    let databytes = Array.from(arg);
-                    self.postMessage({print:databytes});
-                    return databytes.length;
-                }
                 onmessage = async function (e) {
                     const data = e.data;
-                    try {
-                        if (!self.pyodide) {
-                            self.pyodide = await loadPyodide();
-                        }
-                        self.pyodide.setStdout({write:do_print,isatty:data.isatty});
-                        self.pyodide.setStderr({write:do_print,isatty:data.isatty});
-
-                        await self.pyodide.loadPackagesFromImports(data.python);
-                        let results = await self.pyodide.runPythonAsync(data.python);
-                        self.postMessage({results});
-                    } catch (error) {
-                        do_print(new TextEncoder().encode(
-                            `Worker failed: ${error && error.stack || error}\n`));
-                        self.postMessage({results: 1});
+                    if (!self.pyodide) {
+                        self.pyodide = await loadPyodide();
                     }
+                    function do_print(arg) {
+                        let databytes = Array.from(arg);
+                        self.postMessage({print:databytes});
+                        return databytes.length;
+                    }
+                    self.pyodide.setStdout({write:do_print,isatty:data.isatty});
+                    self.pyodide.setStderr({write:do_print,isatty:data.isatty});
+
+                    await self.pyodide.loadPackagesFromImports(data.python);
+                    let results = await self.pyodide.runPythonAsync(data.python);
+                    self.postMessage({results});
                 }
                 """
             self.send_response(200)
@@ -222,78 +202,56 @@ class BrowserDriver:
     def __init__(self, hostname, port, driver):
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
+        # Chrome on CI takes longer than locally to compile.
+        self.driver.set_script_timeout(1200)
 
     def load_pyodide(self, dist_dir):
         pass
 
     def load_arrow(self):
-        code = (f"import pyodide_js as pjs\n"
-                f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
-        for attempt in range(3):
-            try:
-                result = self.execute_python(code, timeout=300)
-                if result:
-                    raise RuntimeError(
-                        "PyArrow wheel failed to load in browser "
-                        f"(exit status {result}), see log above")
-                return result
-            except TimeoutError:
-                if attempt == 2:
-                    raise TimeoutError(
-                        "Timed out initializing Pyodide/PyArrow in browser")
-                print("Timed out initializing Pyodide/loading PyArrow. Restarting",
-                      flush=True)
-                self.restart_worker()
-
-    def execute_python(self, code, wait_for_terminate=True, timeout=None):
-        self.driver.execute_script(
-            f"""
-            let python = `{code}`;
-            delete window.python_script_done;
-            window.python_done_callback= (x) => {{window.python_script_done=x;}};
-            window.pyworker.postMessage(
-                {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
-            """
+        self.execute_python(
+            f"import pyodide_js as pjs\n"
+            f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n"
         )
+
+    def execute_python(self, code, wait_for_terminate=True):
         if wait_for_terminate:
-            return self.wait_for_done(timeout=timeout)
-
-    def restart_worker(self):
-        self.driver.execute_script(
-            "window.pyworker.terminate(); startPyWorker(); "
-            "delete window.python_script_done; window.python_done_callback = undefined;"
-        )
+            self.driver.execute_async_script(
+                f"""
+                let callback = arguments[arguments.length-1];
+                python = `{code}`;
+                window.python_done_callback = callback;
+                window.pyworker.postMessage(
+                    {{python, isatty: {'true' if sys.stdout.isatty() else 'false'}}});
+                """
+            )
+        else:
+            self.driver.execute_script(
+                f"""
+                let python = `{code}`;
+                window.python_done_callback= (x) => {{window.python_script_done=x;}};
+                window.pyworker.postMessage(
+                    {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
+                """
+            )
 
     def clear_logs(self):
         self.driver.execute_script("window.python_logs = [];")
 
-    def wait_for_done(self, timeout=None):
-        start = last_heartbeat = time.monotonic()
+    def wait_for_done(self):
         while True:
             # poll for console.log messages from our webworker
-            # (output of pytest), completion and worker death
-            state = self.driver.execute_script(
-                "let logs = window.python_logs; window.python_logs = [];"
-                "return {logs: logs, done: window.python_script_done,"
-                "        failed: window.pyworker_failed === true};"
+            # which are the output of pytest
+            lines = self.driver.execute_script(
+                "let temp = window.python_logs;window.python_logs=[];return temp;"
             )
-            lines = state.get("logs") or []
             if len(lines) > 0:
                 sys.stdout.buffer.write(bytes(lines))
-                sys.stdout.buffer.flush()
-            done = state.get("done")
+            done = self.driver.execute_script("return window.python_script_done;")
             if done is not None:
+                value = done["result"]
                 self.driver.execute_script("delete window.python_script_done;")
-                return done["result"]
-            if state.get("failed"):
-                raise RuntimeError(
-                    "Browser-side worker died. See 'Worker error:' in log above")
-            now = time.monotonic()
-            if timeout is not None and now - start > timeout:
-                raise TimeoutError
-            if now - last_heartbeat > 30:
-                print("Waiting for browser-side Python to finish...", flush=True)
-                last_heartbeat = now
+                return value
             time.sleep(0.1)
 
 
@@ -304,7 +262,6 @@ class ChromeDriver(BrowserDriver):
         options = Options()
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
-        options.add_argument("--disable-dev-shm-usage")
         driver = webdriver.Chrome(options=options)
         driver.command_executor._client_config.timeout = 1200
         super().__init__(hostname, port, driver)

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -242,8 +242,9 @@ class BrowserDriver:
                 return self.execute_python(code, timeout=300)
             except TimeoutError:
                 if attempt == 2:
-                    raise TimeoutError("Timed out loading PyArrow in browser")
-                print("Timed out loading PyArrow in browser; restarting worker",
+                    raise TimeoutError(
+                        "Timed out initializing Pyodide/PyArrow in browser")
+                print("Timed out initializing Pyodide/loading PyArrow. Restarting",
                       flush=True)
                 self.restart_worker()
 

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -82,34 +82,26 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
         elif self.path.endswith("/worker.js"):
             body = b"""
                 importScripts("./pyodide.js");
-                function postLog(message) {
-                    self.postMessage({print: Array.from(new TextEncoder().encode(
-                        `[worker] ${new Date().toISOString()} ${message}\n`))});
+                function do_print(arg) {
+                    let databytes = Array.from(arg);
+                    self.postMessage({print:databytes});
+                    return databytes.length;
                 }
                 onmessage = async function (e) {
                     const data = e.data;
                     try {
                         if (!self.pyodide) {
-                            postLog("loading Pyodide");
                             self.pyodide = await loadPyodide();
-                            postLog("loaded Pyodide");
-                        }
-                        function do_print(arg) {
-                            let databytes = Array.from(arg);
-                            self.postMessage({print:databytes});
-                            return databytes.length;
                         }
                         self.pyodide.setStdout({write:do_print,isatty:data.isatty});
                         self.pyodide.setStderr({write:do_print,isatty:data.isatty});
 
-                        postLog("loading packages from imports");
                         await self.pyodide.loadPackagesFromImports(data.python);
-                        postLog("running Python");
                         let results = await self.pyodide.runPythonAsync(data.python);
-                        postLog(`Python completed with result ${results}`);
                         self.postMessage({results});
                     } catch (error) {
-                        postLog(`Python failed: ${error && error.stack || error}`);
+                        do_print(new TextEncoder().encode(
+                            `Worker failed: ${error && error.stack || error}\n`));
                         self.postMessage({results: 1});
                     }
                 }
@@ -274,7 +266,6 @@ class ChromeDriver(BrowserDriver):
         options = Options()
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
-        options.add_argument("--disable-dev-shm-usage")
         driver = webdriver.Chrome(options=options)
         driver.command_executor._client_config.timeout = 1200
         super().__init__(hostname, port, driver)

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -33,6 +33,9 @@ from io import BytesIO
 from selenium import webdriver
 
 
+BROWSER_TIMEOUT_SECONDS = 3600
+
+
 class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
     def log_request(self, code="-", size="-"):
         # don't log successful requests but log errors
@@ -203,7 +206,7 @@ class BrowserDriver:
         self.driver = driver
         self.driver.get(f"http://{hostname}:{port}/test.html")
         # Chrome on CI takes longer than locally to compile.
-        self.driver.set_script_timeout(1200)
+        self.driver.set_script_timeout(BROWSER_TIMEOUT_SECONDS)
 
     def load_pyodide(self, dist_dir):
         pass
@@ -262,8 +265,9 @@ class ChromeDriver(BrowserDriver):
         options = Options()
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
         driver = webdriver.Chrome(options=options)
-        driver.command_executor._client_config.timeout = 1200
+        driver.command_executor._client_config.timeout = BROWSER_TIMEOUT_SECONDS
         super().__init__(hostname, port, driver)
 
 

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -67,8 +67,20 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
                                 evt.data.print.forEach((x)=>{window.python_logs.push(x)});
                             }
                         }
-                        window.pyworker = new Worker("worker.js");
-                        window.pyworker.onmessage = capturelogs;
+                        function startPyWorker() {
+                            window.pyworker = new Worker("worker.js");
+                            window.pyworker.onmessage = capturelogs;
+                            window.pyworker.onerror = (evt) => {
+                                window.python_logs.push(...new TextEncoder().encode(
+                                    `Worker error: ${evt.message}\n`));
+                                if (window.python_done_callback) {
+                                    let callback = window.python_done_callback;
+                                    window.python_done_callback = undefined;
+                                    callback({result: 1});
+                                }
+                            };
+                        }
+                        startPyWorker();
                     </script>
                 </head>
                 <body></body>
@@ -223,12 +235,19 @@ class BrowserDriver:
         pass
 
     def load_arrow(self):
-        self.execute_python(
-            f"import pyodide_js as pjs\n"
-            f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n"
-        )
+        code = (f"import pyodide_js as pjs\n"
+                f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
+        for attempt in range(3):
+            try:
+                return self.execute_python(code, timeout=300)
+            except TimeoutError:
+                if attempt == 2:
+                    raise TimeoutError("Timed out loading PyArrow in browser")
+                print("Timed out loading PyArrow in browser; restarting worker",
+                      flush=True)
+                self.restart_worker()
 
-    def execute_python(self, code, wait_for_terminate=True):
+    def execute_python(self, code, wait_for_terminate=True, timeout=None):
         self.driver.execute_script(
             f"""
             let python = `{code}`;
@@ -239,13 +258,19 @@ class BrowserDriver:
             """
         )
         if wait_for_terminate:
-            return self.wait_for_done()
+            return self.wait_for_done(timeout=timeout)
+
+    def restart_worker(self):
+        self.driver.execute_script(
+            "window.pyworker.terminate(); startPyWorker(); "
+            "delete window.python_script_done; window.python_done_callback = undefined;"
+        )
 
     def clear_logs(self):
         self.driver.execute_script("window.python_logs = [];")
 
-    def wait_for_done(self):
-        last_heartbeat = time.monotonic()
+    def wait_for_done(self, timeout=None):
+        start = last_heartbeat = time.monotonic()
         while True:
             # poll for console.log messages from our webworker
             # which are the output of pytest
@@ -261,6 +286,8 @@ class BrowserDriver:
                 self.driver.execute_script("delete window.python_script_done;")
                 return value
             now = time.monotonic()
+            if timeout is not None and now - start > timeout:
+                raise TimeoutError
             if now - last_heartbeat > 30:
                 print("Waiting for browser-side Python to finish...", flush=True)
                 last_heartbeat = now

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -87,17 +87,25 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
                     self.postMessage({print:databytes});
                     return databytes.length;
                 }
+                function log(message) {
+                    do_print(new TextEncoder().encode(`[worker] ${message}\n`));
+                }
                 onmessage = async function (e) {
                     const data = e.data;
                     try {
                         if (!self.pyodide) {
+                            log("loading Pyodide");
                             self.pyodide = await loadPyodide();
+                            log("loaded Pyodide");
                         }
                         self.pyodide.setStdout({write:do_print,isatty:data.isatty});
                         self.pyodide.setStderr({write:do_print,isatty:data.isatty});
 
+                        log("loading packages from imports");
                         await self.pyodide.loadPackagesFromImports(data.python);
+                        log("running Python");
                         let results = await self.pyodide.runPythonAsync(data.python);
+                        log("Python completed");
                         self.postMessage({results});
                     } catch (error) {
                         do_print(new TextEncoder().encode(

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -274,6 +274,7 @@ class ChromeDriver(BrowserDriver):
         options = Options()
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
         driver = webdriver.Chrome(options=options)
         driver.command_executor._client_config.timeout = 1200
         super().__init__(hostname, port, driver)

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -85,22 +85,36 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
         elif self.path.endswith("/worker.js"):
             body = b"""
                 importScripts("./pyodide.js");
+                function postLog(message) {
+                    self.postMessage({print: Array.from(new TextEncoder().encode(
+                        `[worker] ${new Date().toISOString()} ${message}\n`))});
+                }
                 onmessage = async function (e) {
                     const data = e.data;
-                    if (!self.pyodide) {
-                        self.pyodide = await loadPyodide();
-                    }
-                    function do_print(arg) {
-                        let databytes = Array.from(arg);
-                        self.postMessage({print:databytes});
-                        return databytes.length;
-                    }
-                    self.pyodide.setStdout({write:do_print,isatty:data.isatty});
-                    self.pyodide.setStderr({write:do_print,isatty:data.isatty});
+                    try {
+                        if (!self.pyodide) {
+                            postLog("loading Pyodide");
+                            self.pyodide = await loadPyodide();
+                            postLog("loaded Pyodide");
+                        }
+                        function do_print(arg) {
+                            let databytes = Array.from(arg);
+                            self.postMessage({print:databytes});
+                            return databytes.length;
+                        }
+                        self.pyodide.setStdout({write:do_print,isatty:data.isatty});
+                        self.pyodide.setStderr({write:do_print,isatty:data.isatty});
 
-                    await self.pyodide.loadPackagesFromImports(data.python);
-                    let results = await self.pyodide.runPythonAsync(data.python);
-                    self.postMessage({results});
+                        postLog("loading packages from imports");
+                        await self.pyodide.loadPackagesFromImports(data.python);
+                        postLog("running Python");
+                        let results = await self.pyodide.runPythonAsync(data.python);
+                        postLog(`Python completed with result ${results}`);
+                        self.postMessage({results});
+                    } catch (error) {
+                        postLog(`Python failed: ${error && error.stack || error}`);
+                        self.postMessage({results: 1});
+                    }
                 }
                 """
             self.send_response(200)
@@ -218,30 +232,23 @@ class BrowserDriver:
         )
 
     def execute_python(self, code, wait_for_terminate=True):
+        self.driver.execute_script(
+            f"""
+            let python = `{code}`;
+            delete window.python_script_done;
+            window.python_done_callback= (x) => {{window.python_script_done=x;}};
+            window.pyworker.postMessage(
+                {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
+            """
+        )
         if wait_for_terminate:
-            self.driver.execute_async_script(
-                f"""
-                let callback = arguments[arguments.length-1];
-                python = `{code}`;
-                window.python_done_callback = callback;
-                window.pyworker.postMessage(
-                    {{python, isatty: {'true' if sys.stdout.isatty() else 'false'}}});
-                """
-            )
-        else:
-            self.driver.execute_script(
-                f"""
-                let python = `{code}`;
-                window.python_done_callback= (x) => {{window.python_script_done=x;}};
-                window.pyworker.postMessage(
-                    {{python,isatty:{'true' if sys.stdout.isatty() else 'false'}}});
-                """
-            )
+            return self.wait_for_done()
 
     def clear_logs(self):
         self.driver.execute_script("window.python_logs = [];")
 
     def wait_for_done(self):
+        last_heartbeat = time.monotonic()
         while True:
             # poll for console.log messages from our webworker
             # which are the output of pytest
@@ -250,11 +257,16 @@ class BrowserDriver:
             )
             if len(lines) > 0:
                 sys.stdout.buffer.write(bytes(lines))
+                sys.stdout.buffer.flush()
             done = self.driver.execute_script("return window.python_script_done;")
             if done is not None:
                 value = done["result"]
                 self.driver.execute_script("delete window.python_script_done;")
                 return value
+            now = time.monotonic()
+            if now - last_heartbeat > 30:
+                print("Waiting for browser-side Python to finish...", flush=True)
+                last_heartbeat = now
             time.sleep(0.1)
 
 


### PR DESCRIPTION
### Rationale for this change
Fix #50424 `Python Emscripten Crossbow` job with multiple failing points
A) failing to install Chrome - `Requested Chrome major 148, but apt repo currently publishes 150.0.7871.100`,
B) and underlying Abseil failure - `error: expected '(' before 'ABSL_INTERNAL_CONSTEXPR_SINCE_CXX17'` [logB](https://github.com/ursacomputing/crossbow/actions/runs/28963702667/job/85941369345#step:6:2995)
C) pytest 8.1.1 failing on three tests with the message - `E   TypeError: importorskip() got an unexpected keyword argument 'exc_type'` [logC](https://github.com/ursacomputing/crossbow/actions/runs/28972366846/job/85971005157#step:6:6354) 

The remaining intermittent issue be best dealt with in a follow up PR:
D) intermittent `loadPyodide` / Selenium timeout hang - `selenium.common.exceptions.TimeoutException: Message: script timeout` [logD](https://github.com/ursacomputing/crossbow/actions/runs/28997397611/job/86049819728#step:6:6856) and [hang log with debug](https://github.com/ursacomputing/crossbow/actions/runs/29015193964/job/86108340808#step:6:7248)

### What changes are included in this PR?
A) Changed `chrome_version: "148"` to `chrome_version: "latest"`
B) Disabled zlib for protobuf build of the host in order to avoid conda include path overriding vendor Abseil headers.
C) Added work-around for current Pyodide's bundled pytest version 8.1.1 which lacks `importorskip(..., exc_type=...)`

### Are these changes tested?
Yes, test-conda-python-emscripten job completed successfully on rerun. Some earlier runs hit the intermittent Chrome/Selenium timeout mentioned above.

### Are there any user-facing changes?
No.

* GitHub Issue: #50424