### PR TITLE
GH-50481: [C++] Fix CSV reader mis-parsing rows with an embedded NUL byte

### DIFF
--- a/cpp/src/arrow/csv/chunker.cc
+++ b/cpp/src/arrow/csv/chunker.cc
@@ -56,7 +56,8 @@ class Lexer {
 
   // Decide whether it's worth using a bulk filter over the given data area
   bool ShouldUseBulkFilter(const char* data, const char* data_end) {
-    if (!bulk_filter_.CanUseOnBlock(std::string_view(data, static_cast<size_t>(data_end - data)))) {
+    if (!bulk_filter_.CanUseOnBlock(
+            std::string_view(data, static_cast<size_t>(data_end - data)))) {
       return false;
     }
     constexpr int32_t kWordSize = static_cast<int32_t>(sizeof(BulkWordType));

--- a/cpp/src/arrow/csv/chunker.cc
+++ b/cpp/src/arrow/csv/chunker.cc
@@ -56,6 +56,9 @@ class Lexer {
 
   // Decide whether it's worth using a bulk filter over the given data area
   bool ShouldUseBulkFilter(const char* data, const char* data_end) {
+    if (!bulk_filter_.CanUseOnBlock(std::string_view(data, static_cast<size_t>(data_end - data)))) {
+      return false;
+    }
     constexpr int32_t kWordSize = static_cast<int32_t>(sizeof(BulkWordType));
 
     // Only probe the 32 first words and assume they are representative of the rest

--- a/cpp/src/arrow/csv/chunker_test.cc
+++ b/cpp/src/arrow/csv/chunker_test.cc
@@ -341,6 +341,26 @@ TEST_P(BaseChunkerTest, EscapingAndQuoting) {
   }
 }
 
+TEST_P(BaseChunkerTest, EmbeddedNulBytesDisableBulkFilter) {
+  // Regression test for GH-50481 in Lexer's own bulk filter (used for
+  // chunking, separately from BlockParser's).
+  //
+  // Lead-in with no structural bytes so ShouldUseBulkFilter's probe of the
+  // first 256 bytes decides to use the bulk filter here.
+  std::string lead_in(300, 'x');
+  // NUL right before the closing quote: the misaligned-SIMD-scan trigger.
+  std::string trigger_field = "abc";
+  trigger_field += '\0';
+  trigger_field += "def";
+  std::string first_row = lead_in + ",\"" + trigger_field + "\",tail\n";
+  // No trailing newline on the second row, so Process() must split it out
+  // as the partial remainder -- proving the first row's boundary was found.
+  std::string csv = first_row + "next";
+
+  MakeChunker();
+  AssertChunkSize(*chunker_, csv, static_cast<uint32_t>(first_row.size()));
+}
+
 TEST_P(BaseChunkerTest, ParseSkip) {
   {
     auto csv = MakeCSVData({"ab,c,\n", "def,,gh\n", ",ij,kl\n"});

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -133,8 +133,11 @@ class SSE42Filter {
   explicit SSE42Filter(const ParseOptions& options) : filter_(MakeFilter(options)) {}
 
   bool Matches(WordType w) const {
-    // Look up every byte in `w` in the SIMD filter.
-    return _mm_cmpistrc(_mm_set1_epi64x(w), filter_,
+    // Look up every byte in `w` in the SIMD filter. Use the explicit-length
+    // comparison since `w` may contain an embedded NUL byte, which the
+    // implicit-length _mm_cmpistrc would otherwise treat as a terminator.
+    return _mm_cmpestrc(_mm_set1_epi64x(w), sizeof(WordType), filter_,
+                        sizeof(BulkFilterType),
                         _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY);
   }
 

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
+#include <string_view>
 
 #include "arrow/csv/options.h"
 #include "arrow/util/simd.h"
@@ -44,6 +46,10 @@ class SpecializedOptions {
 class BaseBloomFilter {
  public:
   explicit BaseBloomFilter(const ParseOptions& options) : filter_(MakeFilter(options)) {}
+
+  // Bloom filters match bytes individually and have no implicit-length
+  // scanning, so an embedded NUL byte doesn't affect their correctness.
+  bool CanUseOnBlock(std::string_view) const { return true; }
 
  protected:
   using FilterType = uint64_t;
@@ -138,6 +144,13 @@ class SSE42Filter {
                         _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY);
   }
 
+  // _mm_cmpistrc is an implicit-length compare: it treats a NUL byte as a
+  // terminator and can miss a real delimiter/quote/newline sharing an 8-byte
+  // word with one. Never use this filter on a block that contains a NUL.
+  bool CanUseOnBlock(std::string_view data) const {
+    return data.empty() || std::memchr(data.data(), '\0', data.size()) == nullptr;
+  }
+
  protected:
   using BulkFilterType = __m128i;
 
@@ -189,6 +202,10 @@ class NeonFilter {
     vst1_u64(&r, vreinterpret_u64_u8(v));
     return r != 0;
   }
+
+  // NEON compares each byte independently (no implicit-length scanning), so
+  // an embedded NUL byte doesn't affect correctness here.
+  bool CanUseOnBlock(std::string_view) const { return true; }
 
  private:
   const uint8x8_t delim_, quote_, escape_;

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -147,6 +147,10 @@ class SSE42Filter {
   // _mm_cmpistrc is an implicit-length compare: it treats a NUL byte as a
   // terminator and can miss a real delimiter/quote/newline sharing an 8-byte
   // word with one. Never use this filter on a block that contains a NUL.
+  // We could instead use the explicit-length compare _mm_cmpestrc but
+  // it comes with a massive performance cost on some CPUs
+  // (some benchmarks were measured to be twice slower in
+  // https://github.com/apache/arrow/pull/50483).
   bool CanUseOnBlock(std::string_view data) const {
     return data.empty() || std::memchr(data.data(), '\0', data.size()) == nullptr;
   }

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -133,11 +133,8 @@ class SSE42Filter {
   explicit SSE42Filter(const ParseOptions& options) : filter_(MakeFilter(options)) {}
 
   bool Matches(WordType w) const {
-    // Look up every byte in `w` in the SIMD filter. Use the explicit-length
-    // comparison since `w` may contain an embedded NUL byte, which the
-    // implicit-length _mm_cmpistrc would otherwise treat as a terminator.
-    return _mm_cmpestrc(_mm_set1_epi64x(w), static_cast<int>(sizeof(WordType)), filter_,
-                        static_cast<int>(sizeof(BulkFilterType)),
+    // Look up every byte in `w` in the SIMD filter.
+    return _mm_cmpistrc(_mm_set1_epi64x(w), filter_,
                         _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY);
   }
 

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -136,8 +136,8 @@ class SSE42Filter {
     // Look up every byte in `w` in the SIMD filter. Use the explicit-length
     // comparison since `w` may contain an embedded NUL byte, which the
     // implicit-length _mm_cmpistrc would otherwise treat as a terminator.
-    return _mm_cmpestrc(_mm_set1_epi64x(w), sizeof(WordType), filter_,
-                        sizeof(BulkFilterType),
+    return _mm_cmpestrc(_mm_set1_epi64x(w), static_cast<int>(sizeof(WordType)), filter_,
+                        static_cast<int>(sizeof(BulkFilterType)),
                         _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY);
   }
 

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <cstring>
 #include <limits>
 #include <utility>
 
@@ -539,8 +538,7 @@ class BlockParserImpl {
       // has no embedded NUL bytes (see block_has_nul_).
       const int64_t bulk_filter_threshold = static_cast<int64_t>(batch_.num_cols_) *
                                             (batch_.num_rows_ - start_num_rows) * 10;
-      use_bulk_filter_ =
-          !block_has_nul_ && (data - *out_data) > bulk_filter_threshold;
+      use_bulk_filter_ = !block_has_nul_ && (data - *out_data) > bulk_filter_threshold;
     }
 
     // Append new buffers and update size
@@ -566,14 +564,13 @@ class BlockParserImpl {
     block_has_nul_ = false;
     for (const auto& view : views) {
       total_view_length += view.length();
-#if defined(ARROW_HAVE_SSE4_2) && (defined(__x86_64__) || defined(_M_X64))
-      // Only the SSE4.2 bulk filter is affected by embedded NUL bytes,
-      // so only scan for them when that filter is available.
-      if (!block_has_nul_ && !view.empty() &&
-          memchr(view.data(), '\0', view.length()) != nullptr) {
+      if (!block_has_nul_ && !bulk_filter.CanUseOnBlock(view)) {
         block_has_nul_ = true;
       }
-#endif
+    }
+    if (block_has_nul_) {
+      // Clear a bulk filter left on by an earlier NUL-free block.
+      use_bulk_filter_ = false;
     }
     if (total_view_length > std::numeric_limits<uint32_t>::max()) {
       return Status::Invalid("CSV block too large");

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstring>
 #include <limits>
 #include <utility>
 
@@ -533,12 +534,13 @@ class BlockParserImpl {
     }
 
     if (batch_.num_rows_ > start_num_rows && batch_.num_cols_ > 0) {
-      // Use bulk filter only if average value length is >= 10 bytes,
-      // as the bulk filter has a fixed cost that isn't compensated
-      // when values are too short.
+      // Use bulk filter only if average value length is >= 10 bytes
+      // (its fixed cost isn't compensated for short values), and the block
+      // has no embedded NUL bytes (see block_has_nul_).
       const int64_t bulk_filter_threshold = static_cast<int64_t>(batch_.num_cols_) *
                                             (batch_.num_rows_ - start_num_rows) * 10;
-      use_bulk_filter_ = (data - *out_data) > bulk_filter_threshold;
+      use_bulk_filter_ =
+          !block_has_nul_ && (data - *out_data) > bulk_filter_threshold;
     }
 
     // Append new buffers and update size
@@ -561,8 +563,17 @@ class BlockParserImpl {
     values_size_ = 0;
 
     size_t total_view_length = 0;
+    block_has_nul_ = false;
     for (const auto& view : views) {
       total_view_length += view.length();
+#if defined(ARROW_HAVE_SSE4_2) && (defined(__x86_64__) || defined(_M_X64))
+      // Only the SSE4.2 bulk filter is affected by embedded NUL bytes,
+      // so only scan for them when that filter is available.
+      if (!block_has_nul_ && !view.empty() &&
+          memchr(view.data(), '\0', view.length()) != nullptr) {
+        block_has_nul_ = true;
+      }
+#endif
     }
     if (total_view_length > std::numeric_limits<uint32_t>::max()) {
       return Status::Invalid("CSV block too large");
@@ -691,6 +702,7 @@ class BlockParserImpl {
   int32_t max_num_rows_;
 
   bool use_bulk_filter_ = false;
+  bool block_has_nul_ = false;
 
   // Unparsed data size
   int32_t values_size_;

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -966,7 +966,7 @@ TEST(BlockParser, EmbeddedNulInQuotedFieldAfterBulkFilterActivates) {
   }
   csv += '\n';
 
-  BlockParser parser(ParseOptions::Defaults());
+  BlockParser parser(ParseOptions::Defaults(), /*num_cols=*/num_cols);
   AssertParseFinal(parser, csv);
   ASSERT_EQ(parser.num_rows(), num_filler_rows + 1);
 

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -936,37 +936,44 @@ TEST(BlockParser, RowNumberAppendedToError) {
   }
 }
 
-TEST(BlockParser, EmbeddedNulInQuotedFieldAfterBulkFilterActivates) {
-  // Regression test for GH-50481. Once the running average value length
-  // crosses the bulk filter's activation threshold, a NUL byte embedded in a
-  // quoted field could hide the real closing quote if both landed in the
-  // same 8-byte SIMD word, causing the parser to keep consuming subsequent
-  // bytes as if still inside the quoted field.
+TEST(BlockParser, EmbeddedNulBytesDisableBulkFilter) {
+  // Regression test for GH-50481: the bulk filter's implicit-length SIMD
+  // compare can miss a delimiter sharing a word with an embedded NUL byte.
+  // The fix disables the bulk filter for any block containing a NUL, so
+  // every cell here carries one. num_cols is explicit so the bulk filter
+  // isn't delayed by the single-row column-count-inference parse path.
   constexpr int32_t num_cols = 64;
-  constexpr int32_t num_filler_rows = 512;  // = kTargetChunkSize / num_cols
+  // Each ParseChunk call is capped at ~512 rows for num_cols == 64 (from
+  // parser.cc's private kTargetChunkSize). Use 4x that margin so the filler
+  // block still spans multiple calls -- keeping the bulk filter armed
+  // before the trigger row -- even if that constant changes.
+  constexpr int32_t num_filler_rows = 4 * 512;
+
+  // 12 bytes/value, above the bulk filter's 10-byte threshold; the
+  // trailing NUL lands outside the first SIMD word, so it's harmless here.
+  std::string filler_cell = "xxxxxxxxxxx";
+  filler_cell += '\0';
 
   std::string csv;
   for (int32_t r = 0; r < num_filler_rows; ++r) {
     for (int32_t c = 0; c < num_cols; ++c) {
       if (c) csv += ',';
-      // 12 bytes/value, well above the bulk filter's 10-bytes/value
-      // activation threshold.
-      csv += "xxxxxxxxxxxx";
+      csv += filler_cell;
     }
     csv += '\n';
   }
-  // This row's first field carries a real embedded NUL byte immediately
-  // before its closing quote - the byte pattern a misaligned
-  // implicit-length SIMD scan can hide.
+  // Embeds a NUL right before the closing quote - the pattern a
+  // misaligned SIMD scan can hide.
   csv += "\"abc";
   csv += '\0';
   csv += "def\"";
   for (int32_t c = 1; c < num_cols; ++c) {
-    csv += ",xxxxxxxxxxxx";
+    csv += ',';
+    csv += filler_cell;
   }
   csv += '\n';
 
-  BlockParser parser(ParseOptions::Defaults(), /*num_cols=*/num_cols);
+  BlockParser parser(ParseOptions::Defaults(), num_cols, /*first_row=*/0);
   AssertParseFinal(parser, csv);
   ASSERT_EQ(parser.num_rows(), num_filler_rows + 1);
 
@@ -974,6 +981,10 @@ TEST(BlockParser, EmbeddedNulInQuotedFieldAfterBulkFilterActivates) {
   GetLastRow(parser, &last_row);
   ASSERT_EQ(last_row.size(), static_cast<size_t>(num_cols));
   ASSERT_EQ(last_row[0], std::string("abc\0def", 7));
+  // The row's other NUL-bearing fields must come through unmangled too.
+  for (size_t c = 1; c < last_row.size(); ++c) {
+    ASSERT_EQ(last_row[c], filler_cell) << "column " << c;
+  }
 }
 
 }  // namespace csv

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -937,20 +937,14 @@ TEST(BlockParser, RowNumberAppendedToError) {
 }
 
 TEST(BlockParser, EmbeddedNulBytesDisableBulkFilter) {
-  // Regression test for GH-50481: the bulk filter's implicit-length SIMD
-  // compare can miss a delimiter sharing a word with an embedded NUL byte.
-  // The fix disables the bulk filter for any block containing a NUL, so
-  // every cell here carries one. num_cols is explicit so the bulk filter
-  // isn't delayed by the single-row column-count-inference parse path.
+  // Regression test for GH-50481: disables the bulk filter for any block
+  // with an embedded NUL, so every cell here carries one.
   constexpr int32_t num_cols = 64;
-  // Each ParseChunk call is capped at ~512 rows for num_cols == 64 (from
-  // parser.cc's private kTargetChunkSize). Use 4x that margin so the filler
-  // block still spans multiple calls -- keeping the bulk filter armed
-  // before the trigger row -- even if that constant changes.
+  // 4x the ~512-row ParseChunk cap for num_cols == 64, so the filler block
+  // spans multiple calls even if that internal constant changes.
   constexpr int32_t num_filler_rows = 4 * 512;
 
-  // 12 bytes/value, above the bulk filter's 10-byte threshold; the
-  // trailing NUL lands outside the first SIMD word, so it's harmless here.
+  // 12 bytes/value, above the bulk filter's activation threshold.
   std::string filler_cell = "xxxxxxxxxxx";
   filler_cell += '\0';
 
@@ -962,8 +956,7 @@ TEST(BlockParser, EmbeddedNulBytesDisableBulkFilter) {
     }
     csv += '\n';
   }
-  // Embeds a NUL right before the closing quote - the pattern a
-  // misaligned SIMD scan can hide.
+  // NUL right before the closing quote: the misaligned-SIMD-scan trigger.
   csv += "\"abc";
   csv += '\0';
   csv += "def\"";
@@ -981,7 +974,7 @@ TEST(BlockParser, EmbeddedNulBytesDisableBulkFilter) {
   GetLastRow(parser, &last_row);
   ASSERT_EQ(last_row.size(), static_cast<size_t>(num_cols));
   ASSERT_EQ(last_row[0], std::string("abc\0def", 7));
-  // The row's other NUL-bearing fields must come through unmangled too.
+  // Other NUL-bearing fields in the row must come through unmangled too.
   for (size_t c = 1; c < last_row.size(); ++c) {
     ASSERT_EQ(last_row[c], filler_cell) << "column " << c;
   }

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -936,5 +936,44 @@ TEST(BlockParser, RowNumberAppendedToError) {
   }
 }
 
+TEST(BlockParser, EmbeddedNulInQuotedFieldAfterBulkFilterActivates) {
+  // Regression test for GH-50481. Once the running average value length
+  // crosses the bulk filter's activation threshold, a NUL byte embedded in a
+  // quoted field could hide the real closing quote if both landed in the
+  // same 8-byte SIMD word, causing the parser to keep consuming subsequent
+  // bytes as if still inside the quoted field.
+  constexpr int32_t num_cols = 64;
+  constexpr int32_t num_filler_rows = 512;  // = kTargetChunkSize / num_cols
+
+  std::string csv;
+  for (int32_t r = 0; r < num_filler_rows; ++r) {
+    for (int32_t c = 0; c < num_cols; ++c) {
+      if (c) csv += ',';
+      // 12 bytes/value, well above the bulk filter's 10-bytes/value
+      // activation threshold.
+      csv += "xxxxxxxxxxxx";
+    }
+    csv += '\n';
+  }
+  // This row's first field carries a real embedded NUL byte immediately
+  // before its closing quote - the byte pattern a misaligned
+  // implicit-length SIMD scan can hide.
+  csv += "\"abc";
+  csv += '\0';
+  csv += "def\"";
+  for (int32_t c = 1; c < num_cols; ++c) {
+    csv += ",xxxxxxxxxxxx";
+  }
+  csv += '\n';
+
+  BlockParser parser(ParseOptions::Defaults());
+  AssertParseFinal(parser, csv);
+  ASSERT_EQ(parser.num_rows(), num_filler_rows + 1);
+
+  std::vector<std::string> last_row;
+  GetLastRow(parser, &last_row);
+  ASSERT_EQ(last_row[0], std::string("abc\0def", 7));
+}
+
 }  // namespace csv
 }  // namespace arrow

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -972,6 +972,7 @@ TEST(BlockParser, EmbeddedNulInQuotedFieldAfterBulkFilterActivates) {
 
   std::vector<std::string> last_row;
   GetLastRow(parser, &last_row);
+  ASSERT_EQ(last_row.size(), static_cast<size_t>(num_cols));
   ASSERT_EQ(last_row[0], std::string("abc\0def", 7));
 }
 


### PR DESCRIPTION
### Rationale for this change

Fixes #50481. `arrow::csv::TableReader`/`BlockParser` can silently mis-split a row when a text field contains an embedded NUL (`0x00`) byte, once the reader has processed enough data to switch into its SIMD "bulk filter" scanning path.

### What changes are included in this PR?

`SSE42Filter::Matches` (`cpp/src/arrow/csv/lexing_internal.h`) uses `_mm_cmpistrc`, an **implicit-length** SSE4.2 string-compare intrinsic that treats `0x00` as a terminator in both operands. Since the caller feeds it 8 raw CSV bytes at a time, a real quote/comma/newline sharing an 8-byte word with an embedded NUL becomes invisible to the filter — `RunBulkFilter` then trusts the filter's "no special chars" answer and bulk-copies the whole word, silently swallowing the structural character.

An initial version of this fix switched to the explicit-length `_mm_cmpestrc`, passing the true length of each operand instead of relying on NUL-termination. However, this proves to yield massive performance regressions on some CPUs (for example, some CSV parsing benchmarks became 2x slower on an AMD Zen 2 CPU). This is corroborated by the instruction timing from [Agner Fog's instruction tables](www.agner.org/optimize/instruction_tables.pdf).

The final version of the fix instead checks for NUL bytes in an entire block. This can be done very quickly using `memchr` (which is typically vectorized on modern libc's). Since most real-world CSV files don't have embedded NUL bytes, the SIMD bulk filter optimization will most of the time still be enabled.

### Are these changes tested?

Yes, using new regression tests that reproduce the exact trigger.

### Are there any user-facing changes?

No, just a bugfix.

---

This PR (fix, test, and description) was AI-generated (Claude), under human review and local verification described above.
* GitHub Issue: #50481
