### PR TITLE
GH-50565: [CI][C++] Add a JNI Windows CI job

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -459,14 +459,13 @@ jobs:
             -S cpp/examples/minimal_build ^
             -B cpp/examples/minimal_build.build ^
             -GNinja ^
+            -DCMAKE_BUILD_TYPE=Release ^
             -DCMAKE_INSTALL_PREFIX=%CD%\cpp.install
 
-          type cpp\examples\minimal_build.build\CMakeCache.txt | findstr CMAKE_BUILD_TYPE
-          type cpp\examples\minimal_build.build\CMakeCache.txt | findstr CMAKE_MSVC_RUNTIME_LIBRARY
+          cmake --build cpp/examples/minimal_build.build
 
-          cmake --build cpp/examples/minimal_build.build --verbose
-
-          call cpp\examples\minimal_build.build\arrow-example.exe
+          cd cpp\examples\minimal_build
+          call ..\minimal_build.build\arrow-example.exe
 
       - name: Save ccache
         if: ${{ !cancelled() }}

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -461,7 +461,10 @@ jobs:
             -GNinja ^
             -DCMAKE_INSTALL_PREFIX=%CD%\cpp.install
 
-          cmake --build cpp/examples/minimal_build.build
+          type cpp\examples\minimal_build.build\CMakeCache.txt | findstr CMAKE_BUILD_TYPE
+          type cpp\examples\minimal_build.build\CMakeCache.txt | findstr CMAKE_MSVC_RUNTIME_LIBRARY
+
+          cmake --build cpp/examples/minimal_build.build --verbose
 
           call cpp\examples\minimal_build.build\arrow-example.exe
 

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -429,14 +429,6 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cmake --install cpp.build
 
-      - name: Save ccache
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: jni-windows
-
       - name: Test
         shell: cmd
         env:
@@ -457,6 +449,29 @@ jobs:
             --parallel %NUMBER_OF_PROCESSORS% ^
             --test-dir cpp.build ^
             --timeout 300
+
+      - name: Build example
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+
+          cmake ^
+            -S cpp/examples/minimal_build ^
+            -B cpp/examples/minimal_build.build ^
+            -GNinja ^
+            -DCMAKE_INSTALL_PREFIX=%CD%\cpp.install
+
+          cmake --build cpp/examples/minimal_build.build
+
+          call cpp\examples\minimal_build.build\arrow-example.exe
+
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: jni-windows
 
   odbc-linux:
     needs: check-enabled

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -351,6 +351,128 @@ jobs:
           path: ccache
           key: jni-macos
 
+  jni-windows:
+    needs: check-enabled
+    if: needs.check-enabled.outputs.is_enabled == 'true'
+    name: JNI Windows
+    runs-on: windows-2022
+    timeout-minutes: 240
+
+    steps:
+      - name: Disable Crash Dialogs
+        run: |
+          reg add `
+            "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
+            /v DontShowUI `
+            /t REG_DWORD `
+            /d 1 `
+            /f
+
+      - name: Checkout Arrow
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install msys2 (for tzdata for ORC tests)
+        uses: msys2/setup-msys2@v2
+        id: setup-msys2
+
+      - name: Install cmake
+        shell: bash
+        run: |
+          ci/scripts/install_cmake.sh 4.1.2 /usr
+
+      - name: Install ccache
+        shell: bash
+        run: |
+          ci/scripts/install_ccache.sh 4.13.6 /usr
+
+      - name: Setup ccache
+        shell: bash
+        run: |
+          ci/scripts/ccache_setup.sh
+
+      - name: ccache info
+        id: ccache-info
+        shell: bash
+        run: |
+          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
+
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: jni-windows
+
+      - name: CMake
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cmake ^
+            -S cpp ^
+            -B cpp.build ^
+            --preset=ninja-release-jni-windows ^
+            -DARROW_BUILD_TESTS=ON ^
+            -DCMAKE_INSTALL_PREFIX=%CD%\cpp.install
+
+      - name: Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cmake --build cpp.build
+
+      - name: Install
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cmake --install cpp.build
+
+      - name: Test
+        shell: cmd
+        env:
+          MSYS2_LOCATION: ${{ steps.setup-msys2.outputs.msys2-location }}
+          ARROW_TEST_DATA: ${{ github.workspace }}\testing\data
+          PARQUET_TEST_DATA: ${{ github.workspace }}\cpp\submodules\parquet-testing\data
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          set TZDIR=%MSYS2_LOCATION%\usr\share\zoneinfo
+
+          set exclude_tests=arrow-acero-asof-join-node-test
+          set exclude_tests=%exclude_tests%|arrow-acero-hash-join-node-test
+
+          ctest ^
+            --exclude-regex "%exclude_tests%" ^
+            --label-regex unittest ^
+            --output-on-failure ^
+            --parallel %NUMBER_OF_PROCESSORS% ^
+            --test-dir cpp.build ^
+            --timeout 300
+
+      - name: Build example
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+
+          cmake ^
+            -S cpp/examples/minimal_build ^
+            -B cpp/examples/minimal_build.build ^
+            -GNinja ^
+            -DCMAKE_INSTALL_PREFIX=%CD%\cpp.install
+
+          cmake --build cpp/examples/minimal_build.build
+
+          call cpp\examples\minimal_build.build\arrow-example.exe
+
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: jni-windows
+
   odbc-linux:
     needs: check-enabled
     if: needs.check-enabled.outputs.is_enabled == 'true'

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -440,7 +440,7 @@ jobs:
           set TZDIR=%MSYS2_LOCATION%\usr\share\zoneinfo
 
           set exclude_tests=arrow-acero-asof-join-node-test
-          set exclude_tests=%exclude_tests%|arrow-acero-hash-join-node-test
+          set exclude_tests=%exclude_tests%^|arrow-acero-hash-join-node-test
 
           ctest ^
             --exclude-regex "%exclude_tests%" ^

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -429,6 +429,14 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cmake --install cpp.build
 
+      - name: Save ccache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: jni-windows
+
       - name: Test
         shell: cmd
         env:
@@ -449,29 +457,6 @@ jobs:
             --parallel %NUMBER_OF_PROCESSORS% ^
             --test-dir cpp.build ^
             --timeout 300
-
-      - name: Build example
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-
-          cmake ^
-            -S cpp/examples/minimal_build ^
-            -B cpp/examples/minimal_build.build ^
-            -GNinja ^
-            -DCMAKE_INSTALL_PREFIX=%CD%\cpp.install
-
-          cmake --build cpp/examples/minimal_build.build
-
-          call cpp\examples\minimal_build.build\arrow-example.exe
-
-      - name: Save ccache
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: jni-windows
 
   odbc-linux:
     needs: check-enabled

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -681,6 +681,28 @@
         "PARQUET_REQUIRE_ENCRYPTION": "OFF",
         "re2_SOURCE": "BUNDLED"
       }
+    },
+    {
+      "name": "ninja-release-jni-windows",
+      "inherits": [
+        "base-release"
+      ],
+      "displayName": "Build for JNI on Windows",
+      "cacheVariables": {
+        "ARROW_ACERO": "ON",
+        "ARROW_BUILD_SHARED": "OFF",
+        "ARROW_BUILD_STATIC": "ON",
+        "ARROW_CSV": "ON",
+        "ARROW_DATASET": "ON",
+        "ARROW_DEPENDENCY_USE_SHARED": "OFF",
+        "ARROW_ORC": "ON",
+        "ARROW_PARQUET": "ON",
+        "ARROW_S3": "ON",
+        "ARROW_SUBSTRAIT": "ON",
+        "PARQUET_BUILD_EXAMPLES": "OFF",
+        "PARQUET_BUILD_EXECUTABLES": "OFF",
+        "PARQUET_REQUIRE_ENCRYPTION": "OFF"
+      }
     }
   ]
 }

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -699,6 +699,10 @@
         "ARROW_PARQUET": "ON",
         "ARROW_S3": "ON",
         "ARROW_SUBSTRAIT": "ON",
+        "ARROW_WITH_BROTLI": "ON",
+        "ARROW_WITH_LZ4": "ON",
+        "ARROW_WITH_SNAPPY": "ON",
+        "ARROW_WITH_ZSTD": "ON",
         "PARQUET_BUILD_EXAMPLES": "OFF",
         "PARQUET_BUILD_EXECUTABLES": "OFF",
         "PARQUET_REQUIRE_ENCRYPTION": "OFF"

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -46,6 +46,10 @@ if(ARROW_TESTING AND ARROW_COMPUTE)
   target_link_libraries(arrow_compute_testing
                         PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
                         PUBLIC ${ARROW_GTEST_GTEST})
+  if(ARROW_BUILD_STATIC AND WIN32)
+    target_compile_definitions(arrow_compute_testing PUBLIC ARROW_COMPUTE_STATIC
+                                                            ARROW_STATIC)
+  endif()
 endif()
 
 set(ARROW_COMPUTE_TEST_PREFIX "arrow-compute")

--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -70,6 +70,19 @@ foreach(LIB_TARGET ${ARROW_SUBSTRAIT_LIBRARIES})
   target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_ENGINE_EXPORTING)
 endforeach()
 
+message(STATUS "=== ARROW_SUBSTRAIT_LIBRARIES ===")
+
+foreach(LIB_TARGET ${ARROW_SUBSTRAIT_LIBRARIES})
+  get_target_property(DEFS ${LIB_TARGET} COMPILE_DEFINITIONS)
+  get_target_property(IFACE_DEFS ${LIB_TARGET} INTERFACE_COMPILE_DEFINITIONS)
+  get_target_property(LINK_LIBS ${LIB_TARGET} LINK_LIBRARIES)
+
+  message(STATUS "${LIB_TARGET}")
+  message(STATUS "  COMPILE_DEFINITIONS=${DEFS}")
+  message(STATUS "  INTERFACE_COMPILE_DEFINITIONS=${IFACE_DEFS}")
+  message(STATUS "  LINK_LIBRARIES=${LINK_LIBS}")
+endforeach()
+
 set(ARROW_SUBSTRAIT_TEST_LINK_LIBS ${ARROW_SUBSTRAIT_LINK_lIBS} ${ARROW_TEST_LINK_LIBS})
 if(ARROW_TEST_LINKAGE STREQUAL "static")
   list(APPEND ARROW_SUBSTRAIT_TEST_LINK_LIBS arrow_substrait_static
@@ -94,3 +107,13 @@ add_arrow_test(substrait_test
                "arrow_substrait")
 
 add_subdirectory(substrait)
+
+get_target_property(TEST_DEFS substrait_test COMPILE_DEFINITIONS)
+get_target_property(TEST_IFACE substrait_test INTERFACE_COMPILE_DEFINITIONS)
+
+message(STATUS "=== substrait_test ===")
+message(STATUS "COMPILE_DEFINITIONS=${TEST_DEFS}")
+message(STATUS "INTERFACE_COMPILE_DEFINITIONS=${TEST_IFACE}")
+
+get_target_property(TEST_LIBS substrait_test LINK_LIBRARIES)
+message(STATUS "LINK_LIBRARIES=${TEST_LIBS}")

--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -70,10 +70,13 @@ foreach(LIB_TARGET ${ARROW_SUBSTRAIT_LIBRARIES})
   target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_ENGINE_EXPORTING)
 endforeach()
 
+if(ARROW_BUILD_STATIC AND WIN32)
+  target_compile_definitions(arrow_substrait_static PUBLIC ARROW_ENGINE_STATIC)
+endif()
+
 set(ARROW_SUBSTRAIT_TEST_LINK_LIBS ${ARROW_SUBSTRAIT_LINK_lIBS} ${ARROW_TEST_LINK_LIBS})
 if(ARROW_TEST_LINKAGE STREQUAL "static")
-  list(APPEND ARROW_SUBSTRAIT_TEST_LINK_LIBS arrow_substrait_static
-       arrow_substrait_static)
+  list(APPEND ARROW_SUBSTRAIT_TEST_LINK_LIBS arrow_substrait_static)
 else()
   list(APPEND ARROW_SUBSTRAIT_TEST_LINK_LIBS arrow_substrait_shared)
 endif()

--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -70,19 +70,6 @@ foreach(LIB_TARGET ${ARROW_SUBSTRAIT_LIBRARIES})
   target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_ENGINE_EXPORTING)
 endforeach()
 
-message(STATUS "=== ARROW_SUBSTRAIT_LIBRARIES ===")
-
-foreach(LIB_TARGET ${ARROW_SUBSTRAIT_LIBRARIES})
-  get_target_property(DEFS ${LIB_TARGET} COMPILE_DEFINITIONS)
-  get_target_property(IFACE_DEFS ${LIB_TARGET} INTERFACE_COMPILE_DEFINITIONS)
-  get_target_property(LINK_LIBS ${LIB_TARGET} LINK_LIBRARIES)
-
-  message(STATUS "${LIB_TARGET}")
-  message(STATUS "  COMPILE_DEFINITIONS=${DEFS}")
-  message(STATUS "  INTERFACE_COMPILE_DEFINITIONS=${IFACE_DEFS}")
-  message(STATUS "  LINK_LIBRARIES=${LINK_LIBS}")
-endforeach()
-
 set(ARROW_SUBSTRAIT_TEST_LINK_LIBS ${ARROW_SUBSTRAIT_LINK_lIBS} ${ARROW_TEST_LINK_LIBS})
 if(ARROW_TEST_LINKAGE STREQUAL "static")
   list(APPEND ARROW_SUBSTRAIT_TEST_LINK_LIBS arrow_substrait_static
@@ -107,13 +94,3 @@ add_arrow_test(substrait_test
                "arrow_substrait")
 
 add_subdirectory(substrait)
-
-get_target_property(TEST_DEFS substrait_test COMPILE_DEFINITIONS)
-get_target_property(TEST_IFACE substrait_test INTERFACE_COMPILE_DEFINITIONS)
-
-message(STATUS "=== substrait_test ===")
-message(STATUS "COMPILE_DEFINITIONS=${TEST_DEFS}")
-message(STATUS "INTERFACE_COMPILE_DEFINITIONS=${TEST_IFACE}")
-
-get_target_property(TEST_LIBS substrait_test LINK_LIBRARIES)
-message(STATUS "LINK_LIBRARIES=${TEST_LIBS}")


### PR DESCRIPTION
### Rationale

This adds a Windows CI job for the JNI build configuration, following the existing Linux and macOS JNI CI jobs. The new job uses a dedicated CMake preset to match the build options used by the Windows JNI build.

### What changes are included?

- Add a `ninja-release-jni-windows` CMake preset.
- Add a `jni-windows` job to `cpp_extra.yml`.

* GitHub Issue: #50565