### PR TITLE
GH-50522: [C++][Gandiva] fix heap overflow in aes_encrypt output sizing

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -44,6 +44,9 @@ extern "C" {
 
 ARROW_SUPPRESS_MISSING_DECLARATIONS_WARNING
 
+// AES operates on 16 byte blocks for every supported key length.
+static constexpr int64_t kAesBlockSize = 16;
+
 static char mask_array[256] = {
     (char)0,  (char)1,  (char)2,  (char)3,   (char)4,   (char)5,   (char)6,   (char)7,
     (char)8,  (char)9,  (char)10, (char)11,  (char)12,  (char)13,  (char)14,  (char)15,
@@ -361,10 +364,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     return "";
   }
 
-  int64_t kAesBlockSize = 0;
-  if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
-    kAesBlockSize = static_cast<int64_t>(key_data_len);
-  } else {
+  if (key_data_len != 16 && key_data_len != 24 && key_data_len != 32) {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
     gdv_fn_context_set_error_msg(context, oss.str().c_str());
@@ -372,8 +372,8 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     return nullptr;
   }
 
-  *out_len =
-      static_cast<int32_t>(arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize));
+  *out_len = static_cast<int32_t>(
+      arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize) + kAesBlockSize);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     std::string err_msg = "AES_ENCRYPT: could not allocate memory for ciphertext output";
@@ -407,10 +407,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     return "";
   }
 
-  int64_t kAesBlockSize = 0;
-  if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
-    kAesBlockSize = static_cast<int64_t>(key_data_len);
-  } else {
+  if (key_data_len != 16 && key_data_len != 24 && key_data_len != 32) {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
     gdv_fn_context_set_error_msg(context, oss.str().c_str());
@@ -418,8 +415,8 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     return nullptr;
   }
 
-  *out_len =
-      static_cast<int32_t>(arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize));
+  *out_len = static_cast<int32_t>(
+      arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize) + kAesBlockSize);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     std::string err_msg = "Could not allocate memory for returning aes decrypt plaintext";

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -44,6 +44,9 @@ extern "C" {
 
 ARROW_SUPPRESS_MISSING_DECLARATIONS_WARNING
 
+// AES operates on 16 byte blocks for every supported key length.
+static constexpr int64_t kAesBlockSize = 16;
+
 static char mask_array[256] = {
     (char)0,  (char)1,  (char)2,  (char)3,   (char)4,   (char)5,   (char)6,   (char)7,
     (char)8,  (char)9,  (char)10, (char)11,  (char)12,  (char)13,  (char)14,  (char)15,
@@ -366,10 +369,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     return "";
   }
 
-  int64_t kAesBlockSize = 0;
-  if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
-    kAesBlockSize = static_cast<int64_t>(key_data_len);
-  } else {
+  if (key_data_len != 16 && key_data_len != 24 && key_data_len != 32) {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
     gdv_fn_context_set_error_msg(context, oss.str().c_str());
@@ -377,8 +377,8 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     return nullptr;
   }
 
-  *out_len =
-      static_cast<int32_t>(arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize));
+  *out_len = static_cast<int32_t>(
+      arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize) + kAesBlockSize);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     std::string err_msg = "AES_ENCRYPT: could not allocate memory for ciphertext output";
@@ -412,10 +412,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     return "";
   }
 
-  int64_t kAesBlockSize = 0;
-  if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
-    kAesBlockSize = static_cast<int64_t>(key_data_len);
-  } else {
+  if (key_data_len != 16 && key_data_len != 24 && key_data_len != 32) {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
     gdv_fn_context_set_error_msg(context, oss.str().c_str());
@@ -423,8 +420,8 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     return nullptr;
   }
 
-  *out_len =
-      static_cast<int32_t>(arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize));
+  *out_len = static_cast<int32_t>(
+      arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize) + kAesBlockSize);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     std::string err_msg = "Could not allocate memory for returning aes decrypt plaintext";

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -1584,4 +1584,37 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptValidation) {
   EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("invalid key length"));
   ctx.Reset();
 }
+
+TEST(TestGdvFnStubs, TestAesEncryptBlockAlignedInput) {
+  gandiva::ExecutionContext ctx;
+  std::string key16 = "12345678abcdefgh";
+  auto key16_len = static_cast<int32_t>(key16.length());
+  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+
+  // A block-aligned input still gets a whole block of padding appended, so the
+  // ciphertext is one block longer than the input. Encrypting twice from the same
+  // context makes an undersized output buffer observable, because the second
+  // ciphertext lands on top of the first one.
+  std::string first = "aaaaaaaaaaaaaaaa";
+  std::string second = "bbbbbbbbbbbbbbbb";
+  auto first_len = static_cast<int32_t>(first.length());
+  auto second_len = static_cast<int32_t>(second.length());
+
+  int32_t first_cipher_len = 0;
+  const char* first_cipher = gdv_fn_aes_encrypt(
+      ctx_ptr, first.c_str(), first_len, key16.c_str(), key16_len, &first_cipher_len);
+  ASSERT_FALSE(ctx.has_error());
+  EXPECT_EQ(first_cipher_len, first_len + 16);
+
+  int32_t second_cipher_len = 0;
+  gdv_fn_aes_encrypt(ctx_ptr, second.c_str(), second_len, key16.c_str(), key16_len,
+                     &second_cipher_len);
+  ASSERT_FALSE(ctx.has_error());
+
+  int32_t decrypted_len = 0;
+  const char* decrypted = gdv_fn_aes_decrypt(ctx_ptr, first_cipher, first_cipher_len,
+                                             key16.c_str(), key16_len, &decrypted_len);
+  ASSERT_FALSE(ctx.has_error());
+  EXPECT_EQ(first, std::string(decrypted, decrypted_len));
+}
 }  // namespace gandiva

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -1621,4 +1621,37 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptValidation) {
   EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("invalid key length"));
   ctx.Reset();
 }
+
+TEST(TestGdvFnStubs, TestAesEncryptBlockAlignedInput) {
+  gandiva::ExecutionContext ctx;
+  std::string key16 = "12345678abcdefgh";
+  auto key16_len = static_cast<int32_t>(key16.length());
+  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+
+  // A block-aligned input still gets a whole block of padding appended, so the
+  // ciphertext is one block longer than the input. Encrypting twice from the same
+  // context makes an undersized output buffer observable, because the second
+  // ciphertext lands on top of the first one.
+  std::string first = "aaaaaaaaaaaaaaaa";
+  std::string second = "bbbbbbbbbbbbbbbb";
+  auto first_len = static_cast<int32_t>(first.length());
+  auto second_len = static_cast<int32_t>(second.length());
+
+  int32_t first_cipher_len = 0;
+  const char* first_cipher = gdv_fn_aes_encrypt(
+      ctx_ptr, first.c_str(), first_len, key16.c_str(), key16_len, &first_cipher_len);
+  ASSERT_FALSE(ctx.has_error());
+  EXPECT_EQ(first_cipher_len, first_len + 16);
+
+  int32_t second_cipher_len = 0;
+  gdv_fn_aes_encrypt(ctx_ptr, second.c_str(), second_len, key16.c_str(), key16_len,
+                     &second_cipher_len);
+  ASSERT_FALSE(ctx.has_error());
+
+  int32_t decrypted_len = 0;
+  const char* decrypted = gdv_fn_aes_decrypt(ctx_ptr, first_cipher, first_cipher_len,
+                                             key16.c_str(), key16_len, &decrypted_len);
+  ASSERT_FALSE(ctx.has_error());
+  EXPECT_EQ(first, std::string(decrypted, decrypted_len));
+}
 }  // namespace gandiva


### PR DESCRIPTION
### Rationale for this change

`gdv_fn_aes_encrypt` sizes its output buffer with `RoundUpToPowerOf2(data_len, key_data_len)`, which treats the key length as the AES block size. AES works on 16 byte blocks for every supported key length, so the rounding factor is wrong, and a 24 byte key asks `RoundUpToPowerOf2` to round to a factor that is not a power of two, which its contract requires.

On top of that, PKCS#7 padding always appends a whole block, so a block aligned input produces a ciphertext one block longer than the input and the buffer comes up short. Allocated size against the ciphertext OpenSSL actually writes:

| key | data_len | allocated | actual ciphertext |
|-----|----------|-----------|-------------------|
| 16  | 16       | 16        | 32                |
| 16  | 8192     | 8192      | 8208              |
| 24  | 8        | 8         | 16                |
| 32  | 32       | 32        | 48                |

`aes_encrypt(col, key)` over any 16/32/48/... byte value lets `EVP_EncryptFinal_ex` write 16 bytes past the arena buffer, and a 24 byte key with an 8 byte value writes 8 past. The overrun lands on whatever the arena hands out next, so the neighbouring row's output is corrupted; once the value exceeds the arena chunk size the chunk is allocated exactly and the write runs off the end of it.

`gdv_fn_aes_decrypt` sizes its buffer with the same expression. Its plaintext is never longer than the ciphertext so it does not overrun today, but the size it computes can equal `data_len` while OpenSSL documents `inl + block_size` as the output space `EVP_DecryptUpdate` may use, and the trailing `ret[*out_len] = '\0'` needs the room as well.

### What changes are included in this PR?

Both stubs now size the output from the fixed 16 byte AES block plus one block for padding, which covers the exact PKCS#7 ciphertext length and the output space OpenSSL asks for. The key length keeps its 16/24/32 validation and only picks the cipher.

### Are these changes tested?

Yes. `TestGdvFnStubs.TestAesEncryptBlockAlignedInput` encrypts two block aligned values from one context and decrypts the first. The undersized buffer makes the second ciphertext land on top of the first, so the decrypt fails on the current code and round-trips after the fix. It needs no sanitizer, which the existing Gandiva CI jobs do not enable. Full `gandiva-internals-test`, `gandiva-precompiled-test` and `gandiva-projector-test` pass.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** It fixes a heap buffer overflow in `aes_encrypt` that corrupts neighbouring output (or writes off the end of the arena chunk) for any input whose length is a multiple of the AES block size.

* GitHub Issue: #50522
