### PR TITLE
GH-50597: [CI] Retry Chrome PyArrow load and fix Snappy Emscripten configure

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1451,8 +1451,7 @@ macro(build_snappy)
     # ignore linker flag errors, as Snappy sets
     # -Werror -Wall, and Emscripten doesn't support -soname
     list(APPEND SNAPPY_CMAKE_ARGS
-         "-DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
-         "-Wno-error=linkflags")
+         "-DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}")
   endif()
 
   externalproject_add(snappy_ep

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -207,13 +207,9 @@ class NodeDriver:
 
 class BrowserDriver:
     def __init__(self, hostname, port, driver):
-        self.hostname = hostname
-        self.port = port
+        self.url = f"http://{hostname}:{port}/test.html"
         self.driver = driver
-        self._open_test_page()
-
-    def _open_test_page(self):
-        self.driver.get(f"http://{self.hostname}:{self.port}/test.html")
+        self.driver.get(self.url)
         # Chrome on CI takes longer than locally to compile.
         self.driver.set_script_timeout(1200)
 
@@ -238,7 +234,7 @@ class BrowserDriver:
             self.driver.set_script_timeout(1200)
 
     def restart_browser(self):
-        self._open_test_page()
+        self.driver.get(self.url)
 
     def execute_python(self, code, wait_for_terminate=True):
         if wait_for_terminate:
@@ -299,7 +295,8 @@ class ChromeDriver(BrowserDriver):
     def restart_browser(self):
         self.driver.quit()
         self.driver = self._make_driver()
-        self._open_test_page()
+        self.driver.get(self.url)
+        self.driver.set_script_timeout(1200)
 
 
 class FirefoxDriver(BrowserDriver):

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -222,7 +222,7 @@ class BrowserDriver:
         code = (f"import pyodide_js as pjs\n"
                 f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
         for attempt in range(3):
-            # Set temporary timeout for every attempt as Chrome restart creates a new driver
+            # Set temporary timeout each attempt as Chrome restart creates a driver
             self.driver.set_script_timeout(300)
             try:
                 self.execute_python(code)

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -35,6 +35,12 @@ from selenium.common.exceptions import TimeoutException
 
 
 class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
+    def handle(self):
+        try:
+            super().handle()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
     def log_request(self, code="-", size="-"):
         # don't log successful requests but log errors
         if isinstance(code, int) and code >= 400:
@@ -201,8 +207,13 @@ class NodeDriver:
 
 class BrowserDriver:
     def __init__(self, hostname, port, driver):
+        self.hostname = hostname
+        self.port = port
         self.driver = driver
-        self.driver.get(f"http://{hostname}:{port}/test.html")
+        self._open_test_page()
+
+    def _open_test_page(self):
+        self.driver.get(f"http://{self.hostname}:{self.port}/test.html")
         # Chrome on CI takes longer than locally to compile.
         self.driver.set_script_timeout(1200)
 
@@ -220,11 +231,14 @@ class BrowserDriver:
                 except TimeoutException:
                     if attempt == 2:
                         raise
-                    print("Timed out loading PyArrow in browser. Retrying",
+                    print("Timed out loading PyArrow in browser. Restarting browser",
                           flush=True)
-                    self.driver.refresh()
+                    self.restart_browser()
         finally:
             self.driver.set_script_timeout(1200)
+
+    def restart_browser(self):
+        self._open_test_page()
 
     def execute_python(self, code, wait_for_terminate=True):
         if wait_for_terminate:
@@ -268,7 +282,8 @@ class BrowserDriver:
 
 
 class ChromeDriver(BrowserDriver):
-    def __init__(self, hostname, port):
+    @staticmethod
+    def _make_driver():
         from selenium.webdriver.chrome.options import Options
 
         options = Options()
@@ -276,7 +291,15 @@ class ChromeDriver(BrowserDriver):
         options.add_argument("--no-sandbox")
         driver = webdriver.Chrome(options=options)
         driver.command_executor._client_config.timeout = 1200
-        super().__init__(hostname, port, driver)
+        return driver
+
+    def __init__(self, hostname, port):
+        super().__init__(hostname, port, self._make_driver())
+
+    def restart_browser(self):
+        self.driver.quit()
+        self.driver = self._make_driver()
+        self._open_test_page()
 
 
 class FirefoxDriver(BrowserDriver):

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from io import BytesIO
 
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
 
 
 class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
@@ -209,10 +210,21 @@ class BrowserDriver:
         pass
 
     def load_arrow(self):
-        self.execute_python(
-            f"import pyodide_js as pjs\n"
-            f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n"
-        )
+        code = (f"import pyodide_js as pjs\n"
+                f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
+        self.driver.set_script_timeout(300)
+        try:
+            for attempt in range(3):
+                try:
+                    return self.execute_python(code)
+                except TimeoutException:
+                    if attempt == 2:
+                        raise
+                    print("Timed out loading PyArrow in browser. Retrying",
+                          flush=True)
+                    self.driver.refresh()
+        finally:
+            self.driver.set_script_timeout(1200)
 
     def execute_python(self, code, wait_for_terminate=True):
         if wait_for_terminate:

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -39,6 +39,8 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
         try:
             super().handle()
         except (BrokenPipeError, ConnectionResetError):
+            # Browser restart while downloading wheel closes connection
+            # before server response is written so ignore harmless errors
             pass
 
     def log_request(self, code="-", size="-"):
@@ -219,19 +221,20 @@ class BrowserDriver:
     def load_arrow(self):
         code = (f"import pyodide_js as pjs\n"
                 f"await pjs.loadPackage('{PYARROW_WHEEL_PATH.name}')\n")
-        self.driver.set_script_timeout(300)
-        try:
-            for attempt in range(3):
-                try:
-                    return self.execute_python(code)
-                except TimeoutException:
-                    if attempt == 2:
-                        raise
-                    print("Timed out loading PyArrow in browser. Restarting browser",
-                          flush=True)
-                    self.restart_browser()
-        finally:
-            self.driver.set_script_timeout(1200)
+        for attempt in range(3):
+            # Set temporary timeout for every attempt as Chrome restart creates a new driver
+            self.driver.set_script_timeout(300)
+            try:
+                self.execute_python(code)
+            except TimeoutException:
+                if attempt == 2:
+                    raise
+                print("Timed out loading PyArrow in browser. Restarting browser",
+                      flush=True)
+                self.restart_browser()
+            else:
+                self.driver.set_script_timeout(1200)
+                return
 
     def restart_browser(self):
         self.driver.get(self.url)


### PR DESCRIPTION
### Rationale for this change
Fix #50597. Nightly Crossbow job `test-conda-python-emscripten` sometimes finishes with success like [2026-07-18 Docker Test conda-python-emscripten](https://github.com/ursacomputing/crossbow/actions/runs/29628907267/job/88038728709#step:6:7261)

But often hangs like [2026-07-19 Docker Test conda-python-emscripten](https://github.com/ursacomputing/crossbow/actions/runs/29672419322/job/88153721397#step:6:6851)
and [2026-07-20 Docker Test conda-python-emscripten](https://github.com/ursacomputing/crossbow/actions/runs/29715959996/job/88269203693#step:6:6846)
```
    driver.load_arrow()
...
selenium.common.exceptions.TimeoutException: Message: script timeout
```

Additionally, main nightly started failing during `snappy_ep` configure with CMake 4.4: `CMake Error: The warning category "linkflags" is not known.`



### What changes are included in this PR?
import `TimeoutException`, introduce 300s timeout + 3 attempts around load_arrow() and full Chrome restart on timeout,
ignore harmless `BrokenPipeError` / `ConnectionResetError` when Chrome has to be killed mid-download for retry.

Also remove the redundant standalone `-Wno-error=linkflags` CMake argument from Snappy's Emscripten configure arguments. The flag remains in `CMAKE_SHARED_LINKER_FLAGS`

### Are these changes tested?
Yes, locally by `docker compose run --rm -e SETUPTOOLS_SCM_PRETEND_VERSION=26.0.0.dev0  conda-python-emscripten`.
Example test run hit the PyArrow load timeout once, restarted Chrome, and then completed successfully.

### Are there any user-facing changes?
No.
* GitHub Issue: #50597