### PR TITLE
GH-50239: [R] Data race issue from R API requests in parallel region

### DIFF
--- a/r/src/RTasks.cpp
+++ b/r/src/RTasks.cpp
@@ -40,8 +40,11 @@ Status RTasks::Finish() {
     }
   }
 
-  // then wait for the parallel tasks to finish
+  // submit the delayed parallel tasks and wait for them to finish
   if (use_threads_) {
+    for (auto& task : delayed_parallel_tasks_) {
+      parallel_tasks_->Append(std::move(task));
+    }
     status &= parallel_tasks_->Finish();
   }
 
@@ -50,7 +53,7 @@ Status RTasks::Finish() {
 
 void RTasks::Append(bool parallel, RTasks::Task&& task) {
   if (parallel && use_threads_) {
-    parallel_tasks_->Append(std::move(task));
+    delayed_parallel_tasks_.push_back(std::move(task));
   } else {
     delayed_serial_tasks_.push_back(std::move(task));
   }
@@ -58,6 +61,7 @@ void RTasks::Append(bool parallel, RTasks::Task&& task) {
 
 void RTasks::Reset() {
   delayed_serial_tasks_.clear();
+  delayed_parallel_tasks_.clear();
 
   stop_source_.Reset();
   if (use_threads_) {

--- a/r/src/r_task_group.h
+++ b/r/src/r_task_group.h
@@ -45,6 +45,7 @@ class RTasks {
   StopSource stop_source_;
   std::shared_ptr<arrow::internal::TaskGroup> parallel_tasks_;
   std::vector<Task> delayed_serial_tasks_;
+  std::vector<Task> delayed_parallel_tasks_;
 };
 
 }  // namespace r


### PR DESCRIPTION
### Rationale for this change

When `use_threads = TRUE`, parallel tasks are submitted to the thread pool immediately during `RTasks::Append()`. This means worker threads start reading R vector headers (via `INTEGER()`, `REAL()`, etc.) while the main thread is still assigning vectors into the output list via `SET_VECTOR_ELT`, which writes to the same header memory. ThreadSanitizer detects this as a data race.

### What changes are included in this PR?

Delay submission of parallel tasks until `RTasks::Finish()`, matching the existing pattern for serial tasks. All R-side allocations and list assignments complete on the main thread before any worker threads start.

### Are these changes tested?

Existing tests cover the affected code path.
I also ran some local benchmarks to see if this change affected performance, but seems fine.

### Are there any user-facing changes?

No.
* GitHub Issue: #50239