### PR TITLE
GH-50579: [Python] Fix test_categorical_order_survives_roundtrip pandas 3.X deprecation

### DIFF
--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -472,7 +472,7 @@ def test_categorical_index_survives_roundtrip():
 def test_categorical_order_survives_roundtrip():
     # ARROW-6302
     df = pd.DataFrame({"a": pd.Categorical(
-        ["a", "b", "c", "a"], categories=["b", "c", "d"], ordered=True)})
+        ["d", "b", "c", None], categories=["b", "c", "d"], ordered=True)})
 
     table = pa.Table.from_pandas(df)
     bos = pa.BufferOutputStream()


### PR DESCRIPTION
### Rationale for this change
Follow-up to #50543. `test_categorical_order_survives_roundtrip` constructs a
`pd.Categorical` with value "a" not in categories `["b","c","d"]`. pandas 3.0.3
raises a deprecation for out-of-category values, which #50543's filterwarnings
config now turns into an error - failing nightly wheels across platforms.

### What changes are included in this PR?
Replace the out-of-category `"a"` value with an explicit `None`, preserving the
test's intent (ordered categorical with non-sorted categories survives a Parquet
roundtrip, ARROW-6302) plus a null.

### Are these changes tested?
Yes. Reproduced the failure with pandas 3.0.3, confirmed the test passes after
the change; all categorical tests in the module pass.

### Are there any user-facing changes?
No.

Closes #50579.
* GitHub Issue: #50579