### PR TITLE
GH-50436: [Ruby] Add `ArrowFormat::TimestampArray.new(unit, values)`

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -548,6 +548,23 @@ module ArrowFormat
   end
 
   class TimestampType < TemporalType
+    class << self
+      def try_convert(value)
+        case value
+        when Symbol
+          unit = value
+          new(unit, nil)
+        when ::Array
+          unit, time_zone = value
+          new(unit, time_zone)
+        when self
+          value
+        else
+          nil
+        end
+      end
+    end
+
     attr_reader :unit
     attr_reader :time_zone
     def initialize(unit, time_zone)
@@ -556,12 +573,22 @@ module ArrowFormat
       @time_zone = time_zone
     end
 
+    def ==(other)
+      other.is_a?(self.class) and
+        @unit == other.unit and
+        @time_zone == other.time_zone
+    end
+
     def name
       "Timestamp"
     end
 
     def buffer_type
       :s64
+    end
+
+    def pack_template
+      "q"
     end
 
     def build_array(...)

--- a/ruby/red-arrow-format/test/test-timestamp-array.rb
+++ b/ruby/red-arrow-format/test/test-timestamp-array.rb
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestTimestampArray < Test::Unit::TestCase
+  def setup
+    @timestamp_2019_11_17_15_09_11 = 1574003351
+    @timestamp_2025_12_16_05_33_58 = 1765863238
+  end
+
+  sub_test_case("#initialize") do
+    def test_no_null
+      values = [
+        @timestamp_2019_11_17_15_09_11,
+        @timestamp_2025_12_16_05_33_58,
+      ]
+      assert_equal(values,
+                   ArrowFormat::TimestampArray.new(:second, values).to_a)
+    end
+
+    def test_mixed
+      values = [
+        @timestamp_2019_11_17_15_09_11,
+        nil,
+        @timestamp_2025_12_16_05_33_58,
+      ]
+      assert_equal(values,
+                   ArrowFormat::TimestampArray.new(:second, values).to_a)
+    end
+
+    def test_time_zone
+      time_zone = "UTC"
+      array = ArrowFormat::TimestampArray.new([:second, time_zone], [nil])
+      assert_equal(ArrowFormat::TimestampType.new(:second, time_zone),
+                   array.type)
+    end
+  end
+
+  sub_test_case("#==") do
+    def test_no_slice
+      values = [
+        @timestamp_2019_11_17_15_09_11,
+        nil,
+        @timestamp_2025_12_16_05_33_58,
+      ]
+      array1 = ArrowFormat::TimestampArray.new(:second, values)
+      array2 = ArrowFormat::TimestampArray.new(:second, values)
+      assert_equal(array1, array2)
+    end
+
+    def test_sliced
+      values = [
+        @timestamp_2019_11_17_15_09_11,
+        nil,
+        @timestamp_2025_12_16_05_33_58,
+      ]
+      array1 = ArrowFormat::TimestampArray.new(:second, values)
+      array2 = ArrowFormat::TimestampArray.new(:second, [0, *values, 0])
+      assert_equal(array1, array2.slice(1, 3))
+    end
+
+    def test_sliced_different_content
+      values = [
+        @timestamp_2019_11_17_15_09_11,
+        nil,
+        @timestamp_2025_12_16_05_33_58,
+      ]
+      array1 = ArrowFormat::TimestampArray.new(:second, values)
+      array2 = ArrowFormat::TimestampArray.new(:second, [0, 0, *values, 0])
+      assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change

Building a timestamp Arrow array from Ruby objects is convenient.

### What changes are included in this PR?

Accept `ArrowFormat::TimestampArray.new(unit, values)`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #50436