### PR TITLE
GH-50379: [Dev] Convert invalid PRs to draft automatically

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -34,7 +34,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  # Required for the GraphQL convertPullRequestToDraft mutation.
+  contents: write
   pull-requests: write
   issues: write
   

--- a/.github/workflows/dev_pr/title_check.js
+++ b/.github/workflows/dev_pr/title_check.js
@@ -38,11 +38,41 @@ async function commentOpenGitHubIssue(github, context, pullRequestNumber) {
   });
 }
 
+/**
+ * Converts the pull request to draft.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ */
+async function convertToDraft(github, context) {
+  if (context.payload.pull_request.draft) {
+    return;
+  }
+
+  await github.graphql(
+    `
+      mutation ($pullRequestId: ID!) {
+        convertPullRequestToDraft(
+          input: {pullRequestId: $pullRequestId}
+        ) {
+          pullRequest {
+            id
+          }
+        }
+      }
+    `,
+    {
+      pullRequestId: context.payload.pull_request.node_id,
+    },
+  );
+}
+
 module.exports = async ({github, context}) => {
   const pullRequestNumber = context.payload.number;
   const title = context.payload.pull_request.title;
   const issue = helpers.detectIssue(title)
   if (!issue) {
     await commentOpenGitHubIssue(github, context, pullRequestNumber);
+    await convertToDraft(github, context);
   }
 };


### PR DESCRIPTION
### Rationale for this change

Pull requests with titles that don't follow Arrow's expected format already receive an automated guidance comment. Converting these pull requests to drafts makes them easier for maintainers to identify and ignore until the title has been corrected.

### What changes are included in this PR?

This change updates the developer PR workflow so that when a pull request title doesn't match the expected format, it:

- Posts the existing guidance comment.
- Converts the pull request to a draft if it isn't already one.

The workflow permissions are also updated to allow the draft conversion.

### Are these changes tested?

Yes.

Tested on my fork by opening pull requests with invalid titles and verifying that they were automatically converted to drafts after the workflow ran.

### Are there any user-facing changes?

No.
* GitHub Issue: #50379