### PR TITLE
GH-50609: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_deps.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -339,6 +339,7 @@ repos:
           ?^ci/scripts/python_wheel_macos_build\.sh$|
           ?^ci/scripts/python_wheel_xlinux_build\.sh$|
           ?^ci/scripts/r_build\.sh$|
+          ?^ci/scripts/r_deps\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|

--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -52,6 +52,6 @@ fi
 
 # Separately install the optional/test dependencies but don't error on them,
 # they're not available everywhere and that's ok
-"${R_BIN}" -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '""${INSTALL_ARGS}""')"
+"${R_BIN}" -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '\"${INSTALL_ARGS}\"')"
 
 popd

--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -43,7 +43,7 @@ fi
 # install.packages() emits warnings if packages fail to install,
 # but we want to error/fail the build.
 # options(warn=2) turns warnings into errors
-"${R_BIN}" -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '\"${INSTALL_ARGS}\"')"
+"${R_BIN}" -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '${INSTALL_ARGS}')"
 
 # Install DuckDB from github when requested
 if [ "${R_DUCKDB_DEV}" == "true" ]; then
@@ -52,6 +52,6 @@ fi
 
 # Separately install the optional/test dependencies but don't error on them,
 # they're not available everywhere and that's ok
-"${R_BIN}" -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '\"${INSTALL_ARGS}\"')"
+"${R_BIN}" -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '${INSTALL_ARGS}')"
 
 popd

--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -18,21 +18,21 @@
 
 set -ex
 
-: ${R_BIN:=R}
+: "${R_BIN:=R}"
 
-: ${R_PRUNE_DEPS:=FALSE}
-R_PRUNE_DEPS=`echo $R_PRUNE_DEPS | tr '[:upper:]' '[:lower:]'`
+: "${R_PRUNE_DEPS:=FALSE}"
+R_PRUNE_DEPS=$(echo "$R_PRUNE_DEPS" | tr '[:upper:]' '[:lower:]')
 
-: ${R_DUCKDB_DEV:=FALSE}
-R_DUCKDB_DEV=`echo $R_DUCKDB_DEV | tr '[:upper:]' '[:lower:]'`
+: "${R_DUCKDB_DEV:=FALSE}"
+R_DUCKDB_DEV=$(echo "$R_DUCKDB_DEV" | tr '[:upper:]' '[:lower:]')
 
-source_dir=${1}/r
+source_dir="${1}/r"
 
-pushd ${source_dir}
+pushd "${source_dir}"
 
-if [ ${R_PRUNE_DEPS} = "true" ]; then
+if [ "${R_PRUNE_DEPS}" = "true" ]; then
   # To prevent the build from timing out, let's prune some optional deps (and their possible version requirements)
-  ${R_BIN} -e 'd <- read.dcf("DESCRIPTION")
+  "${R_BIN}" -e 'd <- read.dcf("DESCRIPTION")
   to_prune <- c("duckdb", "DBI", "dbplyr", "decor", "knitr", "rmarkdown", "pkgload", "reticulate")
   pattern <- paste0("\\n?", to_prune, " (\\\\(.*\\\\))?,?", collapse = "|")
   d[,"Suggests"] <- gsub(pattern, "", d[,"Suggests"])
@@ -43,15 +43,15 @@ fi
 # install.packages() emits warnings if packages fail to install,
 # but we want to error/fail the build.
 # options(warn=2) turns warnings into errors
-${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '"${INSTALL_ARGS}"')"
+"${R_BIN}" -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '""${INSTALL_ARGS}""')"
 
 # Install DuckDB from github when requested
-if [ ${R_DUCKDB_DEV} == "true" ]; then
-  ${R_BIN} -e "remotes::install_github('duckdb/duckdb-r', build = FALSE)"
+if [ "${R_DUCKDB_DEV}" == "true" ]; then
+  "${R_BIN}" -e "remotes::install_github('duckdb/duckdb-r', build = FALSE)"
 fi
 
 # Separately install the optional/test dependencies but don't error on them,
 # they're not available everywhere and that's ok
-${R_BIN} -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '"${INSTALL_ARGS}"')"
+"${R_BIN}" -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '""${INSTALL_ARGS}""')"
 
 popd

--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -43,7 +43,7 @@ fi
 # install.packages() emits warnings if packages fail to install,
 # but we want to error/fail the build.
 # options(warn=2) turns warnings into errors
-"${R_BIN}" -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '""${INSTALL_ARGS}""')"
+"${R_BIN}" -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '\"${INSTALL_ARGS}\"')"
 
 # Install DuckDB from github when requested
 if [ "${R_DUCKDB_DEV}" == "true" ]; then


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2027: The surrounding quotes actually unquote this. Remove or escape them.
* SC2086: Double quote to prevent globbing and word splitting.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.


```
shellcheck ci/scripts/r_deps.sh

In ci/scripts/r_deps.sh line 21:
: ${R_BIN:=R}
  ^---------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_deps.sh line 23:
: ${R_PRUNE_DEPS:=FALSE}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_deps.sh line 24:
R_PRUNE_DEPS=`echo $R_PRUNE_DEPS | tr '[:upper:]' '[:lower:]'`
             ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                   ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
R_PRUNE_DEPS=$(echo "$R_PRUNE_DEPS" | tr '[:upper:]' '[:lower:]')


In ci/scripts/r_deps.sh line 26:
: ${R_DUCKDB_DEV:=FALSE}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_deps.sh line 27:
R_DUCKDB_DEV=`echo $R_DUCKDB_DEV | tr '[:upper:]' '[:lower:]'`
             ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                   ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
R_DUCKDB_DEV=$(echo "$R_DUCKDB_DEV" | tr '[:upper:]' '[:lower:]')


In ci/scripts/r_deps.sh line 31:
pushd ${source_dir}
      ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${source_dir}"


In ci/scripts/r_deps.sh line 33:
if [ ${R_PRUNE_DEPS} = "true" ]; then
     ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "${R_PRUNE_DEPS}" = "true" ]; then


In ci/scripts/r_deps.sh line 46:
${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '"${INSTALL_ARGS}"')"
                                                                                                                                                        ^-------------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.
                                                                                                                                                        ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '""${INSTALL_ARGS}""')"


In ci/scripts/r_deps.sh line 49:
if [ ${R_DUCKDB_DEV} == "true" ]; then
     ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "${R_DUCKDB_DEV}" == "true" ]; then


In ci/scripts/r_deps.sh line 55:
${R_BIN} -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '"${INSTALL_ARGS}"')"
                                                                         ^-------------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.
                                                                         ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${R_BIN} -e "remotes::install_deps(dependencies = TRUE, INSTALL_opts = '""${INSTALL_ARGS}""')"

For more information:
  https://www.shellcheck.net/wiki/SC2027 -- The surrounding quotes actually u...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
```



### What changes are included in this PR?

* SC2027: Remove redundant quotes.
* SC2086: Quote variable expansions.
* SC2223: Quote default variable assignments.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50609