### PR TITLE
GH-50455: [Ruby] Add `ArrowFormat::TimeType#==`

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -463,6 +463,12 @@ module ArrowFormat
       @unit = unit
     end
 
+    def ==(other)
+      other.is_a?(self.class) and
+        @bit_width == other.bit_width and
+        @unit == other.unit
+    end
+
     def to_s
       "#{super}(#{unit})"
     end

--- a/ruby/red-arrow-format/test/test-time32-type.rb
+++ b/ruby/red-arrow-format/test/test-time32-type.rb
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestTimeType < Test::Unit::TestCase
+  sub_test_case("Time32Type#==") do
+    def test_equal
+      assert_equal(ArrowFormat::Time32Type.new(:second),
+                   ArrowFormat::Time32Type.new(:second))
+    end
+
+    def test_not_equal
+      assert_not_equal(ArrowFormat::Time32Type.new(:second),
+                       ArrowFormat::Time32Type.new(:millisecond))
+    end
+  end
+end

--- a/ruby/red-arrow-format/test/test-time64-type.rb
+++ b/ruby/red-arrow-format/test/test-time64-type.rb
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestTime64Type < Test::Unit::TestCase
+  sub_test_case("#==") do
+    def test_equal
+      assert_equal(ArrowFormat::Time64Type.new(:microsecond),
+                   ArrowFormat::Time64Type.new(:microsecond))
+    end
+
+    def test_not_equal
+      assert_not_equal(ArrowFormat::Time64Type.new(:microsecond),
+                       ArrowFormat::Time64Type.new(:nanosecond))
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change

Comparing `ArrowFormat::Time32Type` and `ArrowFormat::Time64Type` instances with the same unit should return `true`.

### What changes are included in this PR?

Add `ArrowFormat::TimeType#==`.

### Are these changes tested?

Yes.

Added tests for:

* `Time32Type`
  * equal types
  * different units
* `Time64Type`
  * equal types
  * different units

### Are there any user-facing changes?

Yes.

GitHub Issue: #50455
* GitHub Issue: #50455