### PR TITLE
GH-50449: [C++] Invalid version script argument supplied to MSVC linker

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -362,6 +362,10 @@ if(CMAKE_VERSION VERSION_LESS 3.18)
   else()
     set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT TRUE)
   endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # msvc does not support version scripts, but check_linker_flag won't return false
+  # due to how msvc's linker reports unrecognized arguments
+  set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT FALSE)
 else()
   include(CheckLinkerFlag)
   check_linker_flag(CXX

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -363,8 +363,8 @@ if(CMAKE_VERSION VERSION_LESS 3.18)
     set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT TRUE)
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # msvc does not support version scripts, but check_linker_flag won't return false
-  # due to how msvc's linker reports unrecognized arguments
+  # MSVC does not support version scripts, but check_linker_flag won't return false
+  # due to how MSVC's linker reports unrecognized arguments
   set(CXX_LINKER_SUPPORTS_VERSION_SCRIPT FALSE)
 else()
   include(CheckLinkerFlag)


### PR DESCRIPTION
### Rationale for this change

Preventing an invalid argument to be supplied to the MSVC linker, which can potentially break arrow builds on paths with spaces on Windows when using MSVC.

Example of failing build without this patch: https://gitlab.spack.io/spack/spack-packages/-/jobs/22969196

### What changes are included in this PR?

`cpp/CMakeLists.txt` has been updated to add a specific check for the MSVC toolchain, and if true, sets `CXX_LINKER_SUPPORTS_VERSION_SCRIPT` to `FALSE`.

### Are these changes tested?

Yes, see the build of `arrow` in this CI run in Spack's built with this patch and a path with a space: https://gitlab.spack.io/spack/spack-packages/-/jobs/22970695

### Are there any user-facing changes?

No



Alternatively, the `check_linker_flag` could be turned into a `try_compile` with a `-wall` flag (and the MSVC equivalent) turned on, or the path to the version script could be properly quoted on all platforms, but this feels like the most robust solutions with the smallest impact. 

* GitHub Issue: #50449