### PR TITLE
GH-50637: [C++] Register bundled Abseil libraries in `build_absl()`

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1945,6 +1945,101 @@ function(build_absl)
     # Cannot use set_property on alias targets (absl::time is an alias)
     target_link_libraries(time INTERFACE ${CoreFoundation})
   endif()
+
+  list(APPEND
+       ARROW_BUNDLED_STATIC_LIBS
+       absl::bad_any_cast_impl
+       absl::bad_optional_access
+       absl::bad_variant_access
+       absl::base
+       absl::city
+       absl::civil_time
+       absl::cord
+       absl::cord_internal
+       absl::cordz_functions
+       absl::cordz_handle
+       absl::cordz_info
+       absl::cordz_sample_token
+       absl::crc32c
+       absl::crc_cord_state
+       absl::crc_cpu_detect
+       absl::crc_internal
+       absl::debugging_internal
+       absl::decode_rust_punycode
+       absl::demangle_internal
+       absl::demangle_rust
+       absl::die_if_null
+       absl::examine_stack
+       absl::exponential_biased
+       absl::failure_signal_handler
+       absl::flags_commandlineflag
+       absl::flags_commandlineflag_internal
+       absl::flags_config
+       absl::flags_internal
+       absl::flags_marshalling
+       absl::flags_parse
+       absl::flags_private_handle_accessor
+       absl::flags_program_name
+       absl::flags_reflection
+       absl::flags_usage
+       absl::flags_usage_internal
+       absl::graphcycles_internal
+       absl::hash
+       absl::hashtablez_sampler
+       absl::int128
+       absl::kernel_timeout_internal
+       absl::leak_check
+       absl::log_globals
+       absl::log_initialize
+       absl::log_internal_check_op
+       absl::log_internal_conditions
+       absl::log_internal_fnmatch
+       absl::log_internal_format
+       absl::log_internal_globals
+       absl::log_internal_log_sink_set
+       absl::log_internal_message
+       absl::log_internal_nullguard
+       absl::log_internal_proto
+       absl::log_severity
+       absl::log_sink
+       absl::low_level_hash
+       absl::malloc_internal
+       absl::periodic_sampler
+       absl::poison
+       absl::random_distributions
+       absl::random_internal_distribution_test_util
+       absl::random_internal_platform
+       absl::random_internal_pool_urbg
+       absl::random_internal_randen
+       absl::random_internal_randen_hwaes
+       absl::random_internal_randen_hwaes_impl
+       absl::random_internal_randen_slow
+       absl::random_internal_seed_material
+       absl::random_seed_gen_exception
+       absl::random_seed_sequences
+       absl::raw_hash_set
+       absl::raw_logging_internal
+       absl::scoped_set_env
+       absl::spinlock_wait
+       absl::stacktrace
+       absl::status
+       absl::statusor
+       absl::str_format_internal
+       absl::strerror
+       absl::strings
+       absl::strings_internal
+       absl::symbolize
+       absl::synchronization
+       absl::throw_delegate
+       absl::time
+       absl::time_zone
+       absl::utf8_for_code_point
+       absl::vlog_config_internal)
+
+  set(ARROW_BUNDLED_STATIC_LIBS
+      "${ARROW_BUNDLED_STATIC_LIBS}"
+      PARENT_SCOPE)
+
   list(POP_BACK CMAKE_MESSAGE_INDENT)
 endfunction()
 
@@ -2119,103 +2214,8 @@ function(build_protobuf)
                           PROPERTIES IMPORTED_LOCATION "${PROTOBUF_HOST_COMPILER}")
 
     add_dependencies(arrow::protobuf::host_protoc protobuf_ep_host)
-    # For cross-compilation along with ExternalProject we need to
-    # manually include absl deps to the bundled static libs so that
-    # they are available for the generated code in protobuf v31.
-    list(APPEND
-         ARROW_BUNDLED_STATIC_LIBS
-         absl::bad_any_cast_impl
-         absl::bad_optional_access
-         absl::bad_variant_access
-         absl::base
-         absl::city
-         absl::civil_time
-         absl::cord
-         absl::cord_internal
-         absl::cordz_functions
-         absl::cordz_handle
-         absl::cordz_info
-         absl::cordz_sample_token
-         absl::crc32c
-         absl::crc_cord_state
-         absl::crc_cpu_detect
-         absl::crc_internal
-         absl::debugging_internal
-         absl::decode_rust_punycode
-         absl::demangle_internal
-         absl::demangle_rust
-         absl::die_if_null
-         absl::examine_stack
-         absl::exponential_biased
-         absl::failure_signal_handler
-         absl::flags_commandlineflag
-         absl::flags_commandlineflag_internal
-         absl::flags_config
-         absl::flags_internal
-         absl::flags_marshalling
-         absl::flags_parse
-         absl::flags_private_handle_accessor
-         absl::flags_program_name
-         absl::flags_reflection
-         absl::flags_usage
-         absl::flags_usage_internal
-         absl::graphcycles_internal
-         absl::hash
-         absl::hashtablez_sampler
-         absl::int128
-         absl::kernel_timeout_internal
-         absl::leak_check
-         absl::log_globals
-         absl::log_initialize
-         absl::log_internal_check_op
-         absl::log_internal_conditions
-         absl::log_internal_fnmatch
-         absl::log_internal_format
-         absl::log_internal_globals
-         absl::log_internal_log_sink_set
-         absl::log_internal_message
-         absl::log_internal_nullguard
-         absl::log_internal_proto
-         absl::log_severity
-         absl::log_sink
-         absl::low_level_hash
-         absl::malloc_internal
-         absl::periodic_sampler
-         absl::poison
-         absl::random_distributions
-         absl::random_internal_distribution_test_util
-         absl::random_internal_platform
-         absl::random_internal_pool_urbg
-         absl::random_internal_randen
-         absl::random_internal_randen_hwaes
-         absl::random_internal_randen_hwaes_impl
-         absl::random_internal_randen_slow
-         absl::random_internal_seed_material
-         absl::random_seed_gen_exception
-         absl::random_seed_sequences
-         absl::raw_hash_set
-         absl::raw_logging_internal
-         absl::scoped_set_env
-         absl::spinlock_wait
-         absl::stacktrace
-         absl::status
-         absl::statusor
-         absl::str_format_internal
-         absl::strerror
-         absl::strings
-         absl::strings_internal
-         absl::symbolize
-         absl::synchronization
-         absl::throw_delegate
-         absl::time
-         absl::time_zone
-         absl::utf8_for_code_point
-         absl::vlog_config_internal)
+    list(POP_BACK CMAKE_MESSAGE_INDENT)
   endif()
-  set(ARROW_BUNDLED_STATIC_LIBS
-      "${ARROW_BUNDLED_STATIC_LIBS}"
-      PARENT_SCOPE)
-  list(POP_BACK CMAKE_MESSAGE_INDENT)
 endfunction()
 
 # Abseil must be resolved before Protobuf because Protobuf 22+ requires


### PR DESCRIPTION
### What changes are included?

Move the registration of bundled Abseil static libraries from `build_protobuf()` to `build_absl()`.

Since the Abseil targets are defined in `build_absl()`, registering them there keeps the bundled dependency registration with the component that provides them instead of coupling it to the Protobuf build logic.

### Are these changes tested?

- Configured Arrow successfully with CMake.
- Built Arrow successfully with the default configuration.
- CI will verify the change across supported platforms, including the Windows configuration where this issue was originally observed.

### Are there any user-facing changes?

No. This is an internal CMake/build system change.

Closes: https://github.com/apache/arrow/issues/50637
* GitHub Issue: #50637