### PR TITLE
GH-50573: [CI][C++] Remove brew workaround for aws-sdk-cpp

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -244,11 +244,6 @@ jobs:
           # Workaround for https://github.com/grpc/grpc/issues/41755
           # Remove once the runner ships a newer Homebrew.
           brew update
-          # Install aws-sdk-cpp manually to avoid issues with the new default
-          # `brew --jobs auto` causing a lock.
-          # Remove once the upstream issue is solved:
-          # https://github.com/Homebrew/brew/issues/22899
-          brew install aws-sdk-cpp
           brew bundle --file=cpp/Brewfile
       - name: Install MinIO
         run: |

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -278,11 +278,6 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: |
-          # Install aws-sdk-cpp manually to avoid issues with the new default
-          # `brew --jobs auto` causing a lock.
-          # Remove once the upstream issue is solved:
-          # https://github.com/Homebrew/brew/issues/22899
-          brew install aws-sdk-cpp
           brew bundle --file=cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have
@@ -453,11 +448,6 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         run: |
-          # Install aws-sdk-cpp manually to avoid issues with the new default
-          # `brew --jobs auto` causing a lock.
-          # Remove once the upstream issue is solved:
-          # https://github.com/Homebrew/brew/issues/22899
-          brew install aws-sdk-cpp
           brew bundle --file=cpp/Brewfile
 
           # We want to use bundled RE2 for static linking. If

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -203,11 +203,6 @@ jobs:
           # Workaround for https://github.com/grpc/grpc/issues/41755
           # Remove once the runner ships a newer Homebrew.
           brew update
-          # Install aws-sdk-cpp manually to avoid issues with the new default
-          # `brew --jobs auto` causing a lock.
-          # Remove once the upstream issue is solved:
-          # https://github.com/Homebrew/brew/issues/22899
-          brew install aws-sdk-cpp
           brew bundle --file=cpp/Brewfile
           python -m pip install \
             -r python/requirements-build.txt \

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -171,11 +171,6 @@ jobs:
           # We can remove this once GitHub hosted runners include
           # Meson 1.8.4 or later by default.
           brew update
-          # Install aws-sdk-cpp manually to avoid issues with the new default
-          # `brew --jobs auto` causing a lock.
-          # Remove once the upstream issue is solved:
-          # https://github.com/Homebrew/brew/issues/22899
-          brew install aws-sdk-cpp
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile
           # For Meson.

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -45,11 +45,6 @@ jobs:
           # Workaround for https://github.com/grpc/grpc/issues/41755
           # Remove once the runner ships a newer Homebrew.
           brew update
-          # Install aws-sdk-cpp manually to avoid issues with the new default
-          # `brew --jobs auto` causing a lock.
-          # Remove once the upstream issue is solved:
-          # https://github.com/Homebrew/brew/issues/22899
-          brew install aws-sdk-cpp
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile
 


### PR DESCRIPTION
### Rationale for this change

In https://github.com/apache/arrow/pull/50254 we introduced an explicit `brew install aws-sdk-cpp` step in order to workaround a [bug in brew](https://github.com/Homebrew/brew/issues/22899). However, the latter bug has since been fixed and we can now remove the workaround.

### Are these changes tested?

By existing CI jobs.

### Are there any user-facing changes?

No.

* GitHub Issue: #50573