### PR TITLE
GH-50532: [R][CI] R nightly binary upload broken since github3 to pygithub migration

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -448,11 +448,11 @@ class Repo:
         return blob.data
 
     def _github_login(self, github_token=None):
-        """Returns a logged in Github instance using PyGithub"""
+        """Returns a Github instance, optionally authenticated with a token"""
         if not _have_github:
             raise ImportError('Must install PyGithub')
         github_token = github_token or self.github_token
-        if github_token is None:
+        if not github_token:
             return Github(timeout=30)
         return Github(auth=GithubAuth.Token(github_token), timeout=30)
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -452,6 +452,8 @@ class Repo:
         if not _have_github:
             raise ImportError('Must install PyGithub')
         github_token = github_token or self.github_token
+        if github_token is None:
+            return Github(timeout=30)
         return Github(auth=GithubAuth.Token(github_token), timeout=30)
 
     def as_github_repo(self, github_token=None):


### PR DESCRIPTION
### Rationale for this change

#48886 replaced github3 with pygithub in archery. Unlike github3, pygithub's `Auth.Token` requires a non-None string, so `_github_login()` crashes when no token is provided. The `r_nightly.yml` workflow doesn't pass `CROSSBOW_GITHUB_TOKEN` to archery, so it has been failing since June 19 (#50532). No R nightly binaries have been uploaded for a month.

### What changes are included in this PR?

Fall back to unauthenticated `Github()` when no token is provided, restoring the pre-migration behavior. The crossbow repo is public so auth isn't required for downloading artifacts.

### Are these changes tested?

Tested locally by running `archery crossbow download-artifacts` without a token set.

### Are there any user-facing changes?

No.

* GitHub Issue: #50532