### PR TITLE
GH-49384: [Python] Respect copy=True in ChunkedArray.__array__

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -556,7 +556,7 @@ cdef class ChunkedArray(_PandasConvertible):
                 "`np.asarray(obj)` to allow a copy when needed"
             )
         # 'copy' can further be ignored because to_numpy() already returns a copy
-        values = self.to_numpy()
+        values = self.to_numpy().copy()
         if dtype is None:
             return values
         return values.astype(dtype, copy=False)


### PR DESCRIPTION
Closes #49384.

This rework makes `ChunkedArray.__array__(copy=True)` return a real NumPy copy. In single-chunk cases the previous path could return a read-only zero-copy view.

- Make `to_numpy()` result explicitly copied before return
- Keep `copy=False` behavior unchanged (still raises ValueError)

* GitHub Issue: #49384