### PR TITLE
GH-50308: [C++][IPC] Add input size validation to SparseCSFIndex::Make

### DIFF
--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -384,6 +384,21 @@ Result<std::shared_ptr<SparseCSFIndex>> SparseCSFIndex::Make(
     const std::vector<std::shared_ptr<Buffer>>& indptr_data,
     const std::vector<std::shared_ptr<Buffer>>& indices_data) {
   int64_t ndim = axis_order.size();
+
+  // Validate input dimensions before accessing buffers
+  if (ndim == 0) {
+    return Status::Invalid("axis_order cannot be empty");
+  }
+  if (indices_shapes.size() != static_cast<size_t>(ndim)) {
+    return Status::Invalid("indices_shapes must have the same size as axis_order");
+  }
+  if (indptr_data.size() != static_cast<size_t>(ndim - 1)) {
+    return Status::Invalid("indptr_data must have size equal to ndim - 1");
+  }
+  if (indices_data.size() != static_cast<size_t>(ndim)) {
+    return Status::Invalid("indices_data must have the same size as axis_order");
+  }
+
   std::vector<std::shared_ptr<Tensor>> indptr(ndim - 1);
   std::vector<std::shared_ptr<Tensor>> indices(ndim);
 

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -1698,4 +1698,27 @@ TEST(TestSparseCSFMatrixForUInt64Index, Make) {
   ASSERT_RAISES(Invalid, SparseCSFTensor::Make(dense_tensor, uint64()));
 }
 
+TEST(TestSparseCSFIndex, Make) {
+  std::vector<int64_t> axis_order = {0, 1, 2};
+  std::vector<int64_t> indices_shapes = {5, 5, 5};
+  std::vector<std::shared_ptr<Buffer>> indptr_data(2);
+  std::vector<std::shared_ptr<Buffer>> indices_data(3);
+
+  // Invalid indices_shapes size
+  ASSERT_RAISES(Invalid, SparseCSFIndex::Make(int32(), int32(), {5}, axis_order,
+                                              indptr_data, indices_data));
+
+  // Empty axis order
+  ASSERT_RAISES(Invalid, SparseCSFIndex::Make(int32(), int32(), indices_shapes, {},
+                                              indptr_data, indices_data));
+
+  // Invalid indptr_data size
+  ASSERT_RAISES(Invalid, SparseCSFIndex::Make(int32(), int32(), indices_shapes,
+                                              axis_order, {}, indices_data));
+
+  // Invalid indices_data size
+  ASSERT_RAISES(Invalid, SparseCSFIndex::Make(int32(), int32(), indices_shapes,
+                                              axis_order, indptr_data, {}));
+}
+
 }  // namespace arrow


### PR DESCRIPTION
Resolves #50308

### Rationale for this change
`SparseCSFIndex::Make` currently lacks validation for input vector sizes. This can lead to out-of-bounds memory access when provided with inconsistent input lengths. This PR adds the necessary checks to ensure that input is valid before object construction.

### What changes are included in this PR?
- Input validation in `SparseCSFIndex::Make` to verify `axis_order` is nonzero and `indices_shapes`, `indptr_data`, `indices_data` have consistent dimensions.
- A unit test to verify `Status::Invalid` is returned when inputs are mismatched.
### Are these changes tested?
Yes, `cpp/src/arrow/sparse_tensor_test.cc` now contains `TEST(TestSparseCSFIndex, Make)`, which triggers the validation logic.
### Are there any user-facing changes?
No.

**This PR contains a "Critical Fix".**
This fixes a bug that causes a segfault when invalid input parameters are passed to `SparseCSFIndex::Make`.

**AI Usage:**
AI was used to navigate the codebase and set up the build environment.
* GitHub Issue: #50308