### PR TITLE
GH-50487: [C++] Extra semicolon warning from ARROW_SUPPRESS_DEPRECATION_WARNING macro with -Wpedantic

### DIFF
--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -152,13 +152,13 @@
 
 #ifdef __clang__
 #  define ARROW_SUPPRESS_DEPRECATION_WARNING \
-    _Pragma("clang diagnostic push");        \
-    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+    _Pragma("clang diagnostic push")         \
+        _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #  define ARROW_UNSUPPRESS_DEPRECATION_WARNING _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__)
 #  define ARROW_SUPPRESS_DEPRECATION_WARNING \
-    _Pragma("GCC diagnostic push");          \
-    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+    _Pragma("GCC diagnostic push")           \
+        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #  define ARROW_UNSUPPRESS_DEPRECATION_WARNING _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)
 #  define ARROW_SUPPRESS_DEPRECATION_WARNING \
@@ -174,8 +174,8 @@
 // Macros to disable warnings about undeclared global functions
 #if defined(__GNUC__)
 #  define ARROW_SUPPRESS_MISSING_DECLARATIONS_WARNING \
-    _Pragma("GCC diagnostic push");                   \
-    _Pragma("GCC diagnostic ignored \"-Wmissing-declarations\"")
+    _Pragma("GCC diagnostic push")                    \
+        _Pragma("GCC diagnostic ignored \"-Wmissing-declarations\"")
 #  define ARROW_UNSUPPRESS_MISSING_DECLARATIONS_WARNING _Pragma("GCC diagnostic pop")
 #else
 #  define ARROW_SUPPRESS_MISSING_DECLARATIONS_WARNING


### PR DESCRIPTION
### Rationale for this change

When building Arrow 25.0.0 from source and then building the R package, we see:

```
  /home/nic/arrow/r/libarrow/arrow-25.0.0/include/arrow/compute/api
  _vector.h:277:3: note: in expansion of macro
  'ARROW_SUPPRESS_DEPRECATION_WARNING'
       277 |   ARROW_SUPPRESS_DEPRECATION_WARNING
           |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The `ARROW_SUPPRESS_DEPRECATION_WARNING` and `ARROW_SUPPRESS_MISSING_DECLARATIONS_WARNING` macros have trailing semicolons after `_Pragma` directives, which produce empty statements and trigger `-Wpedantic` warnings wherever the macros are used.

### What changes are included in this PR?

Remove unnecessary semicolons after `_Pragma` calls in the clang, GCC, and missing-declarations macro variants in `macros.h`.

### Are these changes tested?

Existing tests cover these macros. The change only removes empty statements.

### Are there any user-facing changes?

No.
* GitHub Issue: #50487