### PR TITLE
GH-50434: [Ruby] Add `ArrowFormat::Date{32,64}.new(values)`

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -417,6 +417,10 @@ module ArrowFormat
       :s32
     end
 
+    def pack_template
+      "l"
+    end
+
     def build_array(...)
       Date32Array.new(...)
     end
@@ -439,6 +443,10 @@ module ArrowFormat
 
     def buffer_type
       :s64
+    end
+
+    def pack_template
+      "q"
     end
 
     def build_array(...)

--- a/ruby/red-arrow-format/test/test-date32-array.rb
+++ b/ruby/red-arrow-format/test/test-date32-array.rb
@@ -15,41 +15,46 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class TestFloat32Array < Test::Unit::TestCase
+class TestDate32Array < Test::Unit::TestCase
+  def setup
+    @date_2017_08_28 = 17406
+    @date_2025_12_09 = 20431
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
-      values = [-Float::INFINITY, -0.0, +0.0, +Float::INFINITY]
+      values = [@date_2017_08_28, @date_2025_12_09]
       assert_equal(values,
-                   ArrowFormat::Float32Array.new(values).to_a)
+                   ArrowFormat::Date32Array.new(values).to_a)
     end
 
     def test_mixed
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
+      values = [@date_2017_08_28, nil, @date_2025_12_09]
       assert_equal(values,
-                   ArrowFormat::Float32Array.new(values).to_a)
+                   ArrowFormat::Date32Array.new(values).to_a)
     end
   end
 
   sub_test_case("#==") do
     def test_no_slice
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
-      array1 = ArrowFormat::Float32Array.new(values)
-      array2 = ArrowFormat::Float32Array.new(values)
+      values = [@date_2017_08_28, nil, @date_2025_12_09]
+      array1 = ArrowFormat::Date32Array.new(values)
+      array2 = ArrowFormat::Date32Array.new(values)
       assert_equal(array1, array2)
     end
 
     def test_sliced
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
-      array1 = ArrowFormat::Float32Array.new(values)
-      array2 = ArrowFormat::Float32Array.new([0.0, *values, 0.0])
-      assert_equal(array1, array2.slice(1, 5))
+      values = [@date_2017_08_28, nil, @date_2025_12_09]
+      array1 = ArrowFormat::Date32Array.new(values)
+      array2 = ArrowFormat::Date32Array.new([0, *values, 0])
+      assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
-      array1 = ArrowFormat::Float32Array.new(values)
-      array2 = ArrowFormat::Float32Array.new([0.0, 0.0, *values, 0.0])
-      assert_not_equal(array1, array2.slice(1, 5))
+      values = [@date_2017_08_28, nil, @date_2025_12_09]
+      array1 = ArrowFormat::Date32Array.new(values)
+      array2 = ArrowFormat::Date32Array.new([0, 0, *values, 0])
+      assert_not_equal(array1, array2.slice(1, 3))
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-date64-array.rb
+++ b/ruby/red-arrow-format/test/test-date64-array.rb
@@ -15,41 +15,46 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class TestFloat32Array < Test::Unit::TestCase
+class TestDate64Array < Test::Unit::TestCase
+  def setup
+    @date_2017_08_28_00_00_00 = 1503878400000
+    @date_2025_12_10_00_00_00 = 1765324800000
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
-      values = [-Float::INFINITY, -0.0, +0.0, +Float::INFINITY]
+      values = [@date_2017_08_28_00_00_00, @date_2025_12_10_00_00_00]
       assert_equal(values,
-                   ArrowFormat::Float32Array.new(values).to_a)
+                   ArrowFormat::Date64Array.new(values).to_a)
     end
 
     def test_mixed
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
+      values = [@date_2017_08_28_00_00_00, nil, @date_2025_12_10_00_00_00]
       assert_equal(values,
-                   ArrowFormat::Float32Array.new(values).to_a)
+                   ArrowFormat::Date64Array.new(values).to_a)
     end
   end
 
   sub_test_case("#==") do
     def test_no_slice
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
-      array1 = ArrowFormat::Float32Array.new(values)
-      array2 = ArrowFormat::Float32Array.new(values)
+      values = [@date_2017_08_28_00_00_00, nil, @date_2025_12_10_00_00_00]
+      array1 = ArrowFormat::Date64Array.new(values)
+      array2 = ArrowFormat::Date64Array.new(values)
       assert_equal(array1, array2)
     end
 
     def test_sliced
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
-      array1 = ArrowFormat::Float32Array.new(values)
-      array2 = ArrowFormat::Float32Array.new([0.0, *values, 0.0])
-      assert_equal(array1, array2.slice(1, 5))
+      values = [@date_2017_08_28_00_00_00, nil, @date_2025_12_10_00_00_00]
+      array1 = ArrowFormat::Date64Array.new(values)
+      array2 = ArrowFormat::Date64Array.new([0, *values, 0])
+      assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
-      values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
-      array1 = ArrowFormat::Float32Array.new(values)
-      array2 = ArrowFormat::Float32Array.new([0.0, 0.0, *values, 0.0])
-      assert_not_equal(array1, array2.slice(1, 5))
+      values = [@date_2017_08_28_00_00_00, nil, @date_2025_12_10_00_00_00]
+      array1 = ArrowFormat::Date64Array.new(values)
+      array2 = ArrowFormat::Date64Array.new([0, 0, *values, 0])
+      assert_not_equal(array1, array2.slice(1, 3))
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-float64-array.rb
+++ b/ruby/red-arrow-format/test/test-float64-array.rb
@@ -41,14 +41,14 @@ class TestFloat64Array < Test::Unit::TestCase
     def test_sliced
       values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
       array1 = ArrowFormat::Float64Array.new(values)
-      array2 = ArrowFormat::Float64Array.new([0.0] + values + [0.0])
+      array2 = ArrowFormat::Float64Array.new([0.0, *values, 0.0])
       assert_equal(array1, array2.slice(1, 5))
     end
 
     def test_sliced_different_content
       values = [-Float::INFINITY, -0.0, nil, +0.0, +Float::INFINITY]
       array1 = ArrowFormat::Float64Array.new(values)
-      array2 = ArrowFormat::Float64Array.new([0.0, 0.0] + values + [0.0])
+      array2 = ArrowFormat::Float64Array.new([0.0, 0.0, *values, 0.0])
       assert_not_equal(array1, array2.slice(1, 5))
     end
   end

--- a/ruby/red-arrow-format/test/test-int16-array.rb
+++ b/ruby/red-arrow-format/test/test-int16-array.rb
@@ -41,14 +41,14 @@ class TestInt16Array < Test::Unit::TestCase
     def test_sliced
       values = [-(2 ** 15), nil, (2 ** 15) - 1]
       array1 = ArrowFormat::Int16Array.new(values)
-      array2 = ArrowFormat::Int16Array.new([0] + values + [0])
+      array2 = ArrowFormat::Int16Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [-(2 ** 15), nil, (2 ** 15) - 1]
       array1 = ArrowFormat::Int16Array.new(values)
-      array2 = ArrowFormat::Int16Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::Int16Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end

--- a/ruby/red-arrow-format/test/test-int32-array.rb
+++ b/ruby/red-arrow-format/test/test-int32-array.rb
@@ -41,14 +41,14 @@ class TestInt32Array < Test::Unit::TestCase
     def test_sliced
       values = [-(2 ** 31), nil, (2 ** 31) - 1]
       array1 = ArrowFormat::Int32Array.new(values)
-      array2 = ArrowFormat::Int32Array.new([0] + values + [0])
+      array2 = ArrowFormat::Int32Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [-(2 ** 31), nil, (2 ** 31) - 1]
       array1 = ArrowFormat::Int32Array.new(values)
-      array2 = ArrowFormat::Int32Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::Int32Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end

--- a/ruby/red-arrow-format/test/test-int64-array.rb
+++ b/ruby/red-arrow-format/test/test-int64-array.rb
@@ -41,14 +41,14 @@ class TestInt64Array < Test::Unit::TestCase
     def test_sliced
       values = [-(2 ** 63), nil, (2 ** 63) - 1]
       array1 = ArrowFormat::Int64Array.new(values)
-      array2 = ArrowFormat::Int64Array.new([0] + values + [0])
+      array2 = ArrowFormat::Int64Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [-(2 ** 63), nil, (2 ** 63) - 1]
       array1 = ArrowFormat::Int64Array.new(values)
-      array2 = ArrowFormat::Int64Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::Int64Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end

--- a/ruby/red-arrow-format/test/test-int8-array.rb
+++ b/ruby/red-arrow-format/test/test-int8-array.rb
@@ -41,14 +41,14 @@ class TestInt8Array < Test::Unit::TestCase
     def test_sliced
       values = [-(2 ** 7), nil, (2 ** 7) - 1]
       array1 = ArrowFormat::Int8Array.new(values)
-      array2 = ArrowFormat::Int8Array.new([0] + values + [0])
+      array2 = ArrowFormat::Int8Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [-(2 ** 7), nil, (2 ** 7) - 1]
       array1 = ArrowFormat::Int8Array.new(values)
-      array2 = ArrowFormat::Int8Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::Int8Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end

--- a/ruby/red-arrow-format/test/test-uint16-array.rb
+++ b/ruby/red-arrow-format/test/test-uint16-array.rb
@@ -41,14 +41,14 @@ class TestUInt16Array < Test::Unit::TestCase
     def test_sliced
       values = [0, nil, (2 ** 16) - 1]
       array1 = ArrowFormat::UInt16Array.new(values)
-      array2 = ArrowFormat::UInt16Array.new([0] + values + [0])
+      array2 = ArrowFormat::UInt16Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [0, nil, (2 ** 16) - 1]
       array1 = ArrowFormat::UInt16Array.new(values)
-      array2 = ArrowFormat::UInt16Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::UInt16Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end

--- a/ruby/red-arrow-format/test/test-uint32-array.rb
+++ b/ruby/red-arrow-format/test/test-uint32-array.rb
@@ -41,14 +41,14 @@ class TestUInt32Array < Test::Unit::TestCase
     def test_sliced
       values = [0, nil, (2 ** 32) - 1]
       array1 = ArrowFormat::UInt32Array.new(values)
-      array2 = ArrowFormat::UInt32Array.new([0] + values + [0])
+      array2 = ArrowFormat::UInt32Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [0, nil, (2 ** 32) - 1]
       array1 = ArrowFormat::UInt32Array.new(values)
-      array2 = ArrowFormat::UInt32Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::UInt32Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end

--- a/ruby/red-arrow-format/test/test-uint64-array.rb
+++ b/ruby/red-arrow-format/test/test-uint64-array.rb
@@ -41,14 +41,14 @@ class TestUInt64Array < Test::Unit::TestCase
     def test_sliced
       values = [0, nil, (2 ** 64) - 1]
       array1 = ArrowFormat::UInt64Array.new(values)
-      array2 = ArrowFormat::UInt64Array.new([0] + values + [0])
+      array2 = ArrowFormat::UInt64Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [0, nil, (2 ** 64) - 1]
       array1 = ArrowFormat::UInt64Array.new(values)
-      array2 = ArrowFormat::UInt64Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::UInt64Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end

--- a/ruby/red-arrow-format/test/test-uint8-array.rb
+++ b/ruby/red-arrow-format/test/test-uint8-array.rb
@@ -41,14 +41,14 @@ class TestUInt8Array < Test::Unit::TestCase
     def test_sliced
       values = [0, nil, (2 ** 8) - 1]
       array1 = ArrowFormat::UInt8Array.new(values)
-      array2 = ArrowFormat::UInt8Array.new([0] + values + [0])
+      array2 = ArrowFormat::UInt8Array.new([0, *values, 0])
       assert_equal(array1, array2.slice(1, 3))
     end
 
     def test_sliced_different_content
       values = [0, nil, (2 ** 8) - 1]
       array1 = ArrowFormat::UInt8Array.new(values)
-      array2 = ArrowFormat::UInt8Array.new([0, 0] + values + [0])
+      array2 = ArrowFormat::UInt8Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
     end
   end


### PR DESCRIPTION
### Rationale for this change

Building a date{32,64} Arrow array from Ruby objects is convenient.

### What changes are included in this PR?

Accept `ArrowFormat::Date{32,64}.new(values)`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #50434