### PR TITLE
GH-50553: [Dev] Clarify invalid PR title guidance comment

### DIFF
--- a/.github/workflows/dev_pr/title_check.md
+++ b/.github/workflows/dev_pr/title_check.md
@@ -19,6 +19,8 @@
 
 Thanks for opening a pull request!
 
+**This pull request has been automatically converted to a draft because its title doesn't match Arrow's required format.**
+
 If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose
 
 Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.
@@ -30,6 +32,8 @@ Then could you also rename the pull request title in the following format?
 or
 
     MINOR: [${COMPONENT}] ${SUMMARY}
+
+**After updating the title, you can mark the pull request as ready for review.**
 
 See also:
 


### PR DESCRIPTION
### Rationale for this change

The developer PR workflow automatically converts pull requests with invalid titles to drafts and posts a guidance comment. The current comment explains the required title format, but it doesn't explicitly state why the pull request was converted to a draft or that contributors should mark it as ready for review after fixing the title.

This change makes those steps clearer to contributors.

### What changes are included in this PR?

- Explain that the pull request was automatically converted to a draft because its title doesn't match the required format.
- Instruct contributors to mark the pull request as ready for review after updating the title.

* GitHub Issue: #50553