### PR TITLE
GH-50537: [R] Fix vector_logic_linter warning by using && in if condition

### DIFF
--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -538,7 +538,7 @@ register_bindings_duration <- function() {
     "base::as.difftime",
     function(x, format = "%X", units = "secs") {
       # windows doesn't seem to like "%X"
-      if (format == "%X" & tolower(Sys.info()[["sysname"]]) == "windows") {
+      if (format == "%X" && tolower(Sys.info()[["sysname"]]) == "windows") {
         format <- "%H:%M:%S"
       }
 


### PR DESCRIPTION
## Rationale for this change

Fix a `vector_logic_linter` warning by using `&&` instead of `&` in an `if` condition.

```
Error: Not lint free
R/dplyr-funcs-datetime.R:541:26: warning: [vector_logic_linter] Use `&&` in conditional expressions.
      if (format == "%X" & tolower(Sys.info()[["sysname"]]) == "windows") {
```

https://github.com/apache/arrow/actions/runs/29632093671/job/88047704304?pr=50536#step:5:76

### What changes are included in this PR?

- Replace `&` with `&&` in the `if` condition.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50537