### PR TITLE
GH-50535: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -334,6 +334,7 @@ repos:
           ?^ci/scripts/python_sdist_test\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/python_test_type_annotations\.sh$|
+          ?^ci/scripts/python_test\.sh$|
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -19,19 +19,21 @@
 
 set -ex
 
-arrow_dir=${1}
-test_dir=${1}/python/build/dist
+arrow_dir="${1}"
+# shellcheck disable=SC2034  # Unused variable
+test_dir="${1}/python/build/dist"
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  # shellcheck source=/dev/null
   . "${ARROW_PYTHON_VENV}/bin/activate"
 fi
 
-export ARROW_SOURCE_DIR=${arrow_dir}
-export ARROW_TEST_DATA=${arrow_dir}/testing/data
-export PARQUET_TEST_DATA=${arrow_dir}/cpp/submodules/parquet-testing/data
-export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
-export DYLD_LIBRARY_PATH=${ARROW_HOME}/lib:${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
-export ARROW_GDB_SCRIPT=${arrow_dir}/cpp/gdb_arrow.py
+export ARROW_SOURCE_DIR="${arrow_dir}"
+export ARROW_TEST_DATA="${arrow_dir}/testing/data"
+export PARQUET_TEST_DATA="${arrow_dir}/cpp/submodules/parquet-testing/data"
+export LD_LIBRARY_PATH="${ARROW_HOME}/lib:${LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="${ARROW_HOME}/lib:${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}"
+export ARROW_GDB_SCRIPT="${arrow_dir}/cpp/gdb_arrow.py"
 
 # Enable some checks inside Python itself
 export PYTHONDEVMODE=1
@@ -42,18 +44,18 @@ if [ -z "${ARROW_DEBUG_MEMORY_POOL}" ]; then
 fi
 
 # By default, force-test all optional components
-: ${PYARROW_TEST_ACERO:=${ARROW_ACERO:-ON}}
-: ${PYARROW_TEST_AZURE:=${ARROW_AZURE:-ON}}
-: ${PYARROW_TEST_CUDA:=${ARROW_CUDA:-ON}}
-: ${PYARROW_TEST_DATASET:=${ARROW_DATASET:-ON}}
-: ${PYARROW_TEST_FLIGHT:=${ARROW_FLIGHT:-ON}}
-: ${PYARROW_TEST_GANDIVA:=${ARROW_GANDIVA:-ON}}
-: ${PYARROW_TEST_GCS:=${ARROW_GCS:-ON}}
-: ${PYARROW_TEST_HDFS:=${ARROW_HDFS:-ON}}
-: ${PYARROW_TEST_ORC:=${ARROW_ORC:-ON}}
-: ${PYARROW_TEST_PARQUET:=${ARROW_PARQUET:-ON}}
-: ${PYARROW_TEST_PARQUET_ENCRYPTION:=${PARQUET_REQUIRE_ENCRYPTION:-ON}}
-: ${PYARROW_TEST_S3:=${ARROW_S3:-ON}}
+: "${PYARROW_TEST_ACERO:=${ARROW_ACERO:-ON}}"
+: "${PYARROW_TEST_AZURE:=${ARROW_AZURE:-ON}}"
+: "${PYARROW_TEST_CUDA:=${ARROW_CUDA:-ON}}"
+: "${PYARROW_TEST_DATASET:=${ARROW_DATASET:-ON}}"
+: "${PYARROW_TEST_FLIGHT:=${ARROW_FLIGHT:-ON}}"
+: "${PYARROW_TEST_GANDIVA:=${ARROW_GANDIVA:-ON}}"
+: "${PYARROW_TEST_GCS:=${ARROW_GCS:-ON}}"
+: "${PYARROW_TEST_HDFS:=${ARROW_HDFS:-ON}}"
+: "${PYARROW_TEST_ORC:=${ARROW_ORC:-ON}}"
+: "${PYARROW_TEST_PARQUET:=${ARROW_PARQUET:-ON}}"
+: "${PYARROW_TEST_PARQUET_ENCRYPTION:=${PARQUET_REQUIRE_ENCRYPTION:-ON}}"
+: "${PYARROW_TEST_S3:=${ARROW_S3:-ON}}"
 
 export PYARROW_TEST_ACERO
 export PYARROW_TEST_AZURE
@@ -69,9 +71,9 @@ export PYARROW_TEST_PARQUET_ENCRYPTION
 export PYARROW_TEST_S3
 
 # Testing PyArrow
-pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
+pytest -r s "${PYTEST_ARGS}" --pyargs pyarrow
 
 # Testing RST documentation examples (if PYTEST_RST_ARGS is set)
 if [ -n "${PYTEST_RST_ARGS}" ]; then
-  pytest ${PYTEST_RST_ARGS} ${arrow_dir}/docs/source/python
+  pytest "${PYTEST_RST_ARGS}" "${arrow_dir}/docs/source/python"
 fi

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -20,8 +20,6 @@
 set -ex
 
 arrow_dir="${1}"
-# shellcheck disable=SC2034  # Unused variable
-test_dir="${1}/python/build/dist"
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
   # shellcheck source=/dev/null

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -68,10 +68,17 @@ export PYARROW_TEST_PARQUET
 export PYARROW_TEST_PARQUET_ENCRYPTION
 export PYARROW_TEST_S3
 
+# Convert the space-separated options into a Bash array.
+# This avoids ShellCheck SC2086 and preserves argument boundaries.
+read -r -a PYTEST_ARGS_ARRAY <<< "$PYTEST_ARGS"
+
 # Testing PyArrow
-pytest -r s "${PYTEST_ARGS}" --pyargs pyarrow
+pytest -r s "${PYTEST_ARGS_ARRAY[@]}" --pyargs pyarrow
 
 # Testing RST documentation examples (if PYTEST_RST_ARGS is set)
 if [ -n "${PYTEST_RST_ARGS}" ]; then
-  pytest "${PYTEST_RST_ARGS}" "${arrow_dir}/docs/source/python"
+  # Convert the space-separated options into a Bash array.
+  # This avoids ShellCheck SC2086 and preserves argument boundaries.
+  read -r -a PYTEST_RST_ARGS_ARRAY <<< "$PYTEST_RST_ARGS"
+  pytest "${PYTEST_RST_ARGS_ARRAY[@]}" "${arrow_dir}/docs/source/python"
 fi


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2034: `test_dir` appears unused. Verify it or export it.
* SC1091: Not following: (error message here)
* SC2086: Double quote to prevent globbing and word splitting.

```
shellcheck ci/scripts/python_test.sh

In ci/scripts/python_test.sh line 23:
test_dir=${1}/python/build/dist
^------^ SC2034 (warning): test_dir appears unused. Verify use (or export if used externally).


In ci/scripts/python_test.sh line 26:
  . "${ARROW_PYTHON_VENV}/bin/activate"
    ^-- SC1091 (info): Not following: ./bin/activate: openBinaryFile: does not exist (No such file or directory)


In ci/scripts/python_test.sh line 45:
: ${PYARROW_TEST_ACERO:=${ARROW_ACERO:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 46:
: ${PYARROW_TEST_AZURE:=${ARROW_AZURE:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 47:
: ${PYARROW_TEST_CUDA:=${ARROW_CUDA:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 48:
: ${PYARROW_TEST_DATASET:=${ARROW_DATASET:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 49:
: ${PYARROW_TEST_FLIGHT:=${ARROW_FLIGHT:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 50:
: ${PYARROW_TEST_GANDIVA:=${ARROW_GANDIVA:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 51:
: ${PYARROW_TEST_GCS:=${ARROW_GCS:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 52:
: ${PYARROW_TEST_HDFS:=${ARROW_HDFS:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 53:
: ${PYARROW_TEST_ORC:=${ARROW_ORC:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 54:
: ${PYARROW_TEST_PARQUET:=${ARROW_PARQUET:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 55:
: ${PYARROW_TEST_PARQUET_ENCRYPTION:=${PARQUET_REQUIRE_ENCRYPTION:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 56:
: ${PYARROW_TEST_S3:=${ARROW_S3:-ON}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_test.sh line 72:
pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
            ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pytest -r s "${PYTEST_ARGS}" --pyargs pyarrow


In ci/scripts/python_test.sh line 76:
  pytest ${PYTEST_RST_ARGS} ${arrow_dir}/docs/source/python
         ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                            ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  pytest "${PYTEST_RST_ARGS}" "${arrow_dir}"/docs/source/python

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- test_dir appears unused. Verify u...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./bin/activate: op...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```


### What changes are included in this PR?

* SC2034: Add a ShellCheck directive to disable the unused variable check.
* SC1091: Add a ShellCheck directive to disable source file checking. 
* SC2086: Quote variables.


### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50535