### PR TITLE
GH-50582: [CI][C++] Install missing `simdjson-static` on Alpine Linux

### DIFF
--- a/ci/docker/alpine-linux-3.22-cpp.dockerfile
+++ b/ci/docker/alpine-linux-3.22-cpp.dockerfile
@@ -60,6 +60,7 @@ RUN apk add \
         rsync \
         samurai \
         simdjson-dev \
+        simdjson-static \
         snappy-dev \
         sqlite-dev \
         thrift-dev \


### PR DESCRIPTION
### Rationale for this change

`simdjson-static` is needed for `find_package(simdjson)` on Alpine Linux because `simdjsontargets.cmake` refers `libsimdjson.a` but it's included in `simdjson-static` not `simdjson-dev`.

### What changes are included in this PR?

Install `simdjson-static`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50582