### PR TITLE
GH-50438: Add ArrowFormat::DurationArray.new(unit, values)

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -534,6 +534,11 @@ module ArrowFormat
   end
 
   class DurationArray < TemporalArray
+    class << self
+      def type_class
+        DurationType
+      end
+    end
   end
 
   class VariableSizeBinaryArray < Array

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -657,6 +657,20 @@ module ArrowFormat
   end
 
   class DurationType < TemporalType
+    class << self
+      def try_convert(value)
+        case value
+        when Symbol
+          unit = value
+          new(unit)
+        when self
+          value
+        else
+          nil
+        end
+      end
+    end
+
     attr_reader :unit
     def initialize(unit)
       super()
@@ -669,6 +683,10 @@ module ArrowFormat
 
     def buffer_type
       :s64
+    end
+
+    def pack_template
+      "q"
     end
 
     def build_array(...)

--- a/ruby/red-arrow-format/test/test-duration-array.rb
+++ b/ruby/red-arrow-format/test/test-duration-array.rb
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestDurationArray < Test::Unit::TestCase
+  sub_test_case("#initialize") do
+    def test_no_null
+      values = [-(2 ** 63), (2 ** 63) - 1]
+      assert_equal(values,
+                   ArrowFormat::DurationArray.new(:second, values).to_a)
+    end
+
+    def test_mixed
+      values = [-(2 ** 63), nil, (2 ** 63) - 1]
+      assert_equal(values,
+                   ArrowFormat::DurationArray.new(:second, values).to_a)
+    end
+  end
+
+  sub_test_case("#==") do
+    def test_no_slice
+      values = [-(2 ** 63), nil, (2 ** 63) - 1]
+      array1 = ArrowFormat::DurationArray.new(:second, values)
+      array2 = ArrowFormat::DurationArray.new(:second, values)
+      assert_equal(array1, array2)
+    end
+
+    def test_sliced
+      values = [-(2 ** 63), nil, (2 ** 63) - 1]
+      array1 = ArrowFormat::DurationArray.new(:second, values)
+      array2 = ArrowFormat::DurationArray.new(:second, [0, *values, 0])
+      assert_equal(array1, array2.slice(1, 3))
+    end
+
+    def test_sliced_different_content
+      values = [-(2 ** 63), nil, (2 ** 63) - 1]
+      array1 = ArrowFormat::DurationArray.new(:second, values)
+      array2 = ArrowFormat::DurationArray.new(:second, [0, 0, *values, 0])
+      assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change

Building a duration Arrow array from Ruby objects is convenient.

### What changes are included in this PR?

Accept `ArrowFormat::DurationArray.new(unit, values)`.

### Are these changes tested?

Yes.

Added tests for:

* initialization
* mixed values with `nil`
* equality
* sliced arrays

### Are there any user-facing changes?

Yes.

* GitHub Issue: #50438