### PR TITLE
GH-50370: [CI] Copilot auto-reviews trigger workflow approval requirement on pr_review_trigger.yml

### DIFF
--- a/.github/workflows/pr_review_trigger.yml
+++ b/.github/workflows/pr_review_trigger.yml
@@ -26,6 +26,7 @@ jobs:
   # workflow. We trigger a new workflow run which will have permissions to add labels.
   label-when-reviewed:
     name: "Label PRs when reviewed"
+    if: github.event.review.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - name: "Upload PR review Payload"


### PR DESCRIPTION
### Rationale for this change

"Approve workflow to run" button always appears after copilot reviews, is annoying

### What changes are included in this PR?

Stop the label workflow running upon copilot review

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #50370