### PR TITLE
GH-50472: [C++][Gandiva] fix integer overflow in mask output allocation

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -648,8 +648,14 @@ const char* mask_utf8_utf8_utf8_utf8(int64_t context, const char* data, int32_t 
     return nullptr;
   }
 
-  int32_t max_length =
-      std::max(upper_length, std::max(lower_length, num_length)) * data_len;
+  int32_t max_repl_length = std::max(upper_length, std::max(lower_length, num_length));
+  int32_t max_length = 0;
+  if (ARROW_PREDICT_FALSE(arrow::internal::MultiplyWithOverflow(max_repl_length, data_len,
+                                                                &max_length))) {
+    gdv_fn_context_set_error_msg(context, "Would overflow maximum output size");
+    *out_len = 0;
+    return nullptr;
+  }
   char* out = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, max_length));
   if (out == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -1502,6 +1502,20 @@ TEST(TestGdvFnStubs, TestMask) {
   result = mask_utf8_utf8_utf8_utf8(ctx_ptr, data.c_str(), data_len, "\?", 1, "*", 1, "#",
                                     1, &out_len);
   EXPECT_EQ(std::string(result, out_len), expected);
+
+  // A replacement length that overflows int32 when multiplied by the input
+  // length must be rejected instead of under-allocating the output buffer.
+  std::string big_data(65536, 'A');
+  std::string big_repl(65537, 'Z');
+  data_len = static_cast<int32_t>(big_data.length());
+  out_len = -1;
+  result = mask_utf8_utf8_utf8_utf8(ctx_ptr, big_data.c_str(), data_len, big_repl.c_str(),
+                                    static_cast<int32_t>(big_repl.length()), "x", 1, "n",
+                                    1, &out_len);
+  EXPECT_EQ(result, nullptr);
+  EXPECT_EQ(out_len, 0);
+  EXPECT_TRUE(ctx.has_error());
+  ctx.Reset();
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecrypt16) {


### PR DESCRIPTION
### Rationale for this change

`mask_utf8_utf8_utf8_utf8` sizes its output arena buffer with `std::max(upper_length, lower_length, num_length) * data_len` in `int32_t`. The replacement lengths and the input length both come from the SQL `mask` arguments, so a large replacement combined with a large input wraps the multiply and yields a small `max_length`. The masking loop then writes each replacement past the undersized allocation. With `data_len = 65536` and a 65537-byte replacement the true size is 4,295,032,832 which truncates to 65536, and the first masked character already overruns the buffer, crashing with SIGSEGV.

### What changes are included in this PR?

Compute the size with `arrow::internal::MultiplyWithOverflow` and return an error when it overflows, the same guard `repeat_utf8_int32`, `to_hex_binary`, and the multibyte `translate` path already use.

### Are these changes tested?

Yes. Added a case to `TestGdvFnStubs.TestMask` that passes a 64 KiB input with a 64 KiB+1 replacement; it crashes before the change and now returns an error with the fix.

### Are there any user-facing changes?

`mask` on inputs whose masked size would exceed `INT32_MAX` now returns an error instead of crashing.

**This PR contains a "Critical Fix".** It fixes a heap buffer overflow (crash) reachable from the `mask` SQL function on large inputs.

* GitHub Issue: #50472