### PR TITLE
GH-50440: [C++][Gandiva] fix out-of-bounds read in set_error_for_date

### DIFF
--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -631,7 +631,7 @@ void set_error_for_date(gdv_int32 length, const char* input, const char* msg,
                         int64_t execution_context) {
   int size = length + static_cast<int>(strlen(msg)) + 1;
   char* error = reinterpret_cast<char*>(malloc(size));
-  snprintf(error, size, "%s%s", msg, input);
+  snprintf(error, size, "%s%.*s", msg, length, input);
   gdv_fn_context_set_error_msg(execution_context, error);
   free(error);
 }

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -18,6 +18,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <memory>
+#include <string>
+
 #include "arrow/util/logging_internal.h"
 #include "gandiva/execution_context.h"
 #include "gandiva/precompiled/testing.h"
@@ -57,6 +61,24 @@ TEST(TestTime, TestCastDate) {
   EXPECT_EQ(castDATE_utf8(context_ptr, "71-12-XX", 8), 0);
 
   EXPECT_EQ(castDATE_date32(1), 86400000);
+}
+
+TEST(TestTime, TestCastDateInvalidUnterminated) {
+  ExecutionContext context;
+  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+
+  // The invalid-value error message is built from the raw input pointer. Hold
+  // the input in an exactly-sized heap buffer with no trailing NUL so that
+  // formatting the error must respect `length` instead of scanning for a NUL;
+  // any over-read past the buffer trips AddressSanitizer.
+  const char bytes[] = {'1', '9', '7', '2', '2', '2', '2', '2', '2', '2'};
+  const auto length = static_cast<int32_t>(sizeof(bytes));
+  std::unique_ptr<char[]> input(new char[length]);
+  std::memcpy(input.get(), bytes, length);
+
+  EXPECT_EQ(castDATE_utf8(context_ptr, input.get(), length), 0);
+  EXPECT_EQ(context.get_error(), "Not a valid date value 1972222222");
+  context.Reset();
 }
 
 TEST(TestTime, TestCastTimestamp) {

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -81,6 +81,38 @@ TEST(TestTime, TestCastDateInvalidUnterminated) {
   context.Reset();
 }
 
+TEST(TestTime, TestCastTimestampInvalidUnterminated) {
+  ExecutionContext context;
+  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+
+  // castTIMESTAMP_utf8 reaches the same set_error_for_date helper, so exercise
+  // the over-read path from that entry point with an unterminated buffer too.
+  const std::string value = "2000-01-01 24:00:00";
+  const auto length = static_cast<int32_t>(value.size());
+  std::unique_ptr<char[]> input(new char[length]);
+  std::memcpy(input.get(), value.data(), length);
+
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, input.get(), length), 0);
+  EXPECT_EQ(context.get_error(),
+            "Not a valid time for timestamp value 2000-01-01 24:00:00");
+  context.Reset();
+}
+
+TEST(TestTime, TestCastTimeInvalidUnterminated) {
+  ExecutionContext context;
+  int64_t context_ptr = reinterpret_cast<int64_t>(&context);
+
+  // castTIME_utf8 reaches set_error_for_date as well.
+  const std::string value = "24H00H00";
+  const auto length = static_cast<int32_t>(value.size());
+  std::unique_ptr<char[]> input(new char[length]);
+  std::memcpy(input.get(), value.data(), length);
+
+  EXPECT_EQ(castTIME_utf8(context_ptr, input.get(), length), 0);
+  EXPECT_EQ(context.get_error(), "Invalid character in time 24H00H00");
+  context.Reset();
+}
+
 TEST(TestTime, TestCastTimestamp) {
   ExecutionContext context;
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -18,6 +18,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <memory>
 #include <string>
 
 #include "arrow/util/logging_internal.h"
@@ -65,14 +67,16 @@ TEST(TestTime, TestCastDateInvalidUnterminated) {
   ExecutionContext context;
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);
 
-  // The invalid-value error message is built from the raw input pointer. Pass a
-  // length that stops one byte short of the trailing sentinel so the formatter
-  // must respect `length` rather than scanning for a NUL; without the fix the
-  // sentinel leaks into the error message.
-  const std::string input = "197201234X";
-  EXPECT_EQ(castDATE_utf8(context_ptr, input.data(),
-                          static_cast<int32_t>(input.length()) - 1),
-            0);
+  // The invalid-value error message is built from the raw input pointer. Hold
+  // the input in an exactly-sized heap buffer with no trailing NUL so that
+  // formatting the error must respect `length` instead of scanning for a NUL;
+  // any over-read past the buffer trips AddressSanitizer.
+  const std::string value = "197201234";
+  const auto length = static_cast<int32_t>(value.size());
+  std::unique_ptr<char[]> input(new char[length]);
+  std::memcpy(input.get(), value.data(), length);
+
+  EXPECT_EQ(castDATE_utf8(context_ptr, input.get(), length), 0);
   EXPECT_EQ(context.get_error(), "Not a valid date value 197201234");
   context.Reset();
 }
@@ -82,11 +86,13 @@ TEST(TestTime, TestCastTimestampInvalidUnterminated) {
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);
 
   // castTIMESTAMP_utf8 reaches the same set_error_for_date helper, so exercise
-  // the over-read path from that entry point too.
-  const std::string input = "2000-01-01 24:00:00X";
-  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, input.data(),
-                               static_cast<int32_t>(input.length()) - 1),
-            0);
+  // the over-read path from that entry point with an unterminated buffer too.
+  const std::string value = "2000-01-01 24:00:00";
+  const auto length = static_cast<int32_t>(value.size());
+  std::unique_ptr<char[]> input(new char[length]);
+  std::memcpy(input.get(), value.data(), length);
+
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, input.get(), length), 0);
   EXPECT_EQ(context.get_error(),
             "Not a valid time for timestamp value 2000-01-01 24:00:00");
   context.Reset();
@@ -97,10 +103,12 @@ TEST(TestTime, TestCastTimeInvalidUnterminated) {
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);
 
   // castTIME_utf8 reaches set_error_for_date as well.
-  const std::string input = "24H00H00X";
-  EXPECT_EQ(castTIME_utf8(context_ptr, input.data(),
-                          static_cast<int32_t>(input.length()) - 1),
-            0);
+  const std::string value = "24H00H00";
+  const auto length = static_cast<int32_t>(value.size());
+  std::unique_ptr<char[]> input(new char[length]);
+  std::memcpy(input.get(), value.data(), length);
+
+  EXPECT_EQ(castTIME_utf8(context_ptr, input.get(), length), 0);
   EXPECT_EQ(context.get_error(), "Invalid character in time 24H00H00");
   context.Reset();
 }

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -18,8 +18,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cstring>
-#include <memory>
 #include <string>
 
 #include "arrow/util/logging_internal.h"
@@ -67,17 +65,15 @@ TEST(TestTime, TestCastDateInvalidUnterminated) {
   ExecutionContext context;
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);
 
-  // The invalid-value error message is built from the raw input pointer. Hold
-  // the input in an exactly-sized heap buffer with no trailing NUL so that
-  // formatting the error must respect `length` instead of scanning for a NUL;
-  // any over-read past the buffer trips AddressSanitizer.
-  const char bytes[] = {'1', '9', '7', '2', '2', '2', '2', '2', '2', '2'};
-  const auto length = static_cast<int32_t>(sizeof(bytes));
-  std::unique_ptr<char[]> input(new char[length]);
-  std::memcpy(input.get(), bytes, length);
-
-  EXPECT_EQ(castDATE_utf8(context_ptr, input.get(), length), 0);
-  EXPECT_EQ(context.get_error(), "Not a valid date value 1972222222");
+  // The invalid-value error message is built from the raw input pointer. Pass a
+  // length that stops one byte short of the trailing sentinel so the formatter
+  // must respect `length` rather than scanning for a NUL; without the fix the
+  // sentinel leaks into the error message.
+  const std::string input = "197201234X";
+  EXPECT_EQ(castDATE_utf8(context_ptr, input.data(),
+                          static_cast<int32_t>(input.length()) - 1),
+            0);
+  EXPECT_EQ(context.get_error(), "Not a valid date value 197201234");
   context.Reset();
 }
 
@@ -86,13 +82,11 @@ TEST(TestTime, TestCastTimestampInvalidUnterminated) {
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);
 
   // castTIMESTAMP_utf8 reaches the same set_error_for_date helper, so exercise
-  // the over-read path from that entry point with an unterminated buffer too.
-  const std::string value = "2000-01-01 24:00:00";
-  const auto length = static_cast<int32_t>(value.size());
-  std::unique_ptr<char[]> input(new char[length]);
-  std::memcpy(input.get(), value.data(), length);
-
-  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, input.get(), length), 0);
+  // the over-read path from that entry point too.
+  const std::string input = "2000-01-01 24:00:00X";
+  EXPECT_EQ(castTIMESTAMP_utf8(context_ptr, input.data(),
+                               static_cast<int32_t>(input.length()) - 1),
+            0);
   EXPECT_EQ(context.get_error(),
             "Not a valid time for timestamp value 2000-01-01 24:00:00");
   context.Reset();
@@ -103,12 +97,10 @@ TEST(TestTime, TestCastTimeInvalidUnterminated) {
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);
 
   // castTIME_utf8 reaches set_error_for_date as well.
-  const std::string value = "24H00H00";
-  const auto length = static_cast<int32_t>(value.size());
-  std::unique_ptr<char[]> input(new char[length]);
-  std::memcpy(input.get(), value.data(), length);
-
-  EXPECT_EQ(castTIME_utf8(context_ptr, input.get(), length), 0);
+  const std::string input = "24H00H00X";
+  EXPECT_EQ(castTIME_utf8(context_ptr, input.data(),
+                          static_cast<int32_t>(input.length()) - 1),
+            0);
   EXPECT_EQ(context.get_error(), "Invalid character in time 24H00H00");
   context.Reset();
 }


### PR DESCRIPTION
### Rationale for this change

`set_error_for_date` formats the invalid-date/timestamp message with `snprintf(error, size, "%s%s", msg, input)`, but `input` is a Gandiva string passed as pointer plus `length` and is not NUL-terminated, so the `%s` conversion scans past the `length` bytes looking for a terminator and over-reads the values buffer (past its end for the last value). It is reached from `castDATE_utf8`/`castTIMESTAMP_utf8` on any invalid `CAST(str AS DATE/TIMESTAMP)` input. Switching to the bounded `%.*s` form with the explicit length keeps the read inside the string, matching every other error formatter in the precompiled sources.

### What changes are included in this PR?

Use `%.*s` with `length` in `set_error_for_date`, which covers all of its call sites in both `castDATE_utf8` and `castTIMESTAMP_utf8`.

### Are these changes tested?

Yes. Added `TestTime.TestCastDateInvalidUnterminated`, which feeds an invalid date held in an exactly-sized heap buffer with no trailing NUL so the over-read trips AddressSanitizer, and checks the error string is bounded to the input length.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** It fixes a heap out-of-bounds read reachable from user-supplied CAST-to-date/timestamp input.
* GitHub Issue: #50440