### PR TITLE
GH-50510: [CI][Dev] Fix shellcheck error in the ci/scripts/ccache_fix_perms.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -294,6 +294,7 @@ repos:
           ?^c_glib/test/run-test\.sh$|
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
+          ?^ci/scripts/ccache_fix_perms\.sh$|
           ?^ci/scripts/ccache_setup\.sh$|
           ?^ci/scripts/cpp_build\.sh$|
           ?^ci/scripts/cpp_test\.sh$|

--- a/ci/scripts/ccache_fix_perms.sh
+++ b/ci/scripts/ccache_fix_perms.sh
@@ -24,4 +24,4 @@ set -eux
 
 cache_dir=$(ccache --get-config cache_dir)
 
-find ${cache_dir} -type f -exec chmod 644 {} \;
+find "${cache_dir}" -type f -exec chmod 644 {} \;


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2086: Double quote to prevent globbing and word splitting

```
In ci/scripts/ccache_fix_perms.sh line 27:
find ${cache_dir} -type f -exec chmod 644 {} \;
     ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
find "${cache_dir}" -type f -exec chmod 644 {} \;

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```


### What changes are included in this PR?

* SC2086: Quote the variable.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50510