### PR TITLE
GH-50504: [C++][Gandiva] fix out-of-bounds read in upper/lower/initcap

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <memory>
 
 #include "arrow/util/logging.h"
 #include "gandiva/execution_context.h"
@@ -649,6 +650,20 @@ TEST(TestGdvFnStubs, TestUpper) {
 
   ctx.Reset();
 
+  // Truncated trailing multibyte glyph in an exact-sized buffer (no trailing NUL);
+  // the lead byte claims more bytes than remain. Use new[] so the over-read trips
+  // ASAN instead of landing on std::string's guaranteed terminator.
+  {
+    const int32_t trunc_len = 4;
+    std::unique_ptr<char[]> trunc(new char[trunc_len]{'a', 'b', 'c', '\xc3'});
+    out_str = gdv_fn_upper_utf8(ctx_ptr, trunc.get(), trunc_len, &out_len);
+    EXPECT_EQ(out_len, 0);
+    EXPECT_THAT(ctx.get_error(),
+                ::testing::HasSubstr(
+                    "unexpected byte \\c3 encountered while decoding utf8 string"));
+    ctx.Reset();
+  }
+
   // Max Len Test
   out_len = -1;
   int32_t bad_len = std::numeric_limits<int32_t>::max() / 2 + 1;
@@ -752,6 +767,19 @@ TEST(TestGdvFnStubs, TestLower) {
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
   ctx.Reset();
 
+  // Truncated trailing 3-byte lead in an exact-sized buffer (no trailing NUL); only
+  // the lead byte is present, so decoding must not read the missing continuation bytes.
+  {
+    const int32_t trunc_len = 4;
+    std::unique_ptr<char[]> trunc(new char[trunc_len]{'a', 'b', 'c', '\xe0'});
+    out_str = gdv_fn_lower_utf8(ctx_ptr, trunc.get(), trunc_len, &out_len);
+    EXPECT_EQ(out_len, 0);
+    EXPECT_THAT(ctx.get_error(),
+                ::testing::HasSubstr(
+                    "unexpected byte \\e0 encountered while decoding utf8 string"));
+    ctx.Reset();
+  }
+
   std::string e(
       "åbÑg\xe0\xa0"
       "åBUå");
@@ -805,7 +833,7 @@ TEST(TestGdvFnStubs, TestInitCap) {
   EXPECT_EQ(std::string(out_str, out_len), "{Õhp,Pqśv}Ń+");
   EXPECT_FALSE(ctx.has_error());
 
-  out_str = gdv_fn_initcap_utf8(ctx_ptr, "sɦasasdsɦsd\"sdsdɦ", 19, &out_len);
+  out_str = gdv_fn_initcap_utf8(ctx_ptr, "sɦasasdsɦsd\"sdsdɦ", 20, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "Sɦasasdsɦsd\"Sdsdɦ");
   EXPECT_FALSE(ctx.has_error());
 
@@ -841,6 +869,19 @@ TEST(TestGdvFnStubs, TestInitCap) {
               ::testing::HasSubstr(
                   "unexpected byte \\c3 encountered while decoding utf8 string"));
   ctx.Reset();
+
+  // Truncated trailing multibyte glyph in an exact-sized buffer (no trailing NUL);
+  // the lead byte claims more bytes than remain and must not be decoded past the end.
+  {
+    const int32_t trunc_len = 4;
+    std::unique_ptr<char[]> trunc(new char[trunc_len]{'a', 'b', 'c', '\xc3'});
+    out_str = gdv_fn_initcap_utf8(ctx_ptr, trunc.get(), trunc_len, &out_len);
+    EXPECT_EQ(out_len, 0);
+    EXPECT_THAT(ctx.get_error(),
+                ::testing::HasSubstr(
+                    "unexpected byte \\c3 encountered while decoding utf8 string"));
+    ctx.Reset();
+  }
 
   // Max Len Test
   out_len = -1;

--- a/cpp/src/gandiva/gdv_string_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_string_function_stubs.cc
@@ -276,6 +276,14 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
       continue;
     }
 
+    // A truncated trailing glyph must be rejected before decoding, otherwise
+    // UTF8Decode walks continuation bytes past data[data_len].
+    if (char_len == 0 || i + char_len > data_len) {
+      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      *out_len = 0;
+      return "";
+    }
+
     // Control reaches here when we encounter a multibyte character
     const auto* in_char = (const uint8_t*)(data + i);
 
@@ -351,6 +359,14 @@ const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_le
         out[out_idx++] = cur;
       }
       continue;
+    }
+
+    // A truncated trailing glyph must be rejected before decoding, otherwise
+    // UTF8Decode walks continuation bytes past data[data_len].
+    if (char_len == 0 || i + char_len > data_len) {
+      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      *out_len = 0;
+      return "";
     }
 
     // Control reaches here when we encounter a multibyte character
@@ -570,6 +586,14 @@ const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_
     }
 
     char_len = gdv_fn_utf8_char_length(data[i]);
+
+    // A truncated trailing glyph must be rejected before decoding, otherwise
+    // UTF8Decode walks continuation bytes past data[data_len].
+    if (char_len == 0 || i + char_len > data_len) {
+      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      *out_len = 0;
+      return "";
+    }
 
     // Control reaches here when we encounter a multibyte character
     const auto* in_char = (const uint8_t*)(data + i);


### PR DESCRIPTION
### Rationale for this change

`upper()`, `lower()` and `initcap()` decode a multibyte glyph with `arrow::util::UTF8Decode` in `gdv_string_function_stubs.cc` without checking that the whole glyph fits inside `data_len`. When a string ends in a truncated multibyte sequence (a trailing `0xC3` or `0xE0` lead byte), `UTF8Decode` walks continuation bytes past `data[data_len]`. The input is a string array value buffer, so a packed, exactly-sized buffer makes that read land past the allocation. The three functions share the same decode loop, so all three are affected.

ASAN on an exact-sized input buffer:

```
heap-buffer-overflow READ of size 1 ... 0 bytes after 4-byte region
  in arrow::util::UTF8Decode (utf8_internal.h:353)
  in gdv_fn_upper_utf8 (gdv_string_function_stubs.cc:361)
```

### What changes are included in this PR?

Reject a glyph whose declared length runs past `data_len` before decoding it, in `gdv_fn_lower_utf8`, `gdv_fn_upper_utf8` and `gdv_fn_initcap_utf8`. This takes the same invalid-utf8 error path the functions already use for a bad lead byte, so valid input is handled exactly as before.

One existing initcap test also passed length 19 for a 20-byte literal, which cut off the final `ɦ` glyph. That only stayed hidden because a string literal keeps a spare trailing byte; the length is corrected to 20.

### Are these changes tested?

Yes. New cases in `TestUpper`, `TestLower` and `TestInitCap` feed an exact-sized `new char[]` buffer ending in a truncated lead byte. They fail under ASAN on the current code (heap-buffer-overflow in `UTF8Decode`) and pass with the fix.

### Are there any user-facing changes?

No.

* GitHub Issue: #50504