### PR TITLE
GH-50431: [Python] Make FlightError a non-cdef class for abi3 wheel precursor

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -181,7 +181,7 @@ class CertKeyPair(_CertKeyPair):
     """A TLS certificate and key for use in Flight."""
 
 
-cdef class FlightError(Exception):
+class FlightError(Exception):
     """
     The base class for Flight-specific errors.
 
@@ -201,73 +201,65 @@ cdef class FlightError(Exception):
     extra_info : bytes
         Extra binary error details that were provided by the
         server/will be sent to the client.
-  """
-
-    cdef dict __dict__
+    """
 
     def __init__(self, message='', extra_info=b''):
         super().__init__(message)
         self.extra_info = tobytes(extra_info)
 
-    cdef CStatus to_status(self):
-        message = tobytes(f"Flight error: {self}")
-        return CStatus_UnknownError(message)
 
-
-cdef class FlightInternalError(FlightError, ArrowException):
+class FlightInternalError(FlightError, ArrowException):
     """An error internal to the Flight server occurred."""
 
-    cdef CStatus to_status(self):
-        return MakeFlightError(CFlightStatusInternal,
-                               tobytes(str(self)), self.extra_info)
 
-
-cdef class FlightTimedOutError(FlightError, ArrowException):
+class FlightTimedOutError(FlightError, ArrowException):
     """The Flight RPC call timed out."""
 
-    cdef CStatus to_status(self):
-        return MakeFlightError(CFlightStatusTimedOut,
-                               tobytes(str(self)), self.extra_info)
 
-
-cdef class FlightCancelledError(FlightError, ArrowCancelled):
+class FlightCancelledError(FlightError, ArrowCancelled):
     """The operation was cancelled."""
 
-    cdef CStatus to_status(self):
-        return MakeFlightError(CFlightStatusCancelled, tobytes(str(self)),
-                               self.extra_info)
 
-
-cdef class FlightServerError(FlightError, ArrowException):
+class FlightServerError(FlightError, ArrowException):
     """A server error occurred."""
 
-    cdef CStatus to_status(self):
-        return MakeFlightError(CFlightStatusFailed, tobytes(str(self)),
-                               self.extra_info)
 
-
-cdef class FlightUnauthenticatedError(FlightError, ArrowException):
+class FlightUnauthenticatedError(FlightError, ArrowException):
     """The client is not authenticated."""
 
-    cdef CStatus to_status(self):
-        return MakeFlightError(
-            CFlightStatusUnauthenticated, tobytes(str(self)), self.extra_info)
 
-
-cdef class FlightUnauthorizedError(FlightError, ArrowException):
+class FlightUnauthorizedError(FlightError, ArrowException):
     """The client is not authorized to perform the given operation."""
 
-    cdef CStatus to_status(self):
-        return MakeFlightError(CFlightStatusUnauthorized, tobytes(str(self)),
-                               self.extra_info)
 
-
-cdef class FlightUnavailableError(FlightError, ArrowException):
+class FlightUnavailableError(FlightError, ArrowException):
     """The server is not reachable or available."""
 
-    cdef CStatus to_status(self):
-        return MakeFlightError(CFlightStatusUnavailable, tobytes(str(self)),
-                               self.extra_info)
+
+cdef CStatus _flight_error_to_status(error) except *:
+    extra_info = tobytes(getattr(error, "extra_info", b""))
+    if isinstance(error, FlightInternalError):
+        return MakeFlightError(CFlightStatusInternal, tobytes(str(error)),
+                               extra_info)
+    elif isinstance(error, FlightTimedOutError):
+        return MakeFlightError(CFlightStatusTimedOut, tobytes(str(error)),
+                               extra_info)
+    elif isinstance(error, FlightCancelledError):
+        return MakeFlightError(CFlightStatusCancelled, tobytes(str(error)),
+                               extra_info)
+    elif isinstance(error, FlightServerError):
+        return MakeFlightError(CFlightStatusFailed, tobytes(str(error)),
+                               extra_info)
+    elif isinstance(error, FlightUnauthenticatedError):
+        return MakeFlightError(CFlightStatusUnauthenticated, tobytes(str(error)),
+                               extra_info)
+    elif isinstance(error, FlightUnauthorizedError):
+        return MakeFlightError(CFlightStatusUnauthorized, tobytes(str(error)),
+                               extra_info)
+    elif isinstance(error, FlightUnavailableError):
+        return MakeFlightError(CFlightStatusUnavailable, tobytes(str(error)),
+                               extra_info)
+    return CStatus_UnknownError(tobytes(f"Flight error: {error}"))
 
 
 class FlightWriteSizeExceededError(ArrowInvalid):
@@ -2140,7 +2132,7 @@ cdef CStatus _data_stream_next(void* self, CFlightPayload* payload) except *:
             payload.ipc_message.metadata.reset(<CBuffer*> nullptr)
             return CStatus_OK()
         except FlightError as flight_error:
-            return (<FlightError> flight_error).to_status()
+            return _flight_error_to_status(flight_error)
 
         if isinstance(result, (list, tuple)):
             result, metadata = result
@@ -2214,7 +2206,7 @@ cdef CStatus _list_flights(void* self, const CServerCallContext& context,
             flights.push_back(deref((<FlightInfo> info).info.get()))
         listing.reset(new CSimpleFlightListing(flights))
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     return CStatus_OK()
 
 
@@ -2231,7 +2223,7 @@ cdef CStatus _get_flight_info(void* self, const CServerCallContext& context,
             ServerCallContext.wrap(context),
             py_descriptor)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     if not isinstance(result, FlightInfo):
         raise TypeError("FlightServerBase.get_flight_info must return "
                         f"a FlightInfo instance, but got {type(result)}")
@@ -2272,7 +2264,7 @@ cdef CStatus _do_put(void* self, const CServerCallContext& context,
                                py_reader, py_writer)
         return CStatus_OK()
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
 
 
 cdef CStatus _do_get(void* self, const CServerCallContext& context,
@@ -2287,7 +2279,7 @@ cdef CStatus _do_get(void* self, const CServerCallContext& context,
         result = (<object> self).do_get(ServerCallContext.wrap(context),
                                         py_ticket)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     if not isinstance(result, FlightDataStream):
         raise TypeError("FlightServerBase.do_get must return "
                         "a FlightDataStream")
@@ -2316,7 +2308,7 @@ cdef CStatus _do_exchange(void* self, const CServerCallContext& context,
                                     descriptor, py_reader, py_writer)
         return CStatus_OK()
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
 
 
 cdef CStatus _do_action_result_next(
@@ -2336,7 +2328,7 @@ cdef CStatus _do_action_result_next(
     except StopIteration:
         result.reset(nullptr)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     return CStatus_OK()
 
 
@@ -2351,7 +2343,7 @@ cdef CStatus _do_action(void* self, const CServerCallContext& context,
         responses = (<object> self).do_action(ServerCallContext.wrap(context),
                                               py_action)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     # Let the application return an iterator or anything convertible
     # into one
     if responses is None:
@@ -2377,7 +2369,7 @@ cdef CStatus _list_actions(void* self, const CServerCallContext& context,
             action_type.description = tobytes(action[1])
             actions.push_back(action_type)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     return CStatus_OK()
 
 
@@ -2389,7 +2381,7 @@ cdef CStatus _server_authenticate(void* self, CServerAuthSender* outgoing,
     try:
         (<object> self).authenticate(sender, reader)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     finally:
         sender.poison()
         reader.poison()
@@ -2403,7 +2395,7 @@ cdef CStatus _is_valid(void* self, const c_string& token,
         c_result = tobytes((<object> self).is_valid(token))
         peer_identity[0] = c_result
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     return CStatus_OK()
 
 
@@ -2415,7 +2407,7 @@ cdef CStatus _client_authenticate(void* self, CClientAuthSender* outgoing,
     try:
         (<object> self).authenticate(sender, reader)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     finally:
         sender.poison()
         reader.poison()
@@ -2429,7 +2421,7 @@ cdef CStatus _get_token(void* self, c_string* token) except *:
         c_result = tobytes((<object> self).get_token())
         token[0] = c_result
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     return CStatus_OK()
 
 
@@ -2439,7 +2431,7 @@ cdef CStatus _middleware_sending_headers(
     try:
         headers = (<object> self).sending_headers()
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
 
     if headers:
         for header, values in headers.items():
@@ -2471,7 +2463,7 @@ cdef CStatus _middleware_call_completed(
         else:
             (<object> self).call_completed(None)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     return CStatus_OK()
 
 
@@ -2483,7 +2475,7 @@ cdef CStatus _middleware_received_headers(
         headers = convert_headers(c_headers)
         (<object> self).received_headers(headers)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
     return CStatus_OK()
 
 
@@ -2516,7 +2508,7 @@ cdef CStatus _server_middleware_start_call(
         headers = convert_headers(c_headers)
         instance = (<object> self).start_call(call_info, headers)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
 
     if instance:
         ServerMiddleware.wrap(instance, c_instance)
@@ -2534,7 +2526,7 @@ cdef CStatus _client_middleware_start_call(
         call_info = wrap_call_info(c_info)
         instance = (<object> self).start_call(call_info)
     except FlightError as flight_error:
-        return (<FlightError> flight_error).to_status()
+        return _flight_error_to_status(flight_error)
 
     if instance:
         ClientMiddleware.wrap(instance, c_instance)


### PR DESCRIPTION
### Rationale for this change

Towards https://github.com/apache/arrow/issues/50398

closes https://github.com/apache/arrow/issues/50431

### What changes are included in this PR?

This is an agent generated PR that makes `FlightError` a non-cdef subclass of `Exception` as Cython does not support building with the Limited API and cdef classes that inherit from Python classes.

It appears before a `cdef CStatus to_status` was defined on each subclass to return a `MakeFlightError` per flight error flavor. This was pull out to a dedicated `_flight_error_to_status` function instead.

### Are these changes tested?

Yes (via existing tests?)

### Are there any user-facing changes?

No

* GitHub Issue: #50398
* GitHub Issue: #50431