### PR TITLE
GH-50551: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_wheel_macos_build.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -335,6 +335,7 @@ repos:
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/python_test_type_annotations\.sh$|
           ?^ci/scripts/python_test\.sh$|
+          ?^ci/scripts/python_wheel_macos_build\.sh$|
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -90,7 +90,7 @@ which -a protoc || echo "no protoc on PATH!"
 
 echo "=== Protobuf compiler version from vcpkg ==="
 _pbc="${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/tools/protobuf/protoc"
-echo "$_pbc: $( $_pbc --version)"
+echo "$_pbc: $($_pbc --version)"
 
 mkdir -p "${build_dir}/build"
 pushd "${build_dir}/build"

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -19,30 +19,30 @@
 
 set -ex
 
-arch=${1}
-source_dir=${2}
-build_dir=${3}
+arch="${1}"
+source_dir="${2}"
+build_dir="${3}"
 
 echo "=== (${PYTHON_VERSION}) Clear output directories and leftovers ==="
 # Clear output directories and leftovers
-rm -rf ${build_dir}/build
-rm -rf ${build_dir}/install
-rm -rf ${source_dir}/python/dist
-rm -rf ${source_dir}/python/build
-rm -rf ${source_dir}/python/pyarrow/*.so
-rm -rf ${source_dir}/python/pyarrow/*.so.*
+rm -rf "${build_dir}/build"
+rm -rf "${build_dir}/install"
+rm -rf "${source_dir}/python/dist"
+rm -rf "${source_dir}/python/build"
+rm -rf "${source_dir}"/python/pyarrow/*.so
+rm -rf "${source_dir}"/python/pyarrow/*.so.*
 
 echo "=== (${PYTHON_VERSION}) Set SDK, C++ and Wheel flags ==="
 export _PYTHON_HOST_PLATFORM="macosx-${MACOSX_DEPLOYMENT_TARGET}-${arch}"
-export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12.0}
-export SDKROOT=${SDKROOT:-$(xcrun --sdk macosx --show-sdk-path)}
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-12.0}"
+export SDKROOT="${SDKROOT:-$(xcrun --sdk macosx --show-sdk-path)}"
 
-if [ $arch = "arm64" ]; then
+if [ "$arch" = "arm64" ]; then
   export CMAKE_OSX_ARCHITECTURES="arm64"
-  : ${ARROW_SIMD_LEVEL:="NEON"}
-elif [ $arch = "x86_64" ]; then
+  : "${ARROW_SIMD_LEVEL:=NEON}"
+elif [ "$arch" = "x86_64" ]; then
   export CMAKE_OSX_ARCHITECTURES="x86_64"
-  : ${ARROW_SIMD_LEVEL:="SSE4_2"}
+  : "${ARROW_SIMD_LEVEL:=SSE4_2}"
 else
   echo "Unexpected architecture: $arch"
   exit 1
@@ -52,97 +52,97 @@ pip install \
   --force-reinstall \
   --only-binary=:all: \
   --upgrade \
-  -r ${source_dir}/python/requirements-wheel-build.txt
+  -r "${source_dir}/python/requirements-wheel-build.txt"
 pip install "delocate>=0.10.3"
 
 echo "=== (${PYTHON_VERSION}) Building Arrow C++ libraries ==="
-: ${ARROW_ACERO:=ON}
-: ${ARROW_AZURE:=ON}
-: ${ARROW_DATASET:=ON}
-: ${ARROW_FLIGHT:=ON}
-: ${ARROW_GANDIVA:=OFF}
-: ${ARROW_GCS:=ON}
-: ${ARROW_HDFS:=ON}
-: ${ARROW_JEMALLOC:=ON}
-: ${ARROW_MIMALLOC:=ON}
-: ${ARROW_ORC:=ON}
-: ${ARROW_PARQUET:=ON}
-: ${PARQUET_REQUIRE_ENCRYPTION:=ON}
-: ${ARROW_SUBSTRAIT:=ON}
-: ${ARROW_S3:=ON}
-: ${ARROW_TENSORFLOW:=ON}
-: ${ARROW_WITH_BROTLI:=ON}
-: ${ARROW_WITH_BZ2:=ON}
-: ${ARROW_WITH_LZ4:=ON}
-: ${ARROW_WITH_OPENTELEMETRY:=ON}
-: ${ARROW_WITH_SNAPPY:=ON}
-: ${ARROW_WITH_ZLIB:=ON}
-: ${ARROW_WITH_ZSTD:=ON}
-: ${CMAKE_BUILD_TYPE:=release}
-: ${CMAKE_GENERATOR:=Ninja}
-: ${CMAKE_UNITY_BUILD:=ON}
-: ${VCPKG_ROOT:=/opt/vcpkg}
-: ${VCPKG_FEATURE_FLAGS:=-manifests}
-: ${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-osx-static-${CMAKE_BUILD_TYPE}}}
+: "${ARROW_ACERO:=ON}"
+: "${ARROW_AZURE:=ON}"
+: "${ARROW_DATASET:=ON}"
+: "${ARROW_FLIGHT:=ON}"
+: "${ARROW_GANDIVA:=OFF}"
+: "${ARROW_GCS:=ON}"
+: "${ARROW_HDFS:=ON}"
+: "${ARROW_JEMALLOC:=ON}"
+: "${ARROW_MIMALLOC:=ON}"
+: "${ARROW_ORC:=ON}"
+: "${ARROW_PARQUET:=ON}"
+: "${PARQUET_REQUIRE_ENCRYPTION:=ON}"
+: "${ARROW_SUBSTRAIT:=ON}"
+: "${ARROW_S3:=ON}"
+: "${ARROW_TENSORFLOW:=ON}"
+: "${ARROW_WITH_BROTLI:=ON}"
+: "${ARROW_WITH_BZ2:=ON}"
+: "${ARROW_WITH_LZ4:=ON}"
+: "${ARROW_WITH_OPENTELEMETRY:=ON}"
+: "${ARROW_WITH_SNAPPY:=ON}"
+: "${ARROW_WITH_ZLIB:=ON}"
+: "${ARROW_WITH_ZSTD:=ON}"
+: "${CMAKE_BUILD_TYPE:=release}"
+: "${CMAKE_GENERATOR:=Ninja}"
+: "${CMAKE_UNITY_BUILD:=ON}"
+: "${VCPKG_ROOT:=/opt/vcpkg}"
+: "${VCPKG_FEATURE_FLAGS:=-manifests}"
+: "${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-osx-static-${CMAKE_BUILD_TYPE}}}"
 
 echo "=== Protobuf compiler versions on PATH ==="
 which -a protoc || echo "no protoc on PATH!"
 
 echo "=== Protobuf compiler version from vcpkg ==="
-_pbc=${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/tools/protobuf/protoc
-echo "$_pbc: `$_pbc --version`"
+_pbc="${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/tools/protobuf/protoc"
+echo "$_pbc: $( $_pbc --version)"
 
-mkdir -p ${build_dir}/build
-pushd ${build_dir}/build
+mkdir -p "${build_dir}/build"
+pushd "${build_dir}/build"
 
 cmake \
-    -DARROW_ACERO=${ARROW_ACERO} \
-    -DARROW_AZURE=${ARROW_AZURE} \
+    -DARROW_ACERO="${ARROW_ACERO}" \
+    -DARROW_AZURE="${ARROW_AZURE}" \
     -DARROW_BUILD_SHARED=ON \
     -DARROW_BUILD_STATIC=OFF \
     -DARROW_BUILD_TESTS=OFF \
     -DARROW_COMPUTE=ON \
     -DARROW_CSV=ON \
-    -DARROW_DATASET=${ARROW_DATASET} \
+    -DARROW_DATASET="${ARROW_DATASET}" \
     -DARROW_DEPENDENCY_SOURCE="VCPKG" \
     -DARROW_DEPENDENCY_USE_SHARED=OFF \
     -DARROW_FILESYSTEM=ON \
-    -DARROW_FLIGHT=${ARROW_FLIGHT} \
-    -DARROW_GANDIVA=${ARROW_GANDIVA} \
-    -DARROW_GCS=${ARROW_GCS} \
-    -DARROW_HDFS=${ARROW_HDFS} \
-    -DARROW_JEMALLOC=${ARROW_JEMALLOC} \
+    -DARROW_FLIGHT="${ARROW_FLIGHT}" \
+    -DARROW_GANDIVA="${ARROW_GANDIVA}" \
+    -DARROW_GCS="${ARROW_GCS}" \
+    -DARROW_HDFS="${ARROW_HDFS}" \
+    -DARROW_JEMALLOC="${ARROW_JEMALLOC}" \
     -DARROW_JSON=ON \
-    -DARROW_MIMALLOC=${ARROW_MIMALLOC} \
-    -DARROW_ORC=${ARROW_ORC} \
+    -DARROW_MIMALLOC="${ARROW_MIMALLOC}" \
+    -DARROW_ORC="${ARROW_ORC}" \
     -DARROW_PACKAGE_KIND="python-wheel-macos" \
-    -DARROW_PARQUET=${ARROW_PARQUET} \
+    -DARROW_PARQUET="${ARROW_PARQUET}" \
     -DARROW_RPATH_ORIGIN=ON \
-    -DARROW_S3=${ARROW_S3} \
-    -DARROW_SIMD_LEVEL=${ARROW_SIMD_LEVEL} \
-    -DARROW_SUBSTRAIT=${ARROW_SUBSTRAIT} \
-    -DARROW_TENSORFLOW=${ARROW_TENSORFLOW} \
+    -DARROW_S3="${ARROW_S3}" \
+    -DARROW_SIMD_LEVEL="${ARROW_SIMD_LEVEL}" \
+    -DARROW_SUBSTRAIT="${ARROW_SUBSTRAIT}" \
+    -DARROW_TENSORFLOW="${ARROW_TENSORFLOW}" \
     -DARROW_USE_CCACHE=ON \
     -DARROW_VERBOSE_THIRDPARTY_BUILD=ON \
-    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI} \
-    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2} \
-    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4} \
-    -DARROW_WITH_OPENTELEMETRY=${ARROW_WITH_OPENTELEMETRY} \
-    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY} \
-    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB} \
-    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD} \
+    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI}" \
+    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2}" \
+    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4}" \
+    -DARROW_WITH_OPENTELEMETRY="${ARROW_WITH_OPENTELEMETRY}" \
+    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY}" \
+    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB}" \
+    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD}" \
     -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 \
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
-    -DCMAKE_INSTALL_PREFIX=${build_dir}/install \
-    -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} \
-    -DPARQUET_REQUIRE_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION} \
+    -DCMAKE_INSTALL_PREFIX="${build_dir}/install" \
+    -DCMAKE_OSX_ARCHITECTURES="${CMAKE_OSX_ARCHITECTURES}" \
+    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD}" \
+    -DPARQUET_REQUIRE_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION}" \
     -DVCPKG_MANIFEST_MODE=OFF \
-    -DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET} \
+    -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \
     -Dxsimd_SOURCE=BUNDLED \
-    -G ${CMAKE_GENERATOR} \
-    ${source_dir}/cpp
+    -G "${CMAKE_GENERATOR}" \
+    "${source_dir}/cpp"
 cmake --build . --target install
 popd
 
@@ -150,40 +150,40 @@ echo "=== (${PYTHON_VERSION}) Building wheel ==="
 export PYARROW_BUNDLE_ARROW_CPP=ON
 # TODO(GH-32609): Re-enable when pyarrow-stubs are shipped in wheels again.
 # export PYARROW_REQUIRE_STUB_DOCSTRINGS=ON
-export PYARROW_WITH_ACERO=${ARROW_ACERO}
-export PYARROW_WITH_AZURE=${ARROW_AZURE}
-export PYARROW_WITH_DATASET=${ARROW_DATASET}
-export PYARROW_WITH_FLIGHT=${ARROW_FLIGHT}
-export PYARROW_WITH_GANDIVA=${ARROW_GANDIVA}
-export PYARROW_WITH_GCS=${ARROW_GCS}
-export PYARROW_WITH_HDFS=${ARROW_HDFS}
-export PYARROW_WITH_ORC=${ARROW_ORC}
-export PYARROW_WITH_PARQUET=${ARROW_PARQUET}
-export PYARROW_WITH_PARQUET_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION}
-export PYARROW_WITH_SUBSTRAIT=${ARROW_SUBSTRAIT}
-export PYARROW_WITH_S3=${ARROW_S3}
-export ARROW_HOME=${build_dir}/install
+export PYARROW_WITH_ACERO="${ARROW_ACERO}"
+export PYARROW_WITH_AZURE="${ARROW_AZURE}"
+export PYARROW_WITH_DATASET="${ARROW_DATASET}"
+export PYARROW_WITH_FLIGHT="${ARROW_FLIGHT}"
+export PYARROW_WITH_GANDIVA="${ARROW_GANDIVA}"
+export PYARROW_WITH_GCS="${ARROW_GCS}"
+export PYARROW_WITH_HDFS="${ARROW_HDFS}"
+export PYARROW_WITH_ORC="${ARROW_ORC}"
+export PYARROW_WITH_PARQUET="${ARROW_PARQUET}"
+export PYARROW_WITH_PARQUET_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION}"
+export PYARROW_WITH_SUBSTRAIT="${ARROW_SUBSTRAIT}"
+export PYARROW_WITH_S3="${ARROW_S3}"
+export ARROW_HOME="${build_dir}/install"
 # PyArrow build configuration
-export CMAKE_PREFIX_PATH=${build_dir}/install
+export CMAKE_PREFIX_PATH="${build_dir}/install"
 # Set PyArrow version explicitly
-export SETUPTOOLS_SCM_PRETEND_VERSION=${PYARROW_VERSION}
+export SETUPTOOLS_SCM_PRETEND_VERSION="${PYARROW_VERSION}"
 
-pushd ${source_dir}/python
+pushd "${source_dir}/python"
 python -m build --sdist --wheel . --no-isolation \
   -C build.verbose=true \
-  -C cmake.build-type=${CMAKE_BUILD_TYPE:-Debug} \
+  -C cmake.build-type="${CMAKE_BUILD_TYPE:-Debug}" \
   -C cmake.args="-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}" \
   -C cmake.args="-DARROW_SIMD_LEVEL=${ARROW_SIMD_LEVEL}"
 popd
 
 echo "=== (${PYTHON_VERSION}) Show dynamic libraries the wheel depend on ==="
-deps=$(delocate-listdeps ${source_dir}/python/dist/*.whl)
+deps=$(delocate-listdeps "${source_dir}"/python/dist/*.whl)
 
-if echo $deps | grep -v "^pyarrow/lib\(arrow\|gandiva\|parquet\)"; then
+if echo "$deps" | grep -v "^pyarrow/lib\(arrow\|gandiva\|parquet\)"; then
   echo "There are non-bundled shared library dependencies."
   exit 1
 fi
 
 # Move the verified wheels
-mkdir -p ${source_dir}/python/repaired_wheels
-mv ${source_dir}/python/dist/*.whl ${source_dir}/python/repaired_wheels/
+mkdir -p "${source_dir}/python/repaired_wheels"
+mv "${source_dir}"/python/dist/*.whl "${source_dir}"/python/repaired_wheels/


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2086: Double quote to prevent globbing and word splitting.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.
* SC2006: Use `$(...)` notation instead of legacy backticked ``...``.

```
shellcheck ci/scripts/python_wheel_macos_build.sh

In ci/scripts/python_wheel_macos_build.sh line 28:
rm -rf ${build_dir}/build
       ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${build_dir}"/build


In ci/scripts/python_wheel_macos_build.sh line 29:
rm -rf ${build_dir}/install
       ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${build_dir}"/install


In ci/scripts/python_wheel_macos_build.sh line 30:
rm -rf ${source_dir}/python/dist
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${source_dir}"/python/dist


In ci/scripts/python_wheel_macos_build.sh line 31:
rm -rf ${source_dir}/python/build
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${source_dir}"/python/build


In ci/scripts/python_wheel_macos_build.sh line 32:
rm -rf ${source_dir}/python/pyarrow/*.so
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${source_dir}"/python/pyarrow/*.so


In ci/scripts/python_wheel_macos_build.sh line 33:
rm -rf ${source_dir}/python/pyarrow/*.so.*
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${source_dir}"/python/pyarrow/*.so.*


In ci/scripts/python_wheel_macos_build.sh line 40:
if [ $arch = "arm64" ]; then
     ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "$arch" = "arm64" ]; then


In ci/scripts/python_wheel_macos_build.sh line 42:
  : ${ARROW_SIMD_LEVEL:="NEON"}
    ^-------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 43:
elif [ $arch = "x86_64" ]; then
       ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
elif [ "$arch" = "x86_64" ]; then


In ci/scripts/python_wheel_macos_build.sh line 45:
  : ${ARROW_SIMD_LEVEL:="SSE4_2"}
    ^---------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 55:
  -r ${source_dir}/python/requirements-wheel-build.txt
     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  -r "${source_dir}"/python/requirements-wheel-build.txt


In ci/scripts/python_wheel_macos_build.sh line 59:
: ${ARROW_ACERO:=ON}
  ^----------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 60:
: ${ARROW_AZURE:=ON}
  ^----------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 61:
: ${ARROW_DATASET:=ON}
  ^------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 62:
: ${ARROW_FLIGHT:=ON}
  ^-----------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 63:
: ${ARROW_GANDIVA:=OFF}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 64:
: ${ARROW_GCS:=ON}
  ^--------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 65:
: ${ARROW_HDFS:=ON}
  ^---------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 66:
: ${ARROW_JEMALLOC:=ON}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 67:
: ${ARROW_MIMALLOC:=ON}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 68:
: ${ARROW_ORC:=ON}
  ^--------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 69:
: ${ARROW_PARQUET:=ON}
  ^------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 70:
: ${PARQUET_REQUIRE_ENCRYPTION:=ON}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 71:
: ${ARROW_SUBSTRAIT:=ON}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 72:
: ${ARROW_S3:=ON}
  ^-------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 73:
: ${ARROW_TENSORFLOW:=ON}
  ^---------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 74:
: ${ARROW_WITH_BROTLI:=ON}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 75:
: ${ARROW_WITH_BZ2:=ON}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 76:
: ${ARROW_WITH_LZ4:=ON}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 77:
: ${ARROW_WITH_OPENTELEMETRY:=ON}
  ^-----------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 78:
: ${ARROW_WITH_SNAPPY:=ON}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 79:
: ${ARROW_WITH_ZLIB:=ON}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 80:
: ${ARROW_WITH_ZSTD:=ON}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 81:
: ${CMAKE_BUILD_TYPE:=release}
  ^--------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 82:
: ${CMAKE_GENERATOR:=Ninja}
  ^-----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 83:
: ${CMAKE_UNITY_BUILD:=ON}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 84:
: ${VCPKG_ROOT:=/opt/vcpkg}
  ^-----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 85:
: ${VCPKG_FEATURE_FLAGS:=-manifests}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 86:
: ${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-osx-static-${CMAKE_BUILD_TYPE}}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_macos_build.sh line 93:
echo "$_pbc: `$_pbc --version`"
             ^---------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
echo "$_pbc: $($_pbc --version)"


In ci/scripts/python_wheel_macos_build.sh line 95:
mkdir -p ${build_dir}/build
         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "${build_dir}"/build


In ci/scripts/python_wheel_macos_build.sh line 96:
pushd ${build_dir}/build
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${build_dir}"/build


In ci/scripts/python_wheel_macos_build.sh line 99:
    -DARROW_ACERO=${ARROW_ACERO} \
                  ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_ACERO="${ARROW_ACERO}" \


In ci/scripts/python_wheel_macos_build.sh line 100:
    -DARROW_AZURE=${ARROW_AZURE} \
                  ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_AZURE="${ARROW_AZURE}" \


In ci/scripts/python_wheel_macos_build.sh line 106:
    -DARROW_DATASET=${ARROW_DATASET} \
                    ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_DATASET="${ARROW_DATASET}" \


In ci/scripts/python_wheel_macos_build.sh line 110:
    -DARROW_FLIGHT=${ARROW_FLIGHT} \
                   ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_FLIGHT="${ARROW_FLIGHT}" \


In ci/scripts/python_wheel_macos_build.sh line 111:
    -DARROW_GANDIVA=${ARROW_GANDIVA} \
                    ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_GANDIVA="${ARROW_GANDIVA}" \


In ci/scripts/python_wheel_macos_build.sh line 112:
    -DARROW_GCS=${ARROW_GCS} \
                ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_GCS="${ARROW_GCS}" \


In ci/scripts/python_wheel_macos_build.sh line 113:
    -DARROW_HDFS=${ARROW_HDFS} \
                 ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_HDFS="${ARROW_HDFS}" \


In ci/scripts/python_wheel_macos_build.sh line 114:
    -DARROW_JEMALLOC=${ARROW_JEMALLOC} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_JEMALLOC="${ARROW_JEMALLOC}" \


In ci/scripts/python_wheel_macos_build.sh line 116:
    -DARROW_MIMALLOC=${ARROW_MIMALLOC} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_MIMALLOC="${ARROW_MIMALLOC}" \


In ci/scripts/python_wheel_macos_build.sh line 117:
    -DARROW_ORC=${ARROW_ORC} \
                ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_ORC="${ARROW_ORC}" \


In ci/scripts/python_wheel_macos_build.sh line 119:
    -DARROW_PARQUET=${ARROW_PARQUET} \
                    ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_PARQUET="${ARROW_PARQUET}" \


In ci/scripts/python_wheel_macos_build.sh line 121:
    -DARROW_S3=${ARROW_S3} \
               ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_S3="${ARROW_S3}" \


In ci/scripts/python_wheel_macos_build.sh line 122:
    -DARROW_SIMD_LEVEL=${ARROW_SIMD_LEVEL} \
                       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_SIMD_LEVEL="${ARROW_SIMD_LEVEL}" \


In ci/scripts/python_wheel_macos_build.sh line 123:
    -DARROW_SUBSTRAIT=${ARROW_SUBSTRAIT} \
                      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_SUBSTRAIT="${ARROW_SUBSTRAIT}" \


In ci/scripts/python_wheel_macos_build.sh line 124:
    -DARROW_TENSORFLOW=${ARROW_TENSORFLOW} \
                       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_TENSORFLOW="${ARROW_TENSORFLOW}" \


In ci/scripts/python_wheel_macos_build.sh line 127:
    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI} \
                        ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI}" \


In ci/scripts/python_wheel_macos_build.sh line 128:
    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2}" \


In ci/scripts/python_wheel_macos_build.sh line 129:
    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4}" \


In ci/scripts/python_wheel_macos_build.sh line 130:
    -DARROW_WITH_OPENTELEMETRY=${ARROW_WITH_OPENTELEMETRY} \
                               ^-------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_OPENTELEMETRY="${ARROW_WITH_OPENTELEMETRY}" \


In ci/scripts/python_wheel_macos_build.sh line 131:
    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY} \
                        ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY}" \


In ci/scripts/python_wheel_macos_build.sh line 132:
    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB} \
                      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB}" \


In ci/scripts/python_wheel_macos_build.sh line 133:
    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD} \
                      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD}" \


In ci/scripts/python_wheel_macos_build.sh line 135:
    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
                       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \


In ci/scripts/python_wheel_macos_build.sh line 137:
    -DCMAKE_INSTALL_PREFIX=${build_dir}/install \
                           ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_INSTALL_PREFIX="${build_dir}"/install \


In ci/scripts/python_wheel_macos_build.sh line 139:
    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} \
                        ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD}" \


In ci/scripts/python_wheel_macos_build.sh line 140:
    -DPARQUET_REQUIRE_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION} \
                                 ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DPARQUET_REQUIRE_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION}" \


In ci/scripts/python_wheel_macos_build.sh line 142:
    -DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET} \
                           ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \


In ci/scripts/python_wheel_macos_build.sh line 144:
    -G ${CMAKE_GENERATOR} \
       ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -G "${CMAKE_GENERATOR}" \


In ci/scripts/python_wheel_macos_build.sh line 145:
    ${source_dir}/cpp
    ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${source_dir}"/cpp


In ci/scripts/python_wheel_macos_build.sh line 171:
pushd ${source_dir}/python
      ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${source_dir}"/python


In ci/scripts/python_wheel_macos_build.sh line 174:
  -C cmake.build-type=${CMAKE_BUILD_TYPE:-Debug} \
                      ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  -C cmake.build-type="${CMAKE_BUILD_TYPE:-Debug}" \


In ci/scripts/python_wheel_macos_build.sh line 180:
deps=$(delocate-listdeps ${source_dir}/python/dist/*.whl)
                         ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
deps=$(delocate-listdeps "${source_dir}"/python/dist/*.whl)


In ci/scripts/python_wheel_macos_build.sh line 182:
if echo $deps | grep -v "^pyarrow/lib\(arrow\|gandiva\|parquet\)"; then
        ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if echo "$deps" | grep -v "^pyarrow/lib\(arrow\|gandiva\|parquet\)"; then


In ci/scripts/python_wheel_macos_build.sh line 188:
mkdir -p ${source_dir}/python/repaired_wheels
         ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "${source_dir}"/python/repaired_wheels


In ci/scripts/python_wheel_macos_build.sh line 189:
mv ${source_dir}/python/dist/*.whl ${source_dir}/python/repaired_wheels/
   ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                   ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "${source_dir}"/python/dist/*.whl "${source_dir}"/python/repaired_wheels/

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```  

### What changes are included in this PR?

* SC2086: Quote variable expansions
* SC2223: Simplify default assignment
* SC2006: Replace backticks with `$(...)`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50551