### PR TITLE
GH-49255: [Python] Fix pandas Categorical DeprecationWarnings in tests

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3126,6 +3126,16 @@ class TestConvertMisc:
         for arr in arrays:
             _check(arr)
 
+    def test_category_construction_deprecation(self):
+        # GH-49255
+        if Version(pd.__version__) < Version("3.0.0"):
+            pytest.skip("out-of-category deprecation added in pandas 3.0")
+        with pytest.warns(
+                DeprecationWarning,
+                match="Constructing a Categorical with a dtype and "
+                      "values containing non-null entries"):
+            pd.Categorical(['a', 'b', 'c'], categories=['a', 'b'])
+
     def test_empty_category(self):
         # ARROW-2443
         df = pd.DataFrame({'cat': pd.Categorical([])})

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3095,8 +3095,6 @@ class TestConvertMisc:
 
         arrays = {
             'cat_strings': pd.Categorical(v1 * repeats),
-            'cat_strings_with_na': pd.Categorical(v1 * repeats,
-                                                  categories=['foo', 'bar']),
             'cat_ints': pd.Categorical(v2 * repeats),
             'cat_binary': pd.Categorical(v3 * repeats),
             'cat_strings_ordered': pd.Categorical(
@@ -3121,8 +3119,8 @@ class TestConvertMisc:
             tm.assert_series_equal(pd.Series(result), pd.Series(v))
 
         arrays = [
-            pd.Categorical(['a', 'b', 'c'], categories=['a', 'b']),
-            pd.Categorical(['a', 'b', 'c'], categories=['a', 'b'],
+            pd.Categorical(['a', 'b', None], categories=['a', 'b']),
+            pd.Categorical(['a', 'b', None], categories=['a', 'b'],
                            ordered=True)
         ]
         for arr in arrays:

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -27,6 +27,8 @@ filterwarnings =
     error:The SparseDataFrame:FutureWarning
     # https://github.com/apache/arrow/issues/38239
     ignore:Setting custom ClientSession:DeprecationWarning
+    # https://github.com/apache/arrow/issues/49255
+    error:Constructing a Categorical with a dtype and values containing non-null entries:DeprecationWarning
 # Get a debug traceback when a test takes a really long time
 faulthandler_timeout = 300
 


### PR DESCRIPTION
### Rationale for this change

pandas 3.0.0 deprecated constructing or casting to a `Categorical` with
non-NA values that are not present in the specified `dtype.categories`. 
This surfaces as DeprecationWarnings in the PyArrow
test suite when run against pandas >= 3.0 (GH-49255), in test_category
and test_category_implicit_from_pandas.

### What changes are included in this PR?

- test_category: remove the `cat_strings_with_na` column (relied on
  silent 'qux' -> NaN; redundant, cat_strings already carries nulls).
- test_category_implicit_from_pandas: use explicit None
  (['a','b',None]) instead of out-of-category 'c'.

### Are these changes tested?
Yes - test-only. Verified no DeprecationWarning under pandas 3.0.3.

### Are there any user-facing changes?
No.

Closes #49255.
* GitHub Issue: #49255