### PR TITLE
GH-50572: [Ruby] Add `ArrowFormat::RecordBatch#records`

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/field.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/field.rb
@@ -1,3 +1,4 @@
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -23,7 +24,8 @@ module ArrowFormat
                    type,
                    nullable: true,
                    metadata: nil)
-      @name = name
+      name = name.to_s if name.is_a?(Symbol)
+      @name = name.to_str
       @type = type
       @nullable = nullable
       @metadata = metadata

--- a/ruby/red-arrow-format/lib/arrow-format/record-batch.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/record-batch.rb
@@ -1,3 +1,4 @@
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -15,6 +16,7 @@
 # under the License.
 
 require_relative "buffer-alignable"
+require_relative "record"
 
 module ArrowFormat
   class RecordBatch
@@ -44,12 +46,43 @@ module ArrowFormat
       @n_rows.zero?
     end
 
-    def to_h
-      hash = {}
-      @schema.fields.zip(@columns) do |field, column|
-        hash[field.name] = column
+    def find_column(name_or_index)
+      case name_or_index
+      when Integer
+        @columns[name_or_index]
+      when Symbol
+        name_to_column[name_or_index.to_s]
+      else
+        name_to_column[name_or_index.to_str]
       end
-      hash
+    end
+
+    def each_record(reuse_record: false)
+      unless block_given?
+        return to_enum(__method__, reuse_record: reuse_record)
+      end
+
+      if reuse_record
+        record = Record.new(self, nil)
+        @n_rows.times do |i|
+          record.index = i
+          yield(record)
+        end
+      else
+        @n_rows.times do |i|
+          yield(Record.new(self, i))
+        end
+      end
+    end
+
+    def records
+      size.times.collect do |i|
+        Record.new(self, i)
+      end
+    end
+
+    def to_h
+      name_to_column.dup
     end
 
     def to_flatbuffers
@@ -158,7 +191,20 @@ module ArrowFormat
         raise ArgumentError, message
       end
 
-      return Schema.new(fields), n_rows, columns
+      return Schema.new(fields), all_n_rows[0], columns
+    end
+
+    def name_to_column
+      @name_to_column ||= build_name_to_column
+    end
+
+    def build_name_to_column
+      name_to_column = {}
+      @schema.fields.zip(@columns) do |field, column|
+        name_to_column[field.name] = column
+      end
+      name_to_column.freeze
+      name_to_column
     end
   end
 end

--- a/ruby/red-arrow-format/lib/arrow-format/record.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/record.rb
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ArrowFormat
+  class Record
+    attr_reader :record_batch
+    attr_accessor :index
+    def initialize(record_batch, index)
+      @record_batch = record_batch
+      @index = index
+    end
+
+    def [](name_or_index)
+      column = @record_batch.find_column(name_or_index)
+      return nil if column.nil?
+      column[@index]
+    end
+
+    def to_a
+      @record_batch.columns.collect do |column|
+        column[@index]
+      end
+    end
+
+    def to_h
+      attributes = {}
+      @record_batch.schema.fields.zip(@record_batch.columns) do |field, column|
+        attributes[field.name] = column[@index]
+      end
+      attributes
+    end
+
+    def respond_to_missing?(name, include_private)
+      return true if @record_batch.find_column(name)
+      super
+    end
+
+    def method_missing(name, *args, &block)
+      if args.empty?
+        column = @record_batch.find_column(name)
+        return column[@index] if column
+      end
+      super
+    end
+  end
+end

--- a/ruby/red-arrow-format/lib/arrow-format/schema.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/schema.rb
@@ -1,3 +1,4 @@
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -25,6 +26,17 @@ module ArrowFormat
       @message_metadata = message_metadata
     end
 
+    def [](name_or_index)
+      case name_or_index
+      when Integer
+        @fields[name_or_index]
+      when Symbol
+        name_to_field[name_or_index.to_s]
+      else
+        name_to_field[name_or_index.to_str]
+      end
+    end
+
     def to_flatbuffers
       fb_schema = FB::Schema::Data.new
       fb_schema.endianness = FB::Endianness::LITTLE
@@ -32,6 +44,19 @@ module ArrowFormat
       fb_schema.custom_metadata = FB.build_custom_metadata(@metadata)
       # fb_schema.features = @features
       fb_schema
+    end
+
+    private
+    def name_to_field
+      @name_to_field ||= build_name_to_field
+    end
+
+    def build_name_to_field
+      name_to_field = {}
+      @fields.each do |field|
+        name_to_field[field.name] = field
+      end
+      name_to_field
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-binary-array.rb
+++ b/ruby/red-arrow-format/test/test-binary-array.rb
@@ -60,7 +60,7 @@ class TestBinaryArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-boolean-array.rb
+++ b/ruby/red-arrow-format/test/test-boolean-array.rb
@@ -61,7 +61,7 @@ class TestBooleanArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-date32-array.rb
+++ b/ruby/red-arrow-format/test/test-date32-array.rb
@@ -62,7 +62,7 @@ class TestDate32Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-date64-array.rb
+++ b/ruby/red-arrow-format/test/test-date64-array.rb
@@ -62,7 +62,7 @@ class TestDate64Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-day-time-interval-array.rb
+++ b/ruby/red-arrow-format/test/test-day-time-interval-array.rb
@@ -97,7 +97,7 @@ class TestDayTimeIntervalArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-duration-array.rb
+++ b/ruby/red-arrow-format/test/test-duration-array.rb
@@ -60,7 +60,7 @@ class TestDurationArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-float32-array.rb
+++ b/ruby/red-arrow-format/test/test-float32-array.rb
@@ -60,7 +60,7 @@ class TestFloat32Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-float64-array.rb
+++ b/ruby/red-arrow-format/test/test-float64-array.rb
@@ -60,7 +60,7 @@ class TestFloat64Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-int16-array.rb
+++ b/ruby/red-arrow-format/test/test-int16-array.rb
@@ -60,7 +60,7 @@ class TestInt16Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-int32-array.rb
+++ b/ruby/red-arrow-format/test/test-int32-array.rb
@@ -60,7 +60,7 @@ class TestInt32Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-int64-array.rb
+++ b/ruby/red-arrow-format/test/test-int64-array.rb
@@ -60,7 +60,7 @@ class TestInt64Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-int8-array.rb
+++ b/ruby/red-arrow-format/test/test-int8-array.rb
@@ -60,7 +60,7 @@ class TestInt8Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-large-binary-array.rb
+++ b/ruby/red-arrow-format/test/test-large-binary-array.rb
@@ -60,7 +60,7 @@ class TestLargeBinaryArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-large-utf8-array.rb
+++ b/ruby/red-arrow-format/test/test-large-utf8-array.rb
@@ -60,7 +60,7 @@ class TestLargeUTF8Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-month-day-nano-interval-array.rb
+++ b/ruby/red-arrow-format/test/test-month-day-nano-interval-array.rb
@@ -102,7 +102,7 @@ class TestMonthDayNanoIntervalArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-record-batch.rb
+++ b/ruby/red-arrow-format/test/test-record-batch.rb
@@ -16,12 +16,16 @@
 # under the License.
 
 class TestRecordBatch < Test::Unit::TestCase
-  sub_test_case("#initialize") do
-    def setup
-      @boolean_array = ArrowFormat::BooleanArray.new([true, nil, false])
-      @int32_array = ArrowFormat::Int32Array.new([-(2 ** 31), 0, (2 ** 31) - 1])
-    end
+  def setup
+    @boolean_array = ArrowFormat::BooleanArray.new([true, nil, false])
+    @int32_array = ArrowFormat::Int32Array.new([-(2 ** 31), 0, (2 ** 31) - 1])
+    @record_batch = ArrowFormat::RecordBatch.new({
+                                                   boolean: @boolean_array,
+                                                   int32: @int32_array,
+                                                 })
+  end
 
+  sub_test_case("#initialize") do
     test("{}") do
       error = ArgumentError.new("no data")
       assert_raise(error) do
@@ -35,7 +39,11 @@ class TestRecordBatch < Test::Unit::TestCase
         int32: @int32_array,
       }
       record_batch = ArrowFormat::RecordBatch.new(raw_records)
-      assert_equal(raw_records, record_batch.to_h)
+      assert_equal({
+                     "boolean" => @boolean_array,
+                     "int32" => @int32_array,
+                   },
+                   record_batch.to_h)
     end
 
     test("{String => Array}") do
@@ -55,8 +63,8 @@ class TestRecordBatch < Test::Unit::TestCase
       ]
       record_batch = ArrowFormat::RecordBatch.new(raw_records)
       assert_equal({
-                     boolean: @boolean_array,
-                     int32: @int32_array,
+                     "boolean" => @boolean_array,
+                     "int32" => @int32_array,
                    },
                    record_batch.to_h)
     end
@@ -71,5 +79,52 @@ class TestRecordBatch < Test::Unit::TestCase
         ArrowFormat::RecordBatch.new(raw_records)
       end
     end
+  end
+
+  sub_test_case("#find_column") do
+    test("Integer") do
+      assert_equal(@int32_array, @record_batch.find_column(1))
+    end
+
+    test("String") do
+      assert_equal(@int32_array, @record_batch.find_column("int32"))
+    end
+
+    test("Symbol") do
+      assert_equal(@int32_array, @record_batch.find_column(:int32))
+    end
+  end
+
+  sub_test_case("#each_record") do
+    test("default") do
+      assert_equal([
+                     [true, -(2 ** 31)],
+                     [nil, 0],
+                     [false, (2 ** 31) - 1],
+                   ],
+                   @record_batch.each_record.collect(&:to_a))
+    end
+
+    test(":reuse_record") do
+      actual = []
+      @record_batch.each_record(reuse_record: true) do |record|
+        actual << [record.object_id, record.index]
+      end
+      assert_equal([
+                     [actual[0][0], 0],
+                     [actual[0][0], 1],
+                     [actual[0][0], 2],
+                   ],
+                   actual)
+    end
+  end
+
+  test("#records") do
+    assert_equal([
+                   {"boolean" => true,  "int32" => -(2 ** 31)},
+                   {"boolean" => nil,   "int32" => 0},
+                   {"boolean" => false, "int32" => (2 ** 31) - 1},
+                 ],
+                 @record_batch.records.collect(&:to_h))
   end
 end

--- a/ruby/red-arrow-format/test/test-record.rb
+++ b/ruby/red-arrow-format/test/test-record.rb
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRecord < Test::Unit::TestCase
+  def setup
+    @boolean_array = ArrowFormat::BooleanArray.new([true, nil, false])
+    @int32_array = ArrowFormat::Int32Array.new([-(2 ** 31), 0, (2 ** 31) - 1])
+    @record_batch = ArrowFormat::RecordBatch.new({
+                                                   boolean: @boolean_array,
+                                                   int32: @int32_array,
+                                                 })
+    @record = @record_batch.records[1]
+  end
+
+  sub_test_case("#[]") do
+    test("Integer") do
+      assert_equal(0, @record[1])
+    end
+
+    test("String") do
+      assert_equal(0, @record["int32"])
+    end
+
+    test("Symbol") do
+      assert_equal(0, @record[:int32])
+    end
+  end
+
+  def test_to_a
+    assert_equal([nil, 0], @record.to_a)
+  end
+
+  def test_to_h
+    assert_equal({"boolean" => nil, "int32" => 0}, @record.to_h)
+  end
+
+  sub_test_case("#respond_to_missing?") do
+    def test_existent
+      assert do
+        @record.respond_to?("int32")
+      end
+    end
+
+    def test_nonexistent
+      assert do
+        not @record.respond_to?("nonexistent")
+      end
+    end
+  end
+
+  sub_test_case("#method_missing") do
+    def test_existent
+      assert_equal(0, @record.int32)
+    end
+
+    def test_existent_have_argument
+      assert_raise(NoMethodError) do
+        @record.int32(nil)
+      end
+    end
+
+    def test_nonexitent
+      assert_raise(NoMethodError) do
+        @record.nonexistent
+      end
+    end
+  end
+end

--- a/ruby/red-arrow-format/test/test-time32-array.rb
+++ b/ruby/red-arrow-format/test/test-time32-array.rb
@@ -62,7 +62,7 @@ class TestTime32Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-time64-array.rb
+++ b/ruby/red-arrow-format/test/test-time64-array.rb
@@ -62,7 +62,7 @@ class TestTime64Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-timestamp-array.rb
+++ b/ruby/red-arrow-format/test/test-timestamp-array.rb
@@ -92,7 +92,7 @@ class TestTimestampArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-uint16-array.rb
+++ b/ruby/red-arrow-format/test/test-uint16-array.rb
@@ -60,7 +60,7 @@ class TestUInt16Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-uint32-array.rb
+++ b/ruby/red-arrow-format/test/test-uint32-array.rb
@@ -60,7 +60,7 @@ class TestUInt32Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-uint64-array.rb
+++ b/ruby/red-arrow-format/test/test-uint64-array.rb
@@ -60,7 +60,7 @@ class TestUInt64Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-uint8-array.rb
+++ b/ruby/red-arrow-format/test/test-uint8-array.rb
@@ -60,7 +60,7 @@ class TestUInt8Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-utf8-array.rb
+++ b/ruby/red-arrow-format/test/test-utf8-array.rb
@@ -60,7 +60,7 @@ class TestUTF8Array < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null

--- a/ruby/red-arrow-format/test/test-year-month-interval-array.rb
+++ b/ruby/red-arrow-format/test/test-year-month-interval-array.rb
@@ -60,7 +60,7 @@ class TestYearMonthIntervalArray < Test::Unit::TestCase
 
   sub_test_case("#[]") do
     def test_valid
-      assert_equal(@values[3], @array[3])
+      assert_equal(@values[2], @array[2])
     end
 
     def test_null


### PR DESCRIPTION
### Rationale for this change

It's a convenient API to get values as Ruby objects.

### What changes are included in this PR?

* Add `ArrowFormat::RecordBatch#records`
* Add `ArrowFormat::RecordBatch#each_record`
* Add `ArrowFormat::Record`
* Add `ArrowFormat::RecordBatch#find_column`
* Add `ArrowFormat::Schema#[]`
* Ensure using `String` for `ArrowFormat::Field#name`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #50572