### PR TITLE
GH-50588: [Ruby] Add `ArrowFormat::Array#[]`

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -61,6 +61,14 @@ module ArrowFormat
       not valid?(i)
     end
 
+    def [](i)
+      if valid?(i)
+        unpack_value(i)
+      else
+        nil
+      end
+    end
+
     def n_nulls
       if @validity_buffer.nil?
         0
@@ -165,6 +173,14 @@ module ArrowFormat
   class NullArray < Array
     def initialize(size)
       super(NullType.singleton, size, nil)
+    end
+
+    def valid?(i)
+      false
+    end
+
+    def null?(i)
+      true
     end
 
     def each_buffer
@@ -294,6 +310,11 @@ module ArrowFormat
       value = 0 if value.nil?
       [value].pack(template)
     end
+
+    def unpack_value(i)
+      offset = element_size * (@offset + i)
+      @values_buffer.get_value(@type.buffer_type, offset)
+    end
   end
 
   class BooleanArray < PrimitiveArray
@@ -361,6 +382,10 @@ module ArrowFormat
       end
       validity_buffer = validity_buffer_builder&.finish(n)
       return n, validity_buffer, values_buffer_builder.finish
+    end
+
+    def unpack_value(i)
+      values_bitmap[i]
     end
   end
 
@@ -600,6 +625,11 @@ module ArrowFormat
         value.pack(template)
       end
     end
+
+    def unpack_value(i)
+      offset = element_size * (@offset + i)
+      @values_buffer.get_values([@type.buffer_type] * 2, offset)
+    end
   end
 
   class MonthDayNanoIntervalArray < IntervalArray
@@ -660,6 +690,13 @@ module ArrowFormat
       else
         value.pack(template)
       end
+    end
+
+    def unpack_value(i)
+      buffer_types = @type.buffer_types
+      value_size = IO::Buffer.size_of(buffer_types)
+      offset = value_size * (@offset + i)
+      @values_buffer.get_values(buffer_types, offset)
     end
   end
 
@@ -767,6 +804,15 @@ module ArrowFormat
 
     def offset_size
       IO::Buffer.size_of(@type.offset_buffer_type)
+    end
+
+    def unpack_value(i)
+      offset_types = [@type.offset_buffer_type] * 2
+      offsets_offset = offset_size * (@offset + i)
+      offset, next_offset = @offsets_buffer.get_values(offset_types,
+                                                       offsets_offset)
+      length = next_offset - offset
+      @values_buffer.get_string(offset, length, @type.encoding)
     end
   end
 

--- a/ruby/red-arrow-format/lib/arrow-format/error.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/error.rb
@@ -1,3 +1,4 @@
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -1,3 +1,4 @@
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file

--- a/ruby/red-arrow-format/test/test-binary-array.rb
+++ b/ruby/red-arrow-format/test/test-binary-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestBinaryArray < Test::Unit::TestCase
+  def setup
+    @values = ["\x00\x01".b, nil, "\xff\x10".b]
+    @array = ArrowFormat::BinaryArray.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = ["\x00\x01".b, "\xff\x10".b]
@@ -50,6 +55,16 @@ class TestBinaryArray < Test::Unit::TestCase
       array1 = ArrowFormat::BinaryArray.new(values)
       array2 = ArrowFormat::BinaryArray.new(["".b, "".b, *values, "".b])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-boolean-array.rb
+++ b/ruby/red-arrow-format/test/test-boolean-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestBooleanArray < Test::Unit::TestCase
+  def setup
+    @values = [true, nil, false]
+    @array = ArrowFormat::BooleanArray.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       assert_equal([true, false],
@@ -51,6 +56,16 @@ class TestBooleanArray < Test::Unit::TestCase
       array1 = ArrowFormat::BooleanArray.new([true, nil, false])
       array2 = ArrowFormat::BooleanArray.new([true, false, nil, false, true])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-date32-array.rb
+++ b/ruby/red-arrow-format/test/test-date32-array.rb
@@ -19,6 +19,8 @@ class TestDate32Array < Test::Unit::TestCase
   def setup
     @date_2017_08_28 = 17406
     @date_2025_12_09 = 20431
+    @values = [@date_2017_08_28, nil, @date_2025_12_09]
+    @array = ArrowFormat::Date32Array.new(@values)
   end
 
   sub_test_case("#initialize") do
@@ -55,6 +57,16 @@ class TestDate32Array < Test::Unit::TestCase
       array1 = ArrowFormat::Date32Array.new(values)
       array2 = ArrowFormat::Date32Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-date64-array.rb
+++ b/ruby/red-arrow-format/test/test-date64-array.rb
@@ -19,6 +19,8 @@ class TestDate64Array < Test::Unit::TestCase
   def setup
     @date_2017_08_28_00_00_00 = 1503878400000
     @date_2025_12_10_00_00_00 = 1765324800000
+    @values = [@date_2017_08_28_00_00_00, nil, @date_2025_12_10_00_00_00]
+    @array = ArrowFormat::Date64Array.new(@values)
   end
 
   sub_test_case("#initialize") do
@@ -55,6 +57,16 @@ class TestDate64Array < Test::Unit::TestCase
       array1 = ArrowFormat::Date64Array.new(values)
       array2 = ArrowFormat::Date64Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-day-time-interval-array.rb
+++ b/ruby/red-arrow-format/test/test-day-time-interval-array.rb
@@ -16,6 +16,15 @@
 # under the License.
 
 class TestDayTimeIntervalArray < Test::Unit::TestCase
+  def setup
+    @values = [
+      [1, 100],
+      nil,
+      [3, 300],
+    ]
+    @array = ArrowFormat::DayTimeIntervalArray.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [
@@ -83,6 +92,16 @@ class TestDayTimeIntervalArray < Test::Unit::TestCase
       array1 = ArrowFormat::DayTimeIntervalArray.new(values)
       array2 = ArrowFormat::DayTimeIntervalArray.new([nil, nil, *values, nil])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-duration-array.rb
+++ b/ruby/red-arrow-format/test/test-duration-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestDurationArray < Test::Unit::TestCase
+  def setup
+    @values = [-(2 ** 63), nil, (2 ** 63) - 1]
+    @array = ArrowFormat::DurationArray.new(:second, @values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [-(2 ** 63), (2 ** 63) - 1]
@@ -50,6 +55,16 @@ class TestDurationArray < Test::Unit::TestCase
       array1 = ArrowFormat::DurationArray.new(:second, values)
       array2 = ArrowFormat::DurationArray.new(:second, [0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-float32-array.rb
+++ b/ruby/red-arrow-format/test/test-float32-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestFloat32Array < Test::Unit::TestCase
+  def setup
+    @values = [-Float::INFINITY, nil, +Float::INFINITY]
+    @array = ArrowFormat::Float32Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [-Float::INFINITY, -0.0, +0.0, +Float::INFINITY]
@@ -50,6 +55,16 @@ class TestFloat32Array < Test::Unit::TestCase
       array1 = ArrowFormat::Float32Array.new(values)
       array2 = ArrowFormat::Float32Array.new([0.0, 0.0, *values, 0.0])
       assert_not_equal(array1, array2.slice(1, 5))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-float64-array.rb
+++ b/ruby/red-arrow-format/test/test-float64-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestFloat64Array < Test::Unit::TestCase
+  def setup
+    @values = [-Float::INFINITY, nil, +Float::INFINITY]
+    @array = ArrowFormat::Float64Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [-Float::INFINITY, -0.0, +0.0, +Float::INFINITY]
@@ -50,6 +55,16 @@ class TestFloat64Array < Test::Unit::TestCase
       array1 = ArrowFormat::Float64Array.new(values)
       array2 = ArrowFormat::Float64Array.new([0.0, 0.0, *values, 0.0])
       assert_not_equal(array1, array2.slice(1, 5))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-int16-array.rb
+++ b/ruby/red-arrow-format/test/test-int16-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestInt16Array < Test::Unit::TestCase
+  def setup
+    @values = [-(2 ** 15), nil, (2 ** 15) - 1]
+    @array = ArrowFormat::Int16Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [-(2 ** 15), (2 ** 15) - 1]
@@ -50,6 +55,16 @@ class TestInt16Array < Test::Unit::TestCase
       array1 = ArrowFormat::Int16Array.new(values)
       array2 = ArrowFormat::Int16Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-int32-array.rb
+++ b/ruby/red-arrow-format/test/test-int32-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestInt32Array < Test::Unit::TestCase
+  def setup
+    @values = [-(2 ** 31), nil, (2 ** 31) - 1]
+    @array = ArrowFormat::Int32Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [-(2 ** 31), (2 ** 31) - 1]
@@ -50,6 +55,16 @@ class TestInt32Array < Test::Unit::TestCase
       array1 = ArrowFormat::Int32Array.new(values)
       array2 = ArrowFormat::Int32Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-int64-array.rb
+++ b/ruby/red-arrow-format/test/test-int64-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestInt64Array < Test::Unit::TestCase
+  def setup
+    @values = [-(2 ** 63), nil, (2 ** 63) - 1]
+    @array = ArrowFormat::Int64Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [-(2 ** 63), (2 ** 63) - 1]
@@ -50,6 +55,16 @@ class TestInt64Array < Test::Unit::TestCase
       array1 = ArrowFormat::Int64Array.new(values)
       array2 = ArrowFormat::Int64Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-int8-array.rb
+++ b/ruby/red-arrow-format/test/test-int8-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestInt8Array < Test::Unit::TestCase
+  def setup
+    @values = [-(2 ** 7), nil, (2 ** 7) - 1]
+    @array = ArrowFormat::Int8Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [-(2 ** 7), (2 ** 7) - 1]
@@ -50,6 +55,16 @@ class TestInt8Array < Test::Unit::TestCase
       array1 = ArrowFormat::Int8Array.new(values)
       array2 = ArrowFormat::Int8Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-large-binary-array.rb
+++ b/ruby/red-arrow-format/test/test-large-binary-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestLargeBinaryArray < Test::Unit::TestCase
+  def setup
+    @values = ["\x00\x01".b, nil, "\xff\x10".b]
+    @array = ArrowFormat::LargeBinaryArray.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = ["\x00\x01".b, "\xff\x10".b]
@@ -50,6 +55,16 @@ class TestLargeBinaryArray < Test::Unit::TestCase
       array1 = ArrowFormat::LargeBinaryArray.new(values)
       array2 = ArrowFormat::LargeBinaryArray.new(["".b, "".b, *values, "".b])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-large-utf8-array.rb
+++ b/ruby/red-arrow-format/test/test-large-utf8-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestLargeUTF8Array < Test::Unit::TestCase
+  def setup
+    @values = ["Hello", nil, "World"]
+    @array = ArrowFormat::LargeUTF8Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = ["Hello", "World"]
@@ -50,6 +55,16 @@ class TestLargeUTF8Array < Test::Unit::TestCase
       array1 = ArrowFormat::LargeUTF8Array.new(values)
       array2 = ArrowFormat::LargeUTF8Array.new(["", "", *values, ""])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-month-day-nano-interval-array.rb
+++ b/ruby/red-arrow-format/test/test-month-day-nano-interval-array.rb
@@ -16,6 +16,15 @@
 # under the License.
 
 class TestMonthDayNanoIntervalArray < Test::Unit::TestCase
+  def setup
+    @values = [
+      [1, 1, 100],
+      nil,
+      [3, 3, 300],
+    ]
+    @array = ArrowFormat::MonthDayNanoIntervalArray.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [
@@ -88,6 +97,16 @@ class TestMonthDayNanoIntervalArray < Test::Unit::TestCase
                                                             nil,
                                                           ])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-null-array.rb
+++ b/ruby/red-arrow-format/test/test-null-array.rb
@@ -16,6 +16,10 @@
 # under the License.
 
 class TestNullArray < Test::Unit::TestCase
+  def setup
+    @array = ArrowFormat::NullArray.new(3)
+  end
+
   def test_initialize
     assert_equal([nil] * 9,
                  ArrowFormat::NullArray.new(9).to_a)
@@ -33,5 +37,9 @@ class TestNullArray < Test::Unit::TestCase
       array2 = ArrowFormat::NullArray.new(5)
       assert_equal(array1, array2.slice(1, 3))
     end
+  end
+
+  def test_aref
+    assert_nil(@array[1])
   end
 end

--- a/ruby/red-arrow-format/test/test-time32-array.rb
+++ b/ruby/red-arrow-format/test/test-time32-array.rb
@@ -19,6 +19,8 @@ class TestTime32Array < Test::Unit::TestCase
   def setup
     @time_00_00_10 = 10
     @time_00_01_10 = 60 + 10
+    @values = [@time_00_00_10, nil, @time_00_01_10]
+    @array = ArrowFormat::Time32Array.new(:second, @values)
   end
 
   sub_test_case("#initialize") do
@@ -55,6 +57,16 @@ class TestTime32Array < Test::Unit::TestCase
       array1 = ArrowFormat::Time32Array.new(:second, values)
       array2 = ArrowFormat::Time32Array.new(:second, [0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-time64-array.rb
+++ b/ruby/red-arrow-format/test/test-time64-array.rb
@@ -19,6 +19,8 @@ class TestTime64Array < Test::Unit::TestCase
   def setup
     @time_00_00_10_000_000 = 10 * 1_000_000
     @time_00_01_10_000_000 = (60 + 10) * 1_000_000
+    @values = [@time_00_00_10_000_000, nil, @time_00_01_10_000_000]
+    @array = ArrowFormat::Time64Array.new(:microsecond, @values)
   end
 
   sub_test_case("#initialize") do
@@ -55,6 +57,16 @@ class TestTime64Array < Test::Unit::TestCase
       array1 = ArrowFormat::Time64Array.new(:microsecond, values)
       array2 = ArrowFormat::Time64Array.new(:microsecond, [0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-timestamp-array.rb
+++ b/ruby/red-arrow-format/test/test-timestamp-array.rb
@@ -19,6 +19,12 @@ class TestTimestampArray < Test::Unit::TestCase
   def setup
     @timestamp_2019_11_17_15_09_11 = 1574003351
     @timestamp_2025_12_16_05_33_58 = 1765863238
+    @values = [
+      @timestamp_2019_11_17_15_09_11,
+      nil,
+      @timestamp_2025_12_16_05_33_58,
+    ]
+    @array = ArrowFormat::TimestampArray.new(:second, @values)
   end
 
   sub_test_case("#initialize") do
@@ -81,6 +87,16 @@ class TestTimestampArray < Test::Unit::TestCase
       array1 = ArrowFormat::TimestampArray.new(:second, values)
       array2 = ArrowFormat::TimestampArray.new(:second, [0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-uint16-array.rb
+++ b/ruby/red-arrow-format/test/test-uint16-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestUInt16Array < Test::Unit::TestCase
+  def setup
+    @values = [0, nil, (2 ** 16) - 1]
+    @array = ArrowFormat::UInt16Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [0, (2 ** 16) - 1]
@@ -50,6 +55,16 @@ class TestUInt16Array < Test::Unit::TestCase
       array1 = ArrowFormat::UInt16Array.new(values)
       array2 = ArrowFormat::UInt16Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-uint32-array.rb
+++ b/ruby/red-arrow-format/test/test-uint32-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestUInt32Array < Test::Unit::TestCase
+  def setup
+    @values = [0, nil, (2 ** 32) - 1]
+    @array = ArrowFormat::UInt32Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [0, (2 ** 32) - 1]
@@ -50,6 +55,16 @@ class TestUInt32Array < Test::Unit::TestCase
       array1 = ArrowFormat::UInt32Array.new(values)
       array2 = ArrowFormat::UInt32Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-uint64-array.rb
+++ b/ruby/red-arrow-format/test/test-uint64-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestUInt64Array < Test::Unit::TestCase
+  def setup
+    @values = [0, nil, (2 ** 64) - 1]
+    @array = ArrowFormat::UInt64Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [0, (2 ** 64) - 1]
@@ -50,6 +55,16 @@ class TestUInt64Array < Test::Unit::TestCase
       array1 = ArrowFormat::UInt64Array.new(values)
       array2 = ArrowFormat::UInt64Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-uint8-array.rb
+++ b/ruby/red-arrow-format/test/test-uint8-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestUInt8Array < Test::Unit::TestCase
+  def setup
+    @values = [0, nil, (2 ** 8) - 1]
+    @array = ArrowFormat::UInt8Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [0, (2 ** 8) - 1]
@@ -50,6 +55,16 @@ class TestUInt8Array < Test::Unit::TestCase
       array1 = ArrowFormat::UInt8Array.new(values)
       array2 = ArrowFormat::UInt8Array.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-utf8-array.rb
+++ b/ruby/red-arrow-format/test/test-utf8-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestUTF8Array < Test::Unit::TestCase
+  def setup
+    @values = ["Hello", nil, "World"]
+    @array = ArrowFormat::UTF8Array.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = ["Hello", "World"]
@@ -50,6 +55,16 @@ class TestUTF8Array < Test::Unit::TestCase
       array1 = ArrowFormat::UTF8Array.new(values)
       array2 = ArrowFormat::UTF8Array.new(["", "", *values, ""])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-year-month-interval-array.rb
+++ b/ruby/red-arrow-format/test/test-year-month-interval-array.rb
@@ -16,6 +16,11 @@
 # under the License.
 
 class TestYearMonthIntervalArray < Test::Unit::TestCase
+  def setup
+    @values = [0, nil, 100]
+    @array = ArrowFormat::YearMonthIntervalArray.new(@values)
+  end
+
   sub_test_case("#initialize") do
     def test_no_null
       values = [0, 100]
@@ -50,6 +55,16 @@ class TestYearMonthIntervalArray < Test::Unit::TestCase
       array1 = ArrowFormat::YearMonthIntervalArray.new(values)
       array2 = ArrowFormat::YearMonthIntervalArray.new([0, 0, *values, 0])
       assert_not_equal(array1, array2.slice(1, 3))
+    end
+  end
+
+  sub_test_case("#[]") do
+    def test_valid
+      assert_equal(@values[3], @array[3])
+    end
+
+    def test_null
+      assert_nil(@array[1])
     end
   end
 end


### PR DESCRIPTION
### Rationale for this change

It's a convenient API to get a value at the given index.

### What changes are included in this PR?

Add `ArrowFormat::Array#[]`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #50588