### PR TITLE
GH-50585: [CI][C++] Use bundled simdjson on Alpine Linux

### DIFF
--- a/ci/docker/alpine-linux-3.22-cpp.dockerfile
+++ b/ci/docker/alpine-linux-3.22-cpp.dockerfile
@@ -105,4 +105,8 @@ ENV ARROW_ACERO=ON \
     google_cloud_cpp_storage_SOURCE=BUNDLED \
     MUSL_LOCPATH=/usr/share/i18n/locales/musl \
     PATH=/usr/lib/ccache/bin:$PATH \
+    # We can remove this once
+    # https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18353
+    # is fixed.
+    simdjson_SOURCE=BUNDLED \
     xsimd_SOURCE=BUNDLED


### PR DESCRIPTION
### Rationale for this change

The simdjson package in Alpine Linux has some problems.

See also: https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18353

### What changes are included in this PR?

Use bundled simdjson for now.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50585