### PR TITLE
GH-46853: [Python][Docs] Document preserving leading zeros in CSV

### DIFF
--- a/docs/source/python/csv.rst
+++ b/docs/source/python/csv.rst
@@ -142,6 +142,18 @@ a :class:`ConvertOptions` instance and pass it to :func:`read_csv`:
    col1: [[1,2,3]]
    col2: [["a","b","c"]]
 
+Quoted CSV values are still subject to type inference. To preserve formatting
+such as leading zeros, set the column type explicitly to ``string``:
+
+.. code-block:: python
+
+   >>> import io
+   >>> source = io.BytesIO(b'code\n"001"\n"002"\n')
+   >>> options = csv.ConvertOptions(column_types={'code': pa.string()})
+   >>> table = csv.read_csv(source, convert_options=options)
+   >>> table['code'].to_pylist()
+   ['001', '002']
+
 .. note::
    To assign a column as ``duration``, the CSV values must be numeric strings
    that match the expected unit (e.g. ``60000`` for 60 seconds when


### PR DESCRIPTION
Summary:
- Document that quoted numeric CSV values are still subject to type inference.
- Add a doctest-backed example showing how `ConvertOptions.column_types` preserves leading zeros.
- AI assistance was used for issue triage and drafting this documentation example.

Validation:
- `/tmp/arrow-doccheck-46853/bin/python -m pytest --doctest-glob="*.rst" docs/source/python/csv.rst -q` — passed, `1 passed`
- `git diff --check HEAD~1 HEAD` — passed

* GitHub Issue: #46853