### PR TITLE
GH-50512: [C++][Compute] Support float16 in hash kernels (dictionary_encode, unique, value_counts)

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -550,6 +550,7 @@ KernelInit GetHashInit(Type::type type_id) {
       return HashInit<RegularHashKernel<UInt8Type, Action>>;
     case Type::INT16:
     case Type::UINT16:
+    case Type::HALF_FLOAT:
       return HashInit<RegularHashKernel<UInt16Type, Action>>;
     case Type::INT32:
     case Type::UINT32:
@@ -699,6 +700,13 @@ void AddHashKernels(VectorFunction* func, VectorKernel base, OutputType out_ty) 
     base.signature = KernelSignature::Make({ty}, out_ty);
     DCHECK_OK(func->AddKernel(base));
   }
+
+  // float16() is not part of PrimitiveTypes() (FloatingPointTypes() only covers
+  // float32 and float64; see GH-43017), so it must be registered explicitly. Like
+  // float32 and float64, it is hashed by its raw bit pattern (via UInt16Type).
+  base.init = GetHashInit<Action>(Type::HALF_FLOAT);
+  base.signature = KernelSignature::Make({float16()}, out_ty);
+  DCHECK_OK(func->AddKernel(base));
 
   // Parametric types that we want matching to be dependent only on type id
   auto parametric_types = {Type::TIME32, Type::TIME64, Type::TIMESTAMP, Type::DURATION,

--- a/cpp/src/arrow/compute/kernels/vector_hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_test.cc
@@ -403,6 +403,44 @@ TEST_F(TestHashKernel, DictEncodeBoolean) {
       ArrayFromJSON(boolean(), "[true]"), ArrayFromJSON(int32(), "[0, null, 0]"));
 }
 
+// float16 is not part of PrimitiveTypes(), so it is not covered by
+// TestHashKernelPrimitive above and gets its own coverage here. Like float32 and
+// float64, it is hashed by its raw bit pattern.
+TEST_F(TestHashKernel, UniqueHalfFloat) {
+  CheckUnique(ArrayFromJSON(float16(), "[1.5, 2.5, null, 1.5, 3.5, null]"),
+              ArrayFromJSON(float16(), "[1.5, 2.5, null, 3.5]"));
+
+  // No nulls
+  CheckUnique(ArrayFromJSON(float16(), "[1.5, 2.5, 1.5, 3.5]"),
+              ArrayFromJSON(float16(), "[1.5, 2.5, 3.5]"));
+
+  // Sliced
+  CheckUnique(ArrayFromJSON(float16(), "[1.5, 2.5, null, 3.5, 2.5, 1.5]")->Slice(1, 4),
+              ArrayFromJSON(float16(), "[2.5, null, 3.5]"));
+}
+
+TEST_F(TestHashKernel, ValueCountsHalfFloat) {
+  CheckValueCounts(ArrayFromJSON(float16(), "[1.5, 2.5, null, 1.5, 3.5, null]"),
+                   ArrayFromJSON(float16(), "[1.5, 2.5, null, 3.5]"),
+                   ArrayFromJSON(int64(), "[2, 1, 2, 1]"));
+}
+
+TEST_F(TestHashKernel, DictEncodeHalfFloat) {
+  CheckDictEncode(ArrayFromJSON(float16(), "[1.5, 2.5, null, 1.5, 3.5, null]"),
+                  ArrayFromJSON(float16(), "[1.5, 2.5, 3.5]"),
+                  ArrayFromJSON(int32(), "[0, 1, null, 0, 2, null]"));
+
+  // No nulls
+  CheckDictEncode(ArrayFromJSON(float16(), "[1.5, 2.5, 1.5, 3.5]"),
+                  ArrayFromJSON(float16(), "[1.5, 2.5, 3.5]"),
+                  ArrayFromJSON(int32(), "[0, 1, 0, 2]"));
+
+  // Sliced
+  CheckDictEncode(
+      ArrayFromJSON(float16(), "[1.5, 2.5, null, 3.5, 2.5, 1.5]")->Slice(1, 4),
+      ArrayFromJSON(float16(), "[2.5, 3.5]"), ArrayFromJSON(int32(), "[0, null, 1, 0]"));
+}
+
 template <typename ArrowType>
 class TestHashKernelBinaryTypes : public TestHashKernel {
  protected:


### PR DESCRIPTION
### Rationale for this change

Asd missing support for `float16` in hash kernels.

### What changes are included in this PR?

Support `float16` in hash kernels: `dictionary_encode`, `unique`, `value_counts`.

### Are these changes tested?

Added `UniqueHalfFloat`, `ValueCountsHalfFloat` and `DictEncodeHalfFloat` to `vector_hash_test.cc`, following the conventions in that file. Coverage includes nulls, repeated values, a no-nulls case, and sliced input. `float16` is not in `PrimitiveTypes()`, so it isn't picked up by the existing `TestHashKernelPrimitive` typed suite and needs its own `TEST_F` cases. `NaN`/`-0.0` cases are deliberately not tested, matching the existing float32/float64 tests.

Built and ran locally:

```
cmake -S cpp -B /tmp/arrow-build -DCMAKE_BUILD_TYPE=Debug -DARROW_COMPUTE=ON \
  -DARROW_BUILD_TESTS=ON -DARROW_DEPENDENCY_SOURCE=BUNDLED -DARROW_SIMD_LEVEL=NONE
cmake --build /tmp/arrow-build --target arrow-compute-vector-test -j8
```

- The 3 new float16 tests pass.
- All 110 `*HashKernel*` tests pass.
- The full `arrow-compute-vector-test` binary passes: **1135 tests from 150 test suites**, no regressions.

### Are there any user-facing changes?

No (except for filling out the feature gap).

* GitHub Issue: #50512