### PR TITLE
GH-50527: [C++] Remove ARROW_SSE4_2_FLAG for x86 MSVC

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -49,7 +49,7 @@ endif()
 if(ARROW_CPU_FLAG STREQUAL "x86")
   # x86/amd64 compiler flags, msvc/gcc/clang
   if(MSVC)
-    set(ARROW_SSE4_2_FLAG "/arch:SSE4.2")
+    set(ARROW_SSE4_2_FLAG "")
     # These definitions are needed for xsimd to consider the corresponding instruction
     # sets available, but they are not set by MSVC (unlike other compilers).
     # See https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/4265

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -49,6 +49,9 @@ endif()
 if(ARROW_CPU_FLAG STREQUAL "x86")
   # x86/amd64 compiler flags, msvc/gcc/clang
   if(MSVC)
+    # The "/arch:SSE4.2" flag is not supported in x86 builds and is
+    # enabled by default in x64. Removed to avoid D9002 nuisance warnings.
+    # See https://learn.microsoft.com/cpp/build/reference/arch-x86
     set(ARROW_SSE4_2_FLAG "")
     # These definitions are needed for xsimd to consider the corresponding instruction
     # sets available, but they are not set by MSVC (unlike other compilers).


### PR DESCRIPTION
The SSE4.2 flag is invalid for the MSVC x86 compiler, and ignored by x64 as an automatic extension of the default (SSE2).
https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86

### Rationale for this change
MSVC builds generate hundreds of nuisance warnings that resemble:
    cl : Command line warning D9002 : ignoring unknown option '/arch:SSE4.2'

### What changes are included in this PR?
Simple replacement of the MSVC-specific flag "/arch:SSE4.2" with an empty string. This matches a working configuration prior to ~July 2025, at which time the flag seems to have been edited while adding xsimd definitions below.

### Are these changes tested?
Yes - using cmake version 3.29.6 and both the VC17 and VC18 compilers.

### Are there any user-facing changes?
No. This only affects developers building the source code and has no impact on the Apache Arrow libraries.
* GitHub Issue: #50527