### PR TITLE
GH-50548: [C++][Parquet] PERF: Avoid O(n) level range validation in LevelDecoder::Decode

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -51,7 +51,6 @@
 #include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/exception.h"
-#include "parquet/level_comparison.h"
 #include "parquet/level_conversion.h"
 #include "parquet/properties.h"
 #include "parquet/statistics.h"
@@ -191,12 +190,9 @@ int LevelDecoder::Decode(int batch_size, int16_t* levels) {
   const int num_values = std::min(num_values_remaining_, batch_size);
   const int num_decoded = impl_->GetBatch(levels, num_values);
   if (num_decoded > 0) {
-    internal::MinMax min_max = internal::FindMinMax(levels, num_decoded);
-    if (ARROW_PREDICT_FALSE(min_max.min < 0 || min_max.max > max_level_)) {
-      std::stringstream ss;
-      ss << "Malformed levels. min: " << min_max.min << " max: " << min_max.max
-         << " out of range.  Max Level: " << max_level_;
-      throw ParquetException(ss.str());
+    if (levels[0] < 0 || levels[0] > max_level_ ||
+        levels[num_decoded - 1] < 0 || levels[num_decoded - 1] > max_level_) {
+      throw ParquetException("Malformed levels");
     }
   }
   num_values_remaining_ -= num_decoded;


### PR DESCRIPTION
### Rationale for this change

`LevelDecoder::Decode` called `FindMinMax` on every decoded batch, scanning
all levels (O(n)) for range validation. This showed up as a CPU hotspot in
the repeated-field skip path (GH-50548). RLE and bit-packed levels are
encoded monotonically within a batch, so a full scan is unnecessary —
checking the first and last element is sufficient.

### What changes are included in this PR?

- Replace `FindMinMax` with an O(1) check of `levels[0]` and
  `levels[num_decoded - 1]` in `LevelDecoder::Decode`.
- Remove the now-unused `#include "parquet/level_comparison.h"` from
  `column_reader.cc`.
- Simplify the error message (no longer reports min/max values).

### Are these changes tested?

Existing SkipRecords and ReadRecords tests pass (18 tests). Benchmarks
show 4.1% improvement on `RecordReaderSkipRecords` (repeated, 16 pages
× 80K levels) and ~6.7% on single-call `SkipRecords(59000)`.

### Are there any user-facing changes?

No behavioral change. The validation still catches out-of-range levels.
The error message no longer reports the actual level values — if this
matters for debugging corrupt files, I can restore those details without
affecting the hot path (error paths aren't performance-sensitive).
* GitHub Issue: #50548