### PR TITLE
MINOR: [CI] Add Acero CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,7 @@ compose.yaml @assignUser @jonkeane @kou @raulcd
 
 ## C++
 /cpp/src/arrow/ @pitrou
+/cpp/src/arrow/acero/ @pitrou @zanmato1984
 /cpp/src/arrow/adapters/orc @wgtmac
 /cpp/src/arrow/flight/ @lidavidm
 /cpp/src/gandiva @dmitry-chirkov-dremio @lriggs @akravchukdremio @xxlaykxx


### PR DESCRIPTION
### Rationale for this change

Follow-up to #50420.

### What changes are included in this PR?

Add an explicit Acero CODEOWNERS entry.

### Are these changes tested?

No; CODEOWNERS-only change.

### Are there any user-facing changes?

No.