### PR TITLE
GH-49384: [Python] Respect copy=True in ChunkedArray.__array__

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -555,8 +555,9 @@ cdef class ChunkedArray(_PandasConvertible):
                 "If using `np.array(obj, copy=False)` replace it with "
                 "`np.asarray(obj)` to allow a copy when needed"
             )
-        # 'copy' can further be ignored because to_numpy() already returns a copy
-        values = self.to_numpy().copy()
+        values = self.to_numpy()
+        if copy is True:
+            return np.array(values, dtype=dtype, copy=True)
         if dtype is None:
             return values
         return values.astype(dtype, copy=False)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -556,7 +556,7 @@ cdef class ChunkedArray(_PandasConvertible):
                 "`np.asarray(obj)` to allow a copy when needed"
             )
         # 'copy' can further be ignored because to_numpy() already returns a copy
-        values = self.to_numpy()
+        values = self.to_numpy().copy()
         if dtype is None:
             return values
         return values.astype(dtype, copy=False)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -144,6 +144,16 @@ def test_chunked_array_to_numpy():
     assert np.array_equal(arr1, arr2)
 
 
+@pytest.mark.numpy
+def test_chunked_array_array_copy_true_is_writable():
+    data = pa.chunked_array([[1, 2, 3]])
+    result = data.__array__(copy=True)
+
+    assert result.flags.writeable
+    result[0] = 99
+    assert result.tolist() == [99, 2, 3]
+
+
 def test_chunked_array_mismatch_types():
     msg = "chunks must all be same type"
     with pytest.raises(TypeError, match=msg):


### PR DESCRIPTION
### Rationale for this change

`ChunkedArray.__array__(copy=True)` should respect NumPy's copy request. For a single-chunk `ChunkedArray`, the current path can return a zero-copy read-only NumPy view instead.

Closes #49384.

### What changes are included in this PR?

- Make `ChunkedArray.__array__(copy=True)` return a real NumPy copy.
- Add a regression test for the single-chunk case.

### Are these changes tested?

Yes:

```bash
python -m pytest python/pyarrow/tests/test_table.py -q
```

### Are there any user-facing changes?

Yes. `np.array(pa.chunked_array([[...]]), copy=True)` now returns a writable copied NumPy array, matching the behavior users expect from `copy=True`.

### AI assistance

I used an AI coding assistant while preparing this patch. I reviewed the change myself, kept it scoped to `ChunkedArray.__array__`, and verified it with the focused PyArrow table tests above.

* GitHub Issue: #49384