### PR TITLE
GH-50600: [Release][Python] Fix verification jobs after dropping Python 3.10

### DIFF
--- a/ci/docker/ubuntu-22.04-verify-rc.dockerfile
+++ b/ci/docker/ubuntu-22.04-verify-rc.dockerfile
@@ -21,10 +21,19 @@ FROM --platform=linux/${arch} ${base}
 
 ENV DEBIAN_FRONTEND=noninteractive
 COPY dev/release/setup-ubuntu.sh /
-RUN /setup-ubuntu.sh && \
+RUN INSTALL_PYTHON=0 /setup-ubuntu.sh && \
     rm /setup-ubuntu.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*
+
+# Ubuntu 22.04 only provides Python 3.10. Install a supported Python from
+# conda-forge (without activating Conda env) for non-Conda verify-rc job
+COPY ci/scripts/install_conda.sh /arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_conda.sh miniforge3 26.1.1-3 /opt/conda && \
+    /opt/conda/bin/mamba create -y -p /opt/python python=3.12 && \
+    /opt/conda/bin/mamba clean --all --yes
+ENV PATH=/opt/python/bin:$PATH \
+    PYTHON_VERSION=3.12
 
 ARG cmake
 COPY ci/scripts/install_cmake.sh /arrow/ci/scripts/

--- a/ci/docker/ubuntu-22.04-verify-rc.dockerfile
+++ b/ci/docker/ubuntu-22.04-verify-rc.dockerfile
@@ -28,12 +28,18 @@ RUN INSTALL_PYTHON=0 /setup-ubuntu.sh && \
 
 # Ubuntu 22.04 only provides Python 3.10. Install a supported Python from
 # conda-forge (without activating Conda env) for non-Conda verify-rc job
+ARG python=3.12
 COPY ci/scripts/install_conda.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_conda.sh miniforge3 26.1.1-3 /opt/conda && \
-    /opt/conda/bin/mamba create -y -p /opt/python python=3.12 && \
-    /opt/conda/bin/mamba clean --all --yes
+    /opt/conda/bin/mamba create -y -p /opt/python python=${python} && \
+    rm -rf \
+        /etc/profile.d/conda.sh \
+        /opt/conda \
+        /root/.conda \
+        /root/.condarc \
+        /root/.mamba
 ENV PATH=/opt/python/bin:$PATH \
-    PYTHON_VERSION=3.12
+    PYTHON_VERSION=${python}
 
 ARG cmake
 COPY ci/scripts/install_cmake.sh /arrow/ci/scripts/

--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -26,12 +26,12 @@ version=$(. /etc/os-release && echo ${VERSION_ID})
 
 apt-get update -y -q
 
-python_packages=()
+# The Ubuntu 22.04 verification image supplies a supported Python separately.
 if [ "${INSTALL_PYTHON:-1}" -gt 0 ]; then
-  python_packages=(python3-dev python3-venv python3-pip)
-  if [ -n "${PYTHON_VERSION:-}" ]; then
-    python_packages=("python${PYTHON_VERSION}-dev" "python${PYTHON_VERSION}-venv")
-  fi
+  apt-get install -y -q --no-install-recommends \
+    python3-dev \
+    python3-pip \
+    python3-venv
 fi
 
 if [ ${version} \> "22.04" ]; then
@@ -57,7 +57,6 @@ apt-get install -y -q --no-install-recommends \
   ninja-build \
   nlohmann-json3-dev \
   pkg-config \
-  "${python_packages[@]}" \
   ruby-dev \
   tzdata \
   wget

--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -26,6 +26,14 @@ version=$(. /etc/os-release && echo ${VERSION_ID})
 
 apt-get update -y -q
 
+python_packages=()
+if [ "${INSTALL_PYTHON:-1}" -gt 0 ]; then
+  python_packages=(python3-dev python3-venv python3-pip)
+  if [ -n "${PYTHON_VERSION:-}" ]; then
+    python_packages=("python${PYTHON_VERSION}-dev" "python${PYTHON_VERSION}-venv")
+  fi
+fi
+
 if [ ${version} \> "22.04" ]; then
   # Some tests rely on legacy timezone aliases such as "US/Pacific"
   apt-get install -y -q --no-install-recommends \
@@ -49,9 +57,7 @@ apt-get install -y -q --no-install-recommends \
   ninja-build \
   nlohmann-json3-dev \
   pkg-config \
-  python3-dev \
-  python3-venv \
-  python3-pip \
+  "${python_packages[@]}" \
   ruby-dev \
   tzdata \
   wget

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -362,7 +362,7 @@ install_conda() {
 maybe_setup_conda() {
   # Optionally setup conda environment with the passed dependencies
   local env="conda-${CONDA_ENV:-source}"
-  local pyver=${PYTHON_VERSION:-3}
+  local pyver=${PYTHON_VERSION:-3.12}
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     show_info "Configuring Conda environment..."
@@ -377,9 +377,10 @@ maybe_setup_conda() {
     if ! conda env list | cut -d" " -f 1 | grep $env; then
       mamba create -y -n $env python=${pyver}
     fi
-    # Install dependencies
+    # Install dependencies. Python version pinned so an unversioned
+    # python dependency does not replace it
     if [ $# -gt 0 ]; then
-      mamba install -y -n $env $@
+      mamba install -y -n $env python=${pyver} $@
     fi
     # Activate the environment
     conda activate $env

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -41,8 +41,8 @@ jobs:
             {% if distro == 'almalinux' and target|upper == 'PYTHON' %}
             -e ARROW_GANDIVA=OFF \
             {% endif %}
-            {# Use a supported Python version on distributions whose default
-             # Python is older, and avoid selecting free-threaded Python in
+            {# Use a supported Python version on distributions with older
+             # default Python and avoid selecting free-threaded Python in
              # the Conda environment.
             #}
             -e PYTHON_VERSION="3.12" \

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -41,15 +41,11 @@ jobs:
             {% if distro == 'almalinux' and target|upper == 'PYTHON' %}
             -e ARROW_GANDIVA=OFF \
             {% endif %}
-            {% if distro == "conda" and target == "integration" %}
-            {# JPype doesn't work with Python 3.13.
-             # See also:
-             # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5
-             # * GH-44386
-             # * GH-44389
+            {# Use a supported Python version on distributions whose default
+             # Python is older, and avoid selecting free-threaded Python in
+             # the Conda environment.
             #}
             -e PYTHON_VERSION="3.12" \
-            {% endif %}
             -e VERIFY_RC="{{ rc|default("") }}" \
             -e TEST_DEFAULT=0 \
             {% if target == "cpp" %}


### PR DESCRIPTION
### Rationale for this change
Closes #50600
Source verification jobs started failing after Python 3.10 support was dropped.

- [Verify-rc conda python](https://github.com/ursacomputing/crossbow/actions/runs/30161259869/job/89686838514#step:5:2725) `/bin/sh: 1: _Python3_EXECUTABLE-NOTFOUND: not found`
- [Verify-rc ubuntu integration](https://github.com/ursacomputing/crossbow/actions/runs/30161260140/job/89686839204#step:5:11494) `      Python < 3.11 is not supported`
- [Verify-rc ubuntu python](https://github.com/ursacomputing/crossbow/actions/runs/30161260003/job/89686838916#step:5:11258) `ERROR: Package 'pyarrow' requires a different Python: 3.10.12 not in '>=3.11'`

### What changes are included in this PR?
- Use conda-forge Python 3.12 for Ubuntu 22.04, remove Miniforge bootstrap after creating Python environment, and allow Ubuntu verification to skip system Python
- Keep Python pinned during Conda dependency installation to avoid selecting free-threaded Python
- Use Python 3.12 for Linux source verification jobs

### Are these changes tested?
Yes, previously failing verify-rc jobs now pass.

### Are there any user-facing changes?
No.
* GitHub Issue: #50600