### PR TITLE
GH-50659: [C++][Dev] Implement ListView support in gdb_arrow.py

### DIFF
--- a/cpp/gdb_arrow.py
+++ b/cpp/gdb_arrow.py
@@ -1063,6 +1063,8 @@ type_reprs = {
     'FixedSizeBinaryType': 'fixed_size_binary',
     'ListType': 'list',
     'LargeListType': 'large_list',
+    'ListViewType': 'list_view',
+    'LargeListViewType': 'large_list_view',
     'FixedSizeListType': 'fixed_size_list',
     'MapType': 'map',
     'StructType': 'struct_',
@@ -2083,6 +2085,8 @@ type_traits_by_id = {
 
     Type.LIST: DataTypeTraits(BaseListTypeClass, 'ListType'),
     Type.LARGE_LIST: DataTypeTraits(BaseListTypeClass, 'LargeListType'),
+    Type.LIST_VIEW: DataTypeTraits(BaseListTypeClass, 'ListViewType'),
+    Type.LARGE_LIST_VIEW: DataTypeTraits(BaseListTypeClass, 'LargeListViewType'),
     Type.FIXED_SIZE_LIST: DataTypeTraits(FixedSizeListTypeClass,
                                          'FixedSizeListType'),
     Type.MAP: DataTypeTraits(MapTypeClass, 'MapType'),

--- a/python/pyarrow/src/arrow/python/gdb.cc
+++ b/python/pyarrow/src/arrow/python/gdb.cc
@@ -216,8 +216,12 @@ void TestSession() {
 
   ListType list_type(uint8());
   LargeListType large_list_type(large_utf8());
+  ListViewType list_view_type(uint8());
+  LargeListViewType large_list_view_type(large_utf8());
   auto heap_list_type = list(uint8());
   auto heap_large_list_type = large_list(large_utf8());
+  auto heap_list_view_type = list_view(uint8());
+  auto heap_large_list_view_type = large_list_view(large_utf8());
 
   FixedSizeListType fixed_size_list_type(float64(), 3);
   auto heap_fixed_size_list_type = fixed_size_list(float64(), 3);
@@ -385,6 +389,12 @@ void TestSession() {
   LargeListScalar large_list_scalar{list_value_array};
   LargeListScalar large_list_scalar_null{list_zero_length, large_list(int32()),
                                          /*is_valid=*/false};
+  ListViewScalar list_view_scalar{list_value_array};
+  ListViewScalar list_view_scalar_null{list_zero_length, list_view(int32()),
+                                       /*is_valid=*/false};
+  LargeListViewScalar large_list_view_scalar{list_value_array};
+  LargeListViewScalar large_list_view_scalar_null{
+      list_zero_length, large_list_view(int32()), /*is_valid=*/false};
   FixedSizeListScalar fixed_size_list_scalar{list_value_array};
   FixedSizeListScalar fixed_size_list_scalar_null{
       list_value_array, fixed_size_list(int32(), 3), /*is_valid=*/false};
@@ -447,6 +457,11 @@ void TestSession() {
 
   auto heap_list_array = SliceArrayFromJSON(list(int64()), "[[1, 2], null, []]");
   ListArray list_array{heap_list_array->data()};
+  auto heap_list_view_array =
+      SliceArrayFromJSON(list_view(int64()), "[[1, 2], null, []]");
+  ListViewArray list_view_array{heap_list_view_array->data()};
+  auto heap_large_list_view_array =
+      SliceArrayFromJSON(large_list_view(int64()), "[[1, 2], null, []]");
 
   const char* json_double_array = "[-1.5, null]";
   auto heap_double_array = SliceArrayFromJSON(float64(), json_double_array);

--- a/python/pyarrow/tests/test_gdb.py
+++ b/python/pyarrow/tests/test_gdb.py
@@ -405,6 +405,10 @@ def test_types_stack(gdb_arrow):
                      "arrow::list(arrow::uint8())")
     check_stack_repr(gdb_arrow, "large_list_type",
                      "arrow::large_list(arrow::large_utf8())")
+    check_stack_repr(gdb_arrow, "list_view_type",
+                     "arrow::list_view(arrow::uint8())")
+    check_stack_repr(gdb_arrow, "large_list_view_type",
+                     "arrow::large_list_view(arrow::large_utf8())")
     check_stack_repr(gdb_arrow, "fixed_size_list_type",
                      "arrow::fixed_size_list(arrow::float64(), 3)")
     check_stack_repr(
@@ -466,6 +470,10 @@ def test_types_heap(gdb_arrow):
                     "arrow::list(arrow::uint8())")
     check_heap_repr(gdb_arrow, "heap_large_list_type",
                     "arrow::large_list(arrow::large_utf8())")
+    check_heap_repr(gdb_arrow, "heap_list_view_type",
+                    "arrow::list_view(arrow::uint8())")
+    check_heap_repr(gdb_arrow, "heap_large_list_view_type",
+                    "arrow::large_list_view(arrow::large_utf8())")
     check_heap_repr(gdb_arrow, "heap_fixed_size_list_type",
                     "arrow::fixed_size_list(arrow::float64(), 3)")
     check_heap_repr(
@@ -737,6 +745,22 @@ def test_scalars_stack(gdb_arrow):
         ('arrow::LargeListScalar of type arrow::large_list(arrow::int32()), '
          'null value'))
     check_stack_repr(
+        gdb_arrow, "list_view_scalar",
+        ('arrow::ListViewScalar of value arrow::Int32Array of '
+         'length 3, offset 0, null count 0 = {[0] = 4, [1] = 5, [2] = 6}'))
+    check_stack_repr(
+        gdb_arrow, "list_view_scalar_null",
+        ('arrow::ListViewScalar of type arrow::list_view(arrow::int32()), '
+         'null value'))
+    check_stack_repr(
+        gdb_arrow, "large_list_view_scalar",
+        ('arrow::LargeListViewScalar of value arrow::Int32Array of '
+         'length 3, offset 0, null count 0 = {[0] = 4, [1] = 5, [2] = 6}'))
+    check_stack_repr(
+        gdb_arrow, "large_list_view_scalar_null",
+        ('arrow::LargeListViewScalar of type '
+         'arrow::large_list_view(arrow::int32()), null value'))
+    check_stack_repr(
         gdb_arrow, "fixed_size_list_scalar",
         ('arrow::FixedSizeListScalar of value arrow::Int32Array of '
          'length 3, offset 0, null count 0 = {[0] = 4, [1] = 5, [2] = 6}'))
@@ -827,6 +851,10 @@ def test_arrays_stack(gdb_arrow):
     check_stack_repr(
         gdb_arrow, "list_array",
         ("arrow::ListArray of type arrow::list(arrow::int64()), "
+         "length 3, offset 0, null count 1"))
+    check_stack_repr(
+        gdb_arrow, "list_view_array",
+        ("arrow::ListViewArray of type arrow::list_view(arrow::int64()), "
          "length 3, offset 0, null count 1"))
 
 
@@ -1080,6 +1108,14 @@ def test_arrays_heap(gdb_arrow):
     check_heap_repr(
         gdb_arrow, "heap_list_array",
         ("arrow::ListArray of type arrow::list(arrow::int64()), "
+         "length 3, offset 0, null count 1"))
+    check_heap_repr(
+        gdb_arrow, "heap_list_view_array",
+        ("arrow::ListViewArray of type arrow::list_view(arrow::int64()), "
+         "length 3, offset 0, null count 1"))
+    check_heap_repr(
+        gdb_arrow, "heap_large_list_view_array",
+        ("arrow::LargeListViewArray of type arrow::large_list_view(arrow::int64()), "
          "length 3, offset 0, null count 1"))
 
 


### PR DESCRIPTION
## Why are these changes needed?

`gdb_arrow.py` currently does not support pretty-printing for `ListView` and `LargeListView` data types.

This PR adds debugger support for these types while reusing the existing pretty-printer infrastructure.

## What changes are included?

- Add `LIST_VIEW` and `LARGE_LIST_VIEW` type registration.
- Reuse the existing pretty-printer implementation where appropriate.
- Add debugger fixtures.
- Add GDB test coverage for the new types.

## Are these changes tested?

Yes.

- Added GDB tests.
- Ran the relevant debugger tests locally.
- Verified Python syntax.
- Verified pre-commit hooks.
- Verified formatting.

## Are there any user-facing changes?

No.

This change only improves the developer debugging experience.
* GitHub Issue: #50659