### PR TITLE
GH-50508: [C++] Support scalar values in AppendScalars

### DIFF
--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -227,6 +227,7 @@ TEST_P(TestRunEndEncodedArray, LogicalRunEnds) {
   ASSERT_OK_AND_ASSIGN(logical_run_ends, ree_slice->LogicalRunEnds(pool));
   ASSERT_ARRAYS_EQUAL(*logical_run_ends, *expected_run_ends);
 }
+
 TEST_P(TestRunEndEncodedArray, Builder) {
   auto value_type = utf8();
   auto ree_type = run_end_encoded(run_end_type, value_type);
@@ -380,22 +381,15 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsPrimitiveScalar) {
   ScalarVector scalars = {v1, v2, v3, v4, v5};
 
   ASSERT_OK(builder->AppendScalars(scalars));
-
   ASSERT_EQ(builder->length(), 5);
-
   ASSERT_OK_AND_ASSIGN(auto array, builder->Finish());
   ASSERT_OK(array->ValidateFull());
 
   auto ree_array = std::dynamic_pointer_cast<RunEndEncodedArray>(array);
-
   ASSERT_NE(ree_array, NULLPTR);
-
   auto expected_run_ends = ArrayFromJSON(run_end_type, "[2,4,5]");
-
   auto expected_values = ArrayFromJSON(float32(), "[1,2,3]");
-
   ASSERT_ARRAYS_EQUAL(*expected_run_ends, *ree_array->run_ends());
-
   ASSERT_ARRAYS_EQUAL(*expected_values, *ree_array->values());
 }
 
@@ -414,22 +408,15 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsRunEndEncodedScalar) {
   ScalarVector scalars = {s1, s2, s3, s4, s5};
 
   ASSERT_OK(builder->AppendScalars(scalars));
-
   ASSERT_EQ(builder->length(), 5);
-
   ASSERT_OK_AND_ASSIGN(auto array, builder->Finish());
   ASSERT_OK(array->ValidateFull());
 
   auto ree_array = std::dynamic_pointer_cast<RunEndEncodedArray>(array);
-
   ASSERT_NE(ree_array, NULLPTR);
-
   auto expected_run_ends = ArrayFromJSON(run_end_type, "[2,4,5]");
-
   auto expected_values = ArrayFromJSON(float32(), "[1,2,3]");
-
   ASSERT_ARRAYS_EQUAL(*expected_run_ends, *ree_array->run_ends());
-
   ASSERT_ARRAYS_EQUAL(*expected_values, *ree_array->values());
 }
 

--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -369,15 +369,13 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsPrimitiveScalar) {
   auto value_type = float32();
   auto ree_type = run_end_encoded(run_end_type, value_type);
 
-  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ArrayBuilder> builder,
-                        MakeBuilder(ree_type));
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ArrayBuilder> builder, MakeBuilder(ree_type));
 
-
-    ASSERT_OK_AND_ASSIGN(auto v1, MakeScalar(float32(), 1.0f));
-    ASSERT_OK_AND_ASSIGN(auto v2, MakeScalar(float32(), 1.0f));
-    ASSERT_OK_AND_ASSIGN(auto v3, MakeScalar(float32(), 2.0f));
-    ASSERT_OK_AND_ASSIGN(auto v4, MakeScalar(float32(), 2.0f));
-    ASSERT_OK_AND_ASSIGN(auto v5, MakeScalar(float32(), 3.0f));
+  ASSERT_OK_AND_ASSIGN(auto v1, MakeScalar(float32(), 1.0f));
+  ASSERT_OK_AND_ASSIGN(auto v2, MakeScalar(float32(), 1.0f));
+  ASSERT_OK_AND_ASSIGN(auto v3, MakeScalar(float32(), 2.0f));
+  ASSERT_OK_AND_ASSIGN(auto v4, MakeScalar(float32(), 2.0f));
+  ASSERT_OK_AND_ASSIGN(auto v5, MakeScalar(float32(), 3.0f));
 
   ScalarVector scalars = {v1, v2, v3, v4, v5};
 
@@ -391,30 +389,25 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsPrimitiveScalar) {
 
   ASSERT_NE(ree_array, NULLPTR);
 
-  auto expected_run_ends =
-      ArrayFromJSON(run_end_type, "[2,4,5]");
+  auto expected_run_ends = ArrayFromJSON(run_end_type, "[2,4,5]");
 
-  auto expected_values =
-      ArrayFromJSON(float32(), "[1,2,3]");
+  auto expected_values = ArrayFromJSON(float32(), "[1,2,3]");
 
-  ASSERT_ARRAYS_EQUAL(*expected_run_ends,
-                      *ree_array->run_ends());
+  ASSERT_ARRAYS_EQUAL(*expected_run_ends, *ree_array->run_ends());
 
-  ASSERT_ARRAYS_EQUAL(*expected_values,
-                      *ree_array->values());
+  ASSERT_ARRAYS_EQUAL(*expected_values, *ree_array->values());
 }
 
 TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsRunEndEncodedScalar) {
   auto value_type = float32();
   auto ree_type = run_end_encoded(run_end_type, value_type);
 
-  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ArrayBuilder> builder,
-                        MakeBuilder(ree_type));
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ArrayBuilder> builder, MakeBuilder(ree_type));
 
   ASSERT_OK_AND_ASSIGN(auto s1, MakeScalar(ree_type, *MakeScalar(float32(), 1.0f)));
- ASSERT_OK_AND_ASSIGN(auto s2,MakeScalar(ree_type, *MakeScalar(float32(), 1.0f)));
-  ASSERT_OK_AND_ASSIGN(auto s3,MakeScalar(ree_type, *MakeScalar(float32(), 2.0f)));
-  ASSERT_OK_AND_ASSIGN(auto s4,MakeScalar(ree_type, *MakeScalar(float32(), 2.0f)));
+  ASSERT_OK_AND_ASSIGN(auto s2, MakeScalar(ree_type, *MakeScalar(float32(), 1.0f)));
+  ASSERT_OK_AND_ASSIGN(auto s3, MakeScalar(ree_type, *MakeScalar(float32(), 2.0f)));
+  ASSERT_OK_AND_ASSIGN(auto s4, MakeScalar(ree_type, *MakeScalar(float32(), 2.0f)));
   ASSERT_OK_AND_ASSIGN(auto s5, MakeScalar(ree_type, *MakeScalar(float32(), 3.0f)));
 
   ScalarVector scalars = {s1, s2, s3, s4, s5};
@@ -425,24 +418,18 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsRunEndEncodedScalar) {
 
   ASSERT_OK_AND_ASSIGN(auto array, builder->Finish());
 
-  auto ree_array =
-      std::dynamic_pointer_cast<RunEndEncodedArray>(array);
+  auto ree_array = std::dynamic_pointer_cast<RunEndEncodedArray>(array);
 
   ASSERT_NE(ree_array, NULLPTR);
 
-  auto expected_run_ends =
-      ArrayFromJSON(run_end_type, "[2,4,5]");
+  auto expected_run_ends = ArrayFromJSON(run_end_type, "[2,4,5]");
 
-  auto expected_values =
-      ArrayFromJSON(float32(), "[1,2,3]");
+  auto expected_values = ArrayFromJSON(float32(), "[1,2,3]");
 
-  ASSERT_ARRAYS_EQUAL(*expected_run_ends,
-                      *ree_array->run_ends());
+  ASSERT_ARRAYS_EQUAL(*expected_run_ends, *ree_array->run_ends());
 
-  ASSERT_ARRAYS_EQUAL(*expected_values,
-                      *ree_array->values());
+  ASSERT_ARRAYS_EQUAL(*expected_values, *ree_array->values());
 }
-
 
 TEST_P(TestRunEndEncodedArray, BuilderReuseAfterFinish) {
   // GH-45532: RunEndEncodedBuilder should clear dimensions after a Finish() call

--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -227,7 +227,6 @@ TEST_P(TestRunEndEncodedArray, LogicalRunEnds) {
   ASSERT_OK_AND_ASSIGN(logical_run_ends, ree_slice->LogicalRunEnds(pool));
   ASSERT_ARRAYS_EQUAL(*logical_run_ends, *expected_run_ends);
 }
-//<--------------------------------------------------------------------------------->
 TEST_P(TestRunEndEncodedArray, Builder) {
   auto value_type = utf8();
   auto ree_type = run_end_encoded(run_end_type, value_type);
@@ -366,7 +365,6 @@ TEST_P(TestRunEndEncodedArray, Builder) {
     }
   }
 }
-//<--------------------------------------------my function---------------------------------------------------->
 TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsPrimitiveScalar) {
   auto value_type = float32();
   auto ree_type = run_end_encoded(run_end_type, value_type);
@@ -444,7 +442,7 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsRunEndEncodedScalar) {
   ASSERT_ARRAYS_EQUAL(*expected_values,
                       *ree_array->values());
 }
-//<----------------------------------------------------------------------------------------------------->
+
 
 TEST_P(TestRunEndEncodedArray, BuilderReuseAfterFinish) {
   // GH-45532: RunEndEncodedBuilder should clear dimensions after a Finish() call

--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -384,6 +384,7 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsPrimitiveScalar) {
   ASSERT_EQ(builder->length(), 5);
 
   ASSERT_OK_AND_ASSIGN(auto array, builder->Finish());
+  ASSERT_OK(array->ValidateFull());
 
   auto ree_array = std::dynamic_pointer_cast<RunEndEncodedArray>(array);
 
@@ -417,6 +418,7 @@ TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsRunEndEncodedScalar) {
   ASSERT_EQ(builder->length(), 5);
 
   ASSERT_OK_AND_ASSIGN(auto array, builder->Finish());
+  ASSERT_OK(array->ValidateFull());
 
   auto ree_array = std::dynamic_pointer_cast<RunEndEncodedArray>(array);
 

--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -227,7 +227,7 @@ TEST_P(TestRunEndEncodedArray, LogicalRunEnds) {
   ASSERT_OK_AND_ASSIGN(logical_run_ends, ree_slice->LogicalRunEnds(pool));
   ASSERT_ARRAYS_EQUAL(*logical_run_ends, *expected_run_ends);
 }
-
+//<--------------------------------------------------------------------------------->
 TEST_P(TestRunEndEncodedArray, Builder) {
   auto value_type = utf8();
   auto ree_type = run_end_encoded(run_end_type, value_type);
@@ -366,6 +366,85 @@ TEST_P(TestRunEndEncodedArray, Builder) {
     }
   }
 }
+//<--------------------------------------------my function---------------------------------------------------->
+TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsPrimitiveScalar) {
+  auto value_type = float32();
+  auto ree_type = run_end_encoded(run_end_type, value_type);
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ArrayBuilder> builder,
+                        MakeBuilder(ree_type));
+
+
+    ASSERT_OK_AND_ASSIGN(auto v1, MakeScalar(float32(), 1.0f));
+    ASSERT_OK_AND_ASSIGN(auto v2, MakeScalar(float32(), 1.0f));
+    ASSERT_OK_AND_ASSIGN(auto v3, MakeScalar(float32(), 2.0f));
+    ASSERT_OK_AND_ASSIGN(auto v4, MakeScalar(float32(), 2.0f));
+    ASSERT_OK_AND_ASSIGN(auto v5, MakeScalar(float32(), 3.0f));
+
+  ScalarVector scalars = {v1, v2, v3, v4, v5};
+
+  ASSERT_OK(builder->AppendScalars(scalars));
+
+  ASSERT_EQ(builder->length(), 5);
+
+  ASSERT_OK_AND_ASSIGN(auto array, builder->Finish());
+
+  auto ree_array = std::dynamic_pointer_cast<RunEndEncodedArray>(array);
+
+  ASSERT_NE(ree_array, NULLPTR);
+
+  auto expected_run_ends =
+      ArrayFromJSON(run_end_type, "[2,4,5]");
+
+  auto expected_values =
+      ArrayFromJSON(float32(), "[1,2,3]");
+
+  ASSERT_ARRAYS_EQUAL(*expected_run_ends,
+                      *ree_array->run_ends());
+
+  ASSERT_ARRAYS_EQUAL(*expected_values,
+                      *ree_array->values());
+}
+
+TEST_P(TestRunEndEncodedArray, BuilderAppendScalarsRunEndEncodedScalar) {
+  auto value_type = float32();
+  auto ree_type = run_end_encoded(run_end_type, value_type);
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ArrayBuilder> builder,
+                        MakeBuilder(ree_type));
+
+  ASSERT_OK_AND_ASSIGN(auto s1, MakeScalar(ree_type, *MakeScalar(float32(), 1.0f)));
+ ASSERT_OK_AND_ASSIGN(auto s2,MakeScalar(ree_type, *MakeScalar(float32(), 1.0f)));
+  ASSERT_OK_AND_ASSIGN(auto s3,MakeScalar(ree_type, *MakeScalar(float32(), 2.0f)));
+  ASSERT_OK_AND_ASSIGN(auto s4,MakeScalar(ree_type, *MakeScalar(float32(), 2.0f)));
+  ASSERT_OK_AND_ASSIGN(auto s5, MakeScalar(ree_type, *MakeScalar(float32(), 3.0f)));
+
+  ScalarVector scalars = {s1, s2, s3, s4, s5};
+
+  ASSERT_OK(builder->AppendScalars(scalars));
+
+  ASSERT_EQ(builder->length(), 5);
+
+  ASSERT_OK_AND_ASSIGN(auto array, builder->Finish());
+
+  auto ree_array =
+      std::dynamic_pointer_cast<RunEndEncodedArray>(array);
+
+  ASSERT_NE(ree_array, NULLPTR);
+
+  auto expected_run_ends =
+      ArrayFromJSON(run_end_type, "[2,4,5]");
+
+  auto expected_values =
+      ArrayFromJSON(float32(), "[1,2,3]");
+
+  ASSERT_ARRAYS_EQUAL(*expected_run_ends,
+                      *ree_array->run_ends());
+
+  ASSERT_ARRAYS_EQUAL(*expected_values,
+                      *ree_array->values());
+}
+//<----------------------------------------------------------------------------------------------------->
 
 TEST_P(TestRunEndEncodedArray, BuilderReuseAfterFinish) {
   // GH-45532: RunEndEncodedBuilder should clear dimensions after a Finish() call

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -201,6 +201,7 @@ Status RunEndEncodedBuilder::AppendEmptyValues(int64_t length) {
   UpdateDimensions(committed_logical_length_, 0);
   return Status::OK();
 }
+
 Status RunEndEncodedBuilder::AppendScalar(const Scalar& scalar, int64_t n_repeats) {
   if (scalar.type->id() == Type::RUN_END_ENCODED) {
     return AppendScalar(*internal::checked_cast<const RunEndEncodedScalar&>(scalar).value,

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -212,12 +212,12 @@ Status RunEndEncodedBuilder::AppendScalar(const Scalar& scalar, int64_t n_repeat
 }
 
 Status RunEndEncodedBuilder::AppendScalars(const ScalarVector& scalars) {
-  if(scalars.empty()) return Status::OK();
-      for (const auto& scalar : scalars) {
-    RETURN_NOT_OK(AppendScalar(*scalar,1));
-}
-  UpdateDimensions(committed_logical_length_,value_run_builder_->open_run_length());
-return Status::OK();
+  if (scalars.empty()) return Status::OK();
+  for (const auto& scalar : scalars) {
+    RETURN_NOT_OK(AppendScalar(*scalar, 1));
+  }
+  UpdateDimensions(committed_logical_length_, value_run_builder_->open_run_length());
+  return Status::OK();
 }
 
 template <typename RunEndCType>

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -201,7 +201,6 @@ Status RunEndEncodedBuilder::AppendEmptyValues(int64_t length) {
   UpdateDimensions(committed_logical_length_, 0);
   return Status::OK();
 }
-
 Status RunEndEncodedBuilder::AppendScalar(const Scalar& scalar, int64_t n_repeats) {
   if (scalar.type->id() == Type::RUN_END_ENCODED) {
     return AppendScalar(*internal::checked_cast<const RunEndEncodedScalar&>(scalar).value,
@@ -212,11 +211,16 @@ Status RunEndEncodedBuilder::AppendScalar(const Scalar& scalar, int64_t n_repeat
   return Status::OK();
 }
 
+//<--------------------------------------------------------------------------------->
 Status RunEndEncodedBuilder::AppendScalars(const ScalarVector& scalars) {
-  RETURN_NOT_OK(this->ArrayBuilder::AppendScalars(scalars));
-  UpdateDimensions(committed_logical_length_, value_run_builder_->open_run_length());
-  return Status::OK();
+  if(scalars.empty()) return Status::OK();
+      for (const auto& scalar : scalars) {
+    RETURN_NOT_OK(AppendScalar(*scalar,1));
 }
+  UpdateDimensions(committed_logical_length_,value_run_builder_->open_run_length());
+return Status::OK();
+}
+//<--------------------------------------------------------------------------------->
 
 template <typename RunEndCType>
 Status RunEndEncodedBuilder::DoAppendArraySlice(const ArraySpan& array, int64_t offset,

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -211,7 +211,6 @@ Status RunEndEncodedBuilder::AppendScalar(const Scalar& scalar, int64_t n_repeat
   return Status::OK();
 }
 
-//<--------------------------------------------------------------------------------->
 Status RunEndEncodedBuilder::AppendScalars(const ScalarVector& scalars) {
   if(scalars.empty()) return Status::OK();
       for (const auto& scalar : scalars) {
@@ -220,7 +219,6 @@ Status RunEndEncodedBuilder::AppendScalars(const ScalarVector& scalars) {
   UpdateDimensions(committed_logical_length_,value_run_builder_->open_run_length());
 return Status::OK();
 }
-//<--------------------------------------------------------------------------------->
 
 template <typename RunEndCType>
 Status RunEndEncodedBuilder::DoAppendArraySlice(const ArraySpan& array, int64_t offset,


### PR DESCRIPTION
# Rationale for this change

`RunEndEncodedBuilder::AppendScalar` accepts regular scalar values, such as `float32` directly. However, `RunEndEncodedBuilder::AppendScalars` only handled `RunEndEncodedScalar` values.

This made the two APIs inconsistent. This PR updates `AppendScalars` to support regular scalar values consistently with `AppendScalar`.

# What changes are included in this PR?

- Updated `RunEndEncodedBuilder::AppendScalars`   to process each scalar through `AppendScalar`.
- Added tests covering regular scalar values and nested `RunEndEncodedScalar` values.
- Added tests verifying the expected run ends and values.

# Are these changes tested?

Yes. The relevant Run-End Encoded tests pass successfully.

# Are there any user-facing changes?

Yes. `RunEndEncodedBuilder::AppendScalars` now accepts regular scalar values, such as `float32`, consistently with `AppendScalar`.

# Breaking changes

No

# Critical Fix

No.
* GitHub Issue: #50508