### PR TITLE
GH-49511: Fix rare doctest Table.join_asof and default_memory_pool failures

### DIFF
--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -150,7 +150,7 @@ def default_memory_pool():
     Examples
     --------
     >>> default_memory_pool()
-    <pyarrow.MemoryPool backend_name=... bytes_allocated=0 max_memory=...>
+    <pyarrow.MemoryPool backend_name=... bytes_allocated=... max_memory=...>
     """
     cdef:
         MemoryPool pool = MemoryPool.__new__(MemoryPool)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2115,8 +2115,8 @@ cdef class _Tabular(_PandasConvertible):
             Name of the column to use to sort (ascending), or
             a list of multiple sorting conditions where
             each entry is a tuple with column name
-            and sorting order ("ascending" or "descending") 
-            and nulls and NaNs are placed 
+            and sorting order ("ascending" or "descending")
+            and nulls and NaNs are placed
             at the start or at the end ("at_start" or "at_end")
         **kwargs : dict, optional
             Additional sorting options.
@@ -5865,7 +5865,7 @@ cdef class Table(_Tabular):
         ...                'n_legs': [5, 100],
         ...                'animal': ["Brittle stars", "Centipede"]})
 
-        >>> t1.join_asof(t2, on='year', by='id', tolerance=-2)
+        >>> t1.join_asof(t2, on='year', by='id', tolerance=-2).combine_chunks()
         pyarrow.Table
         id: int64
         year: int64


### PR DESCRIPTION
### Rationale for this change
#49511 : `Table.join_asof` outputs a non-deterministic number of chunks, so the printed table sometimes appears as one chunk and sometimes as several (rarely).
`default_memory_pool` prints `bytes_allocated=0` except when a preceding (failing) doctest allocated from the process-global pool (also rarely).

### What changes are included in this PR?
Addition of `.combine_chunks()` to `Table.join_asof` (and removal of two trailing spaces) in `table.pxi`
Change to `bytes_allocated=...` from `bytes_allocated=0` in `memory.pxi`

### Are these changes tested?
Yes, local doctest tests OK.

### Are there any user-facing changes?
No, just docstring changes.
* GitHub Issue: #49511