### PR TITLE
GH-50456: [Ruby] Add `ArrowFormat::DurationType#==`

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -716,6 +716,11 @@ module ArrowFormat
       @unit = unit
     end
 
+    def ==(other)
+      other.is_a?(self.class) and
+        @unit == other.unit
+    end
+
     def name
       "Duration"
     end

--- a/ruby/red-arrow-format/test/test-duration-type.rb
+++ b/ruby/red-arrow-format/test/test-duration-type.rb
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestDurationType < Test::Unit::TestCase
+  sub_test_case("#==") do
+    def test_equal
+      assert_equal(ArrowFormat::DurationType.new(:second),
+                   ArrowFormat::DurationType.new(:second))
+    end
+
+    def test_not_equal
+      assert_not_equal(ArrowFormat::DurationType.new(:second),
+                       ArrowFormat::DurationType.new(:millisecond))
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change

Comparing `ArrowFormat::DurationType` instances with the same unit should return `true`.

### What changes are included in this PR?

Add `ArrowFormat::DurationType#==`.

### Are these changes tested?

Yes.

Added tests for:

* equal duration types
* different duration types

### Are there any user-facing changes?

Yes.

GitHub Issue: #50456
* GitHub Issue: #50456