### PR TITLE
GH-50575: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_wheel_xlinux_build.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -336,6 +336,7 @@ repos:
           ?^ci/scripts/python_test_type_annotations\.sh$|
           ?^ci/scripts/python_test\.sh$|
           ?^ci/scripts/python_wheel_macos_build\.sh$|
+          ?^ci/scripts/python_wheel_xlinux_build\.sh$|
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -84,12 +84,12 @@ echo "=== (${PYTHON_VERSION}) Building Arrow C++ libraries ==="
 : "${VCPKG_FEATURE_FLAGS:=-manifests}"
 : "${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-linux-static-${CMAKE_BUILD_TYPE}}}"
 
-ARROW_EXTRA_CMAKE_FLAGS_ARRAY=()
+ARROW_EXTRA_CMAKE_FLAGS=()
 if [[ "$(uname -m)" == arm* ]] || [[ "$(uname -m)" == aarch* ]]; then
     # Build jemalloc --with-lg-page=16 in order to make the wheel work on both
     # 4k and 64k page arm64 systems. For more context see
     # https://github.com/apache/arrow/issues/10929
-    ARROW_EXTRA_CMAKE_FLAGS_ARRAY+=("-DARROW_JEMALLOC_LG_PAGE=16")
+    ARROW_EXTRA_CMAKE_FLAGS+=("-DARROW_JEMALLOC_LG_PAGE=16")
     : "${ARROW_JEMALLOC:=OFF}"
 else
     : "${ARROW_JEMALLOC:=ON}"
@@ -148,7 +148,7 @@ cmake \
     -DVCPKG_MANIFEST_MODE=OFF \
     -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \
     -Dxsimd_SOURCE=BUNDLED \
-    "${ARROW_EXTRA_CMAKE_FLAGS_ARRAY[@]}" \
+    "${ARROW_EXTRA_CMAKE_FLAGS[@]}" \
     -G "${CMAKE_GENERATOR}" \
     /arrow/cpp
 cmake --build . --target install

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -33,7 +33,7 @@ function check_arrow_visibility {
     fi
     grep ' T ' nm_arrow.log | grep -v -E "${allowed_symbols}" | cat - > visible_symbols.log
 
-    if [[ -f visible_symbols.log && `cat visible_symbols.log | wc -l` -eq 0 ]]; then
+    if [[ -f visible_symbols.log && $(cat visible_symbols.log | wc -l) -eq 0 ]]; then
         return 0
     else
         echo "== Unexpected symbols exported by libarrow.so =="
@@ -54,100 +54,100 @@ rm -rf /arrow/python/pyarrow/*.so
 rm -rf /arrow/python/pyarrow/*.so.*
 
 echo "=== (${PYTHON_VERSION}) Building Arrow C++ libraries ==="
-: ${ARROW_ACERO:=ON}
-: ${ARROW_AZURE:=ON}
-: ${ARROW_DATASET:=ON}
-: ${ARROW_FLIGHT:=ON}
-: ${ARROW_GANDIVA:=OFF}
-: ${ARROW_GCS:=ON}
-: ${ARROW_HDFS:=ON}
-: ${ARROW_MIMALLOC:=ON}
-: ${ARROW_ORC:=ON}
-: ${ARROW_PARQUET:=ON}
-: ${PARQUET_REQUIRE_ENCRYPTION:=ON}
-: ${ARROW_SUBSTRAIT:=ON}
-: ${ARROW_S3:=ON}
-: ${ARROW_TENSORFLOW:=ON}
-: ${ARROW_USE_MOLD:=OFF}
-: ${ARROW_WITH_BROTLI:=ON}
-: ${ARROW_WITH_BZ2:=ON}
-: ${ARROW_WITH_LZ4:=ON}
-: ${ARROW_WITH_OPENTELEMETRY:=ON}
-: ${ARROW_WITH_SNAPPY:=ON}
-: ${ARROW_WITH_ZLIB:=ON}
-: ${ARROW_WITH_ZSTD:=ON}
-: ${CMAKE_BUILD_TYPE:=release}
-: ${CMAKE_UNITY_BUILD:=ON}
-: ${CMAKE_GENERATOR:=Ninja}
-: ${VCPKG_ROOT:=/opt/vcpkg}
-: ${VCPKG_FEATURE_FLAGS:=-manifests}
-: ${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-linux-static-${CMAKE_BUILD_TYPE}}}
+: "${ARROW_ACERO:=ON}"
+: "${ARROW_AZURE:=ON}"
+: "${ARROW_DATASET:=ON}"
+: "${ARROW_FLIGHT:=ON}"
+: "${ARROW_GANDIVA:=OFF}"
+: "${ARROW_GCS:=ON}"
+: "${ARROW_HDFS:=ON}"
+: "${ARROW_MIMALLOC:=ON}"
+: "${ARROW_ORC:=ON}"
+: "${ARROW_PARQUET:=ON}"
+: "${PARQUET_REQUIRE_ENCRYPTION:=ON}"
+: "${ARROW_SUBSTRAIT:=ON}"
+: "${ARROW_S3:=ON}"
+: "${ARROW_TENSORFLOW:=ON}"
+: "${ARROW_USE_MOLD:=OFF}"
+: "${ARROW_WITH_BROTLI:=ON}"
+: "${ARROW_WITH_BZ2:=ON}"
+: "${ARROW_WITH_LZ4:=ON}"
+: "${ARROW_WITH_OPENTELEMETRY:=ON}"
+: "${ARROW_WITH_SNAPPY:=ON}"
+: "${ARROW_WITH_ZLIB:=ON}"
+: "${ARROW_WITH_ZSTD:=ON}"
+: "${CMAKE_BUILD_TYPE:=release}"
+: "${CMAKE_UNITY_BUILD:=ON}"
+: "${CMAKE_GENERATOR:=Ninja}"
+: "${VCPKG_ROOT:=/opt/vcpkg}"
+: "${VCPKG_FEATURE_FLAGS:=-manifests}"
+: "${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-linux-static-${CMAKE_BUILD_TYPE}}}"
 
 if [[ "$(uname -m)" == arm* ]] || [[ "$(uname -m)" == aarch* ]]; then
     # Build jemalloc --with-lg-page=16 in order to make the wheel work on both
     # 4k and 64k page arm64 systems. For more context see
     # https://github.com/apache/arrow/issues/10929
     export ARROW_EXTRA_CMAKE_FLAGS="-DARROW_JEMALLOC_LG_PAGE=16"
-    : ${ARROW_JEMALLOC:=OFF}
+    : "${ARROW_JEMALLOC:=OFF}"
 else
-    : ${ARROW_JEMALLOC:=ON}
+    : "${ARROW_JEMALLOC:=ON}"
 fi
 
 if [[ "${LINUX_WHEEL_KIND:-}" == "musllinux" ]]; then
-    : ${CMAKE_INTERPROCEDURAL_OPTIMIZATION:=OFF}
+    : "${CMAKE_INTERPROCEDURAL_OPTIMIZATION:=OFF}"
 else
-    : ${CMAKE_INTERPROCEDURAL_OPTIMIZATION:=ON}
+    : "${CMAKE_INTERPROCEDURAL_OPTIMIZATION:=ON}"
 fi
 
 mkdir /tmp/arrow-build
 pushd /tmp/arrow-build
 
 cmake \
-    -DARROW_ACERO=${ARROW_ACERO} \
-    -DARROW_AZURE=${ARROW_AZURE} \
+    -DARROW_ACERO="${ARROW_ACERO}" \
+    -DARROW_AZURE="${ARROW_AZURE}" \
     -DARROW_BUILD_SHARED=ON \
     -DARROW_BUILD_STATIC=OFF \
     -DARROW_BUILD_TESTS=OFF \
     -DARROW_COMPUTE=ON \
     -DARROW_CSV=ON \
-    -DARROW_DATASET=${ARROW_DATASET} \
+    -DARROW_DATASET="${ARROW_DATASET}" \
     -DARROW_DEPENDENCY_SOURCE="VCPKG" \
     -DARROW_DEPENDENCY_USE_SHARED=OFF \
     -DARROW_FILESYSTEM=ON \
-    -DARROW_FLIGHT=${ARROW_FLIGHT} \
-    -DARROW_GANDIVA=${ARROW_GANDIVA} \
-    -DARROW_GCS=${ARROW_GCS} \
-    -DARROW_HDFS=${ARROW_HDFS} \
-    -DARROW_JEMALLOC=${ARROW_JEMALLOC} \
+    -DARROW_FLIGHT="${ARROW_FLIGHT}" \
+    -DARROW_GANDIVA="${ARROW_GANDIVA}" \
+    -DARROW_GCS="${ARROW_GCS}" \
+    -DARROW_HDFS="${ARROW_HDFS}" \
+    -DARROW_JEMALLOC="${ARROW_JEMALLOC}" \
     -DARROW_JSON=ON \
-    -DARROW_MIMALLOC=${ARROW_MIMALLOC} \
-    -DARROW_ORC=${ARROW_ORC} \
+    -DARROW_MIMALLOC="${ARROW_MIMALLOC}" \
+    -DARROW_ORC="${ARROW_ORC}" \
     -DARROW_PACKAGE_KIND="python-wheel-${LINUX_WHEEL_KIND}${LINUX_WHEEL_VERSION}" \
-    -DARROW_PARQUET=${ARROW_PARQUET} \
+    -DARROW_PARQUET="${ARROW_PARQUET}" \
     -DARROW_RPATH_ORIGIN=ON \
-    -DARROW_S3=${ARROW_S3} \
-    -DARROW_SUBSTRAIT=${ARROW_SUBSTRAIT} \
-    -DARROW_TENSORFLOW=${ARROW_TENSORFLOW} \
+    -DARROW_S3="${ARROW_S3}" \
+    -DARROW_SUBSTRAIT="${ARROW_SUBSTRAIT}" \
+    -DARROW_TENSORFLOW="${ARROW_TENSORFLOW}" \
     -DARROW_USE_CCACHE=ON \
-    -DARROW_USE_MOLD=${ARROW_USE_MOLD} \
-    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI} \
-    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2} \
-    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4} \
-    -DARROW_WITH_OPENTELEMETRY=${ARROW_WITH_OPENTELEMETRY} \
-    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY} \
-    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB} \
-    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD} \
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    -DARROW_USE_MOLD="${ARROW_USE_MOLD}" \
+    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI}" \
+    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2}" \
+    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4}" \
+    -DARROW_WITH_OPENTELEMETRY="${ARROW_WITH_OPENTELEMETRY}" \
+    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY}" \
+    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB}" \
+    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD}" \
+    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX=/tmp/arrow-dist \
-    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${CMAKE_INTERPROCEDURAL_OPTIMIZATION} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} \
-    -DPARQUET_REQUIRE_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION} \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION="${CMAKE_INTERPROCEDURAL_OPTIMIZATION}" \
+    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD}" \
+    -DPARQUET_REQUIRE_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION}" \
     -DVCPKG_MANIFEST_MODE=OFF \
-    -DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET} \
+    -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \
     -Dxsimd_SOURCE=BUNDLED \
-    ${ARROW_EXTRA_CMAKE_FLAGS} \
-    -G ${CMAKE_GENERATOR} \
+    "${ARROW_EXTRA_CMAKE_FLAGS}" \
+    -G "${CMAKE_GENERATOR}" \
     /arrow/cpp
 cmake --build . --target install
 popd
@@ -159,18 +159,18 @@ echo "=== (${PYTHON_VERSION}) Building wheel ==="
 export PYARROW_BUNDLE_ARROW_CPP=ON
 # TODO(GH-32609): Re-enable when pyarrow-stubs are shipped in wheels again.
 # export PYARROW_REQUIRE_STUB_DOCSTRINGS=ON
-export PYARROW_WITH_ACERO=${ARROW_ACERO}
-export PYARROW_WITH_AZURE=${ARROW_AZURE}
-export PYARROW_WITH_DATASET=${ARROW_DATASET}
-export PYARROW_WITH_FLIGHT=${ARROW_FLIGHT}
-export PYARROW_WITH_GANDIVA=${ARROW_GANDIVA}
-export PYARROW_WITH_GCS=${ARROW_GCS}
-export PYARROW_WITH_HDFS=${ARROW_HDFS}
-export PYARROW_WITH_ORC=${ARROW_ORC}
-export PYARROW_WITH_PARQUET=${ARROW_PARQUET}
-export PYARROW_WITH_PARQUET_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION}
-export PYARROW_WITH_SUBSTRAIT=${ARROW_SUBSTRAIT}
-export PYARROW_WITH_S3=${ARROW_S3}
+export PYARROW_WITH_ACERO="${ARROW_ACERO}"
+export PYARROW_WITH_AZURE="${ARROW_AZURE}"
+export PYARROW_WITH_DATASET="${ARROW_DATASET}"
+export PYARROW_WITH_FLIGHT="${ARROW_FLIGHT}"
+export PYARROW_WITH_GANDIVA="${ARROW_GANDIVA}"
+export PYARROW_WITH_GCS="${ARROW_GCS}"
+export PYARROW_WITH_HDFS="${ARROW_HDFS}"
+export PYARROW_WITH_ORC="${ARROW_ORC}"
+export PYARROW_WITH_PARQUET="${ARROW_PARQUET}"
+export PYARROW_WITH_PARQUET_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION}"
+export PYARROW_WITH_SUBSTRAIT="${ARROW_SUBSTRAIT}"
+export PYARROW_WITH_S3="${ARROW_S3}"
 export ARROW_HOME=/tmp/arrow-dist
 # PyArrow build configuration
 export CMAKE_PREFIX_PATH=/tmp/arrow-dist
@@ -178,7 +178,7 @@ export CMAKE_PREFIX_PATH=/tmp/arrow-dist
 pushd /arrow/python
 python -m build --sdist --wheel . --no-isolation \
     -C build.verbose=true \
-    -C cmake.build-type=${CMAKE_BUILD_TYPE:-Debug} \
+    -C cmake.build-type="${CMAKE_BUILD_TYPE:-Debug}" \
     -C cmake.args="-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${CMAKE_INTERPROCEDURAL_OPTIMIZATION}"
 
 echo "=== Strip symbols from wheel ==="
@@ -188,15 +188,15 @@ mv dist/pyarrow-*.whl dist/temp-fix-wheel
 pushd dist/temp-fix-wheel
 wheel_name=$(ls pyarrow-*.whl)
 # Unzip and remove old wheel
-unzip $wheel_name
-rm $wheel_name
-for filename in $(ls pyarrow/*.so pyarrow/*.so.*); do
+unzip "$wheel_name"
+rm "$wheel_name"
+for filename in pyarrow/*.so pyarrow/*.so.*; do
     echo "Stripping debug symbols from: $filename";
-    strip --strip-debug $filename
+    strip --strip-debug "$filename"
 done
 # Zip wheel again after stripping symbols
-zip -r $wheel_name .
-mv $wheel_name ..
+zip -r "$wheel_name" .
+mv "$wheel_name" ..
 popd
 
 rm -rf dist/temp-fix-wheel

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -33,7 +33,8 @@ function check_arrow_visibility {
     fi
     grep ' T ' nm_arrow.log | grep -v -E "${allowed_symbols}" | cat - > visible_symbols.log
 
-    if [[ -f visible_symbols.log && $(wc -l visible_symbols.log) -eq 0 ]]; then
+    # Return early if the log file exists but is empty.
+    if [[ -f visible_symbols.log && ! -s visible_symbols.log ]]; then
         return 0
     else
         echo "== Unexpected symbols exported by libarrow.so =="
@@ -83,11 +84,12 @@ echo "=== (${PYTHON_VERSION}) Building Arrow C++ libraries ==="
 : "${VCPKG_FEATURE_FLAGS:=-manifests}"
 : "${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-linux-static-${CMAKE_BUILD_TYPE}}}"
 
+ARROW_EXTRA_CMAKE_FLAGS_ARRAY=()
 if [[ "$(uname -m)" == arm* ]] || [[ "$(uname -m)" == aarch* ]]; then
     # Build jemalloc --with-lg-page=16 in order to make the wheel work on both
     # 4k and 64k page arm64 systems. For more context see
     # https://github.com/apache/arrow/issues/10929
-    export ARROW_EXTRA_CMAKE_FLAGS="-DARROW_JEMALLOC_LG_PAGE=16"
+    ARROW_EXTRA_CMAKE_FLAGS_ARRAY+=("-DARROW_JEMALLOC_LG_PAGE=16")
     : "${ARROW_JEMALLOC:=OFF}"
 else
     : "${ARROW_JEMALLOC:=ON}"
@@ -146,7 +148,7 @@ cmake \
     -DVCPKG_MANIFEST_MODE=OFF \
     -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \
     -Dxsimd_SOURCE=BUNDLED \
-    "${ARROW_EXTRA_CMAKE_FLAGS}" \
+    "${ARROW_EXTRA_CMAKE_FLAGS_ARRAY[@]}" \
     -G "${CMAKE_GENERATOR}" \
     /arrow/cpp
 cmake --build . --target install

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -33,7 +33,7 @@ function check_arrow_visibility {
     fi
     grep ' T ' nm_arrow.log | grep -v -E "${allowed_symbols}" | cat - > visible_symbols.log
 
-    if [[ -f visible_symbols.log && $(cat visible_symbols.log | wc -l) -eq 0 ]]; then
+    if [[ -f visible_symbols.log && $(wc -l visible_symbols.log) -eq 0 ]]; then
         return 0
     else
         echo "== Unexpected symbols exported by libarrow.so =="


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2045: Use Bash file test operators instead of `ls`.
* SC2086: Double quote to prevent globbing and word splitting.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.


```
shellcheck ci/scripts/python_wheel_xlinux_build.sh

In ci/scripts/python_wheel_xlinux_build.sh line 36:
    if [[ -f visible_symbols.log && `cat visible_symbols.log | wc -l` -eq 0 ]]; then
                                    ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
    if [[ -f visible_symbols.log && $(cat visible_symbols.log | wc -l) -eq 0 ]]; then


In ci/scripts/python_wheel_xlinux_build.sh line 57:
: ${ARROW_ACERO:=ON}
  ^----------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 58:
: ${ARROW_AZURE:=ON}
  ^----------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 59:
: ${ARROW_DATASET:=ON}
  ^------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 60:
: ${ARROW_FLIGHT:=ON}
  ^-----------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 61:
: ${ARROW_GANDIVA:=OFF}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 62:
: ${ARROW_GCS:=ON}
  ^--------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 63:
: ${ARROW_HDFS:=ON}
  ^---------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 64:
: ${ARROW_MIMALLOC:=ON}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 65:
: ${ARROW_ORC:=ON}
  ^--------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 66:
: ${ARROW_PARQUET:=ON}
  ^------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 67:
: ${PARQUET_REQUIRE_ENCRYPTION:=ON}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 68:
: ${ARROW_SUBSTRAIT:=ON}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 69:
: ${ARROW_S3:=ON}
  ^-------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 70:
: ${ARROW_TENSORFLOW:=ON}
  ^---------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 71:
: ${ARROW_USE_MOLD:=OFF}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 72:
: ${ARROW_WITH_BROTLI:=ON}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 73:
: ${ARROW_WITH_BZ2:=ON}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 74:
: ${ARROW_WITH_LZ4:=ON}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 75:
: ${ARROW_WITH_OPENTELEMETRY:=ON}
  ^-----------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 76:
: ${ARROW_WITH_SNAPPY:=ON}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 77:
: ${ARROW_WITH_ZLIB:=ON}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 78:
: ${ARROW_WITH_ZSTD:=ON}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 79:
: ${CMAKE_BUILD_TYPE:=release}
  ^--------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 80:
: ${CMAKE_UNITY_BUILD:=ON}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 81:
: ${CMAKE_GENERATOR:=Ninja}
  ^-----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 82:
: ${VCPKG_ROOT:=/opt/vcpkg}
  ^-----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 83:
: ${VCPKG_FEATURE_FLAGS:=-manifests}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 84:
: ${VCPKG_TARGET_TRIPLET:=${VCPKG_DEFAULT_TRIPLET:-x64-linux-static-${CMAKE_BUILD_TYPE}}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 91:
    : ${ARROW_JEMALLOC:=OFF}
      ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 93:
    : ${ARROW_JEMALLOC:=ON}
      ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 97:
    : ${CMAKE_INTERPROCEDURAL_OPTIMIZATION:=OFF}
      ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 99:
    : ${CMAKE_INTERPROCEDURAL_OPTIMIZATION:=ON}
      ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_wheel_xlinux_build.sh line 106:
    -DARROW_ACERO=${ARROW_ACERO} \
                  ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_ACERO="${ARROW_ACERO}" \


In ci/scripts/python_wheel_xlinux_build.sh line 107:
    -DARROW_AZURE=${ARROW_AZURE} \
                  ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_AZURE="${ARROW_AZURE}" \


In ci/scripts/python_wheel_xlinux_build.sh line 113:
    -DARROW_DATASET=${ARROW_DATASET} \
                    ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_DATASET="${ARROW_DATASET}" \


In ci/scripts/python_wheel_xlinux_build.sh line 117:
    -DARROW_FLIGHT=${ARROW_FLIGHT} \
                   ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_FLIGHT="${ARROW_FLIGHT}" \


In ci/scripts/python_wheel_xlinux_build.sh line 118:
    -DARROW_GANDIVA=${ARROW_GANDIVA} \
                    ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_GANDIVA="${ARROW_GANDIVA}" \


In ci/scripts/python_wheel_xlinux_build.sh line 119:
    -DARROW_GCS=${ARROW_GCS} \
                ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_GCS="${ARROW_GCS}" \


In ci/scripts/python_wheel_xlinux_build.sh line 120:
    -DARROW_HDFS=${ARROW_HDFS} \
                 ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_HDFS="${ARROW_HDFS}" \


In ci/scripts/python_wheel_xlinux_build.sh line 121:
    -DARROW_JEMALLOC=${ARROW_JEMALLOC} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_JEMALLOC="${ARROW_JEMALLOC}" \


In ci/scripts/python_wheel_xlinux_build.sh line 123:
    -DARROW_MIMALLOC=${ARROW_MIMALLOC} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_MIMALLOC="${ARROW_MIMALLOC}" \


In ci/scripts/python_wheel_xlinux_build.sh line 124:
    -DARROW_ORC=${ARROW_ORC} \
                ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_ORC="${ARROW_ORC}" \


In ci/scripts/python_wheel_xlinux_build.sh line 126:
    -DARROW_PARQUET=${ARROW_PARQUET} \
                    ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_PARQUET="${ARROW_PARQUET}" \


In ci/scripts/python_wheel_xlinux_build.sh line 128:
    -DARROW_S3=${ARROW_S3} \
               ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_S3="${ARROW_S3}" \


In ci/scripts/python_wheel_xlinux_build.sh line 129:
    -DARROW_SUBSTRAIT=${ARROW_SUBSTRAIT} \
                      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_SUBSTRAIT="${ARROW_SUBSTRAIT}" \


In ci/scripts/python_wheel_xlinux_build.sh line 130:
    -DARROW_TENSORFLOW=${ARROW_TENSORFLOW} \
                       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_TENSORFLOW="${ARROW_TENSORFLOW}" \


In ci/scripts/python_wheel_xlinux_build.sh line 132:
    -DARROW_USE_MOLD=${ARROW_USE_MOLD} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_USE_MOLD="${ARROW_USE_MOLD}" \


In ci/scripts/python_wheel_xlinux_build.sh line 133:
    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI} \
                        ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI}" \


In ci/scripts/python_wheel_xlinux_build.sh line 134:
    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2}" \


In ci/scripts/python_wheel_xlinux_build.sh line 135:
    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4} \
                     ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4}" \


In ci/scripts/python_wheel_xlinux_build.sh line 136:
    -DARROW_WITH_OPENTELEMETRY=${ARROW_WITH_OPENTELEMETRY} \
                               ^-------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_OPENTELEMETRY="${ARROW_WITH_OPENTELEMETRY}" \


In ci/scripts/python_wheel_xlinux_build.sh line 137:
    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY} \
                        ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY}" \


In ci/scripts/python_wheel_xlinux_build.sh line 138:
    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB} \
                      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB}" \


In ci/scripts/python_wheel_xlinux_build.sh line 139:
    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD} \
                      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD}" \


In ci/scripts/python_wheel_xlinux_build.sh line 140:
    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
                       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \


In ci/scripts/python_wheel_xlinux_build.sh line 143:
    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${CMAKE_INTERPROCEDURAL_OPTIMIZATION} \
                                         ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION="${CMAKE_INTERPROCEDURAL_OPTIMIZATION}" \


In ci/scripts/python_wheel_xlinux_build.sh line 144:
    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} \
                        ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD}" \


In ci/scripts/python_wheel_xlinux_build.sh line 145:
    -DPARQUET_REQUIRE_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION} \
                                 ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DPARQUET_REQUIRE_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION}" \


In ci/scripts/python_wheel_xlinux_build.sh line 147:
    -DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET} \
                           ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \


In ci/scripts/python_wheel_xlinux_build.sh line 149:
    ${ARROW_EXTRA_CMAKE_FLAGS} \
    ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${ARROW_EXTRA_CMAKE_FLAGS}" \


In ci/scripts/python_wheel_xlinux_build.sh line 150:
    -G ${CMAKE_GENERATOR} \
       ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -G "${CMAKE_GENERATOR}" \


In ci/scripts/python_wheel_xlinux_build.sh line 181:
    -C cmake.build-type=${CMAKE_BUILD_TYPE:-Debug} \
                        ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -C cmake.build-type="${CMAKE_BUILD_TYPE:-Debug}" \


In ci/scripts/python_wheel_xlinux_build.sh line 191:
unzip $wheel_name
      ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
unzip "$wheel_name"


In ci/scripts/python_wheel_xlinux_build.sh line 192:
rm $wheel_name
   ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm "$wheel_name"


In ci/scripts/python_wheel_xlinux_build.sh line 193:
for filename in $(ls pyarrow/*.so pyarrow/*.so.*); do
                ^-- SC2045 (error): Iterating over ls output is fragile. Use globs.


In ci/scripts/python_wheel_xlinux_build.sh line 195:
    strip --strip-debug $filename
                        ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    strip --strip-debug "$filename"


In ci/scripts/python_wheel_xlinux_build.sh line 198:
zip -r $wheel_name .
       ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
zip -r "$wheel_name" .


In ci/scripts/python_wheel_xlinux_build.sh line 199:
mv $wheel_name ..
   ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "$wheel_name" ..

For more information:
  https://www.shellcheck.net/wiki/SC2045 -- Iterating over ls output is fragi...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
``` 

### What changes are included in this PR?

* SC2045: Replace `ls` iteration with globs
* SC2086: Quote variable expansions
* SC2223: Quote default assignment

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50575