### PR TITLE
GH-50476: [R] empty_named_list() uses deprecated .Names in structure() 

### DIFF
--- a/r/R/util.R
+++ b/r/R/util.R
@@ -44,7 +44,7 @@ is_list_of <- function(object, class) {
   is.list(object) && all(map_lgl(object, ~ inherits(., class)))
 }
 
-empty_named_list <- function() structure(list(), .Names = character(0))
+empty_named_list <- function() structure(list(), names = character(0))
 
 r_symbolic_constants <- c(
   "pi",


### PR DESCRIPTION
### Rationale for this change

Update .Names to names as CRAN check fails

### What changes are included in this PR?

Update .Names to names as CRAN check fails

### Are these changes tested?

CI

### Are there any user-facing changes?

No
* GitHub Issue: #50476