### PR TITLE
GH-50670: [Release][Dev] Fix only shellcheck SC2086 errors in the dev directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -359,13 +359,22 @@ repos:
           ?^cpp/src/arrow/flight/sql/odbc/tests/dremio/set_up_dremio_instance\.sh$|
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/07-flightsqlodbc-upload\.sh$|
+          ?^dev/release/08-publish-gh-release\.sh$|
           ?^dev/release/09-binary-verify\.sh$|
+          ?^dev/release/account-ruby\.sh$|
           ?^dev/release/binary-recover\.sh$|
+          ?^dev/release/post-01-tag\.sh$|
+          ?^dev/release/post-02-upload\.sh$|
           ?^dev/release/post-03-binary\.sh$|
+          ?^dev/release/post-05-update-gh-release-notes\.sh$|
+          ?^dev/release/post-07-remove-old-artifacts\.sh$|
           ?^dev/release/post-08-docs\.sh$|
           ?^dev/release/post-09-python\.sh$|
+          ?^dev/release/post-13-vcpkg\.sh$|
+          ?^dev/release/post-14-conan\.sh$|
           ?^dev/release/setup-rhel-rebuilds\.sh$|
           ?^dev/release/utils-generate-checksum\.sh$|
+          ?^dev/release/utils-watch-gh-workflow\.sh$|
           ?^swift/gen-protobuffers\.sh$|
           )
   - repo: https://github.com/scop/pre-commit-shfmt

--- a/dev/release/08-publish-gh-release.sh
+++ b/dev/release/08-publish-gh-release.sh
@@ -35,4 +35,4 @@ rc=$2
 REPOSITORY="apache/arrow"
 
 rc_tag="apache-arrow-${version}-rc${rc}"
-gh release edit ${rc_tag} --repo ${REPOSITORY} --draft=false
+gh release edit "${rc_tag}" --repo "${REPOSITORY}" --draft=false

--- a/dev/release/account-ruby.sh
+++ b/dev/release/account-ruby.sh
@@ -33,6 +33,6 @@ account=$1
 
 pushd "${SOURCE_DIR}/../../ruby"
 for gem in red-*; do
-  gem owner ${gem} -a ${account}
+  gem owner "${gem}" -a "${account}"
 done
 popd

--- a/dev/release/post-01-tag.sh
+++ b/dev/release/post-01-tag.sh
@@ -31,5 +31,5 @@ rc=$2
 # Create the release tag and trigger the Publish Release workflow.
 release_tag=apache-arrow-${version}
 release_candidate_tag=${release_tag}-rc${rc}
-git tag -a ${release_tag} ${release_candidate_tag} -m "[Release] Apache Arrow Release ${version}"
-git push upstream ${release_tag}
+git tag -a "${release_tag}" "${release_candidate_tag}" -m "[Release] Apache Arrow Release ${version}"
+git push upstream "${release_tag}"

--- a/dev/release/post-02-upload.sh
+++ b/dev/release/post-02-upload.sh
@@ -34,8 +34,8 @@ echo "Copying dev/ to release/"
 svn \
   cp \
   -m "Apache Arrow ${version}" \
-  https://dist.apache.org/repos/dist/dev/arrow/${rc_id} \
-  https://dist.apache.org/repos/dist/release/arrow/${release_id}
+  "https://dist.apache.org/repos/dist/dev/arrow/${rc_id}" \
+  "https://dist.apache.org/repos/dist/release/arrow/${release_id}"
 
 echo "Success! The release is available here:"
 echo "  https://dist.apache.org/repos/dist/release/arrow/${release_id}"

--- a/dev/release/post-05-update-gh-release-notes.sh
+++ b/dev/release/post-05-update-gh-release-notes.sh
@@ -41,4 +41,4 @@ WORKFLOW="release.yml"
 # Update the Release Notes section
 RELEASE_NOTES_URL="https://arrow.apache.org/release/${VERSION}.html"
 RELEASE_NOTES="Release Notes URL: ${RELEASE_NOTES_URL}"
-gh release edit ${TAG} --repo ${REPOSITORY} --notes "${RELEASE_NOTES}" --verify-tag
+gh release edit "${TAG}" --repo "${REPOSITORY}" --notes "${RELEASE_NOTES}" --verify-tag

--- a/dev/release/post-07-remove-old-artifacts.sh
+++ b/dev/release/post-07-remove-old-artifacts.sh
@@ -33,7 +33,7 @@ for old_rc in $old_rcs; do
   svn \
     delete \
     -m "Remove old Apache Arrow RC: ${old_rc}" \
-    ${dev_base_url}/${old_rc}
+    "${dev_base_url}/${old_rc}"
 done
 
 echo "Keep only the latest release"
@@ -49,7 +49,7 @@ for old_release_version in $old_releases; do
   svn \
     delete \
     -m "Remove old Apache Arrow release: ${old_release_version}" \
-    ${release_base_url}/${old_release_version}
+    "${release_base_url}/${old_release_version}"
 done
 
 echo "Success! See the current artifacts:"

--- a/dev/release/post-13-vcpkg.sh
+++ b/dev/release/post-13-vcpkg.sh
@@ -52,8 +52,8 @@ git rebase upstream/master
 
 branch="arrow-${version}"
 echo "Creating branch: ${branch}"
-git branch -D ${branch} || :
-git checkout -b ${branch}
+git branch -D "${branch}" || :
+git checkout -b "${branch}"
 
 port_arrow=ports/arrow
 echo "Updating: ${port_arrow}"
@@ -92,7 +92,7 @@ git commit -m "[arrow] Update to ${version}"
 git add versions
 git commit -m "Update versions"
 
-git push origin ${branch}
+git push origin "${branch}"
 
 
 owner=$(git remote get-url origin | \

--- a/dev/release/post-14-conan.sh
+++ b/dev/release/post-14-conan.sh
@@ -52,8 +52,8 @@ git rebase upstream/master
 
 branch="arrow-${version}"
 echo "Creating branch: ${branch}"
-git branch -D ${branch} || :
-git checkout -b ${branch}
+git branch -D "${branch}" || :
+git checkout -b "${branch}"
 
 recipes_arrow=recipes/arrow
 echo "Updating: ${recipes_arrow}"
@@ -84,7 +84,7 @@ git add ${recipes_arrow}/config.yml
 git add ${recipes_arrow}/all/conandata.yml
 git commit -m "arrow: add version ${version}"
 
-git push origin ${branch}
+git push origin "${branch}"
 
 
 owner=$(git remote get-url origin | \

--- a/dev/release/utils-watch-gh-workflow.sh
+++ b/dev/release/utils-watch-gh-workflow.sh
@@ -52,4 +52,4 @@ gh run watch \
    --exit-status \
    --interval 60 \
    --repo "${REPOSITORY}" \
-   ${RUN_ID}
+   "${RUN_ID}"


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

Fix only ShellCheck SC2086 errors in the dev directory.

* SC2086: Double quote to prevent globbing and word splitting.

```
shellcheck dev/release/post-01-tag.sh

In dev/release/post-01-tag.sh line 34:
git tag -a ${release_tag} ${release_candidate_tag} -m "[Release] Apache Arrow Release ${version}"
           ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                          ^----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
git tag -a "${release_tag}" "${release_candidate_tag}" -m "[Release] Apache Arrow Release ${version}"


In dev/release/post-01-tag.sh line 35:
git push upstream ${release_tag}
                  ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
git push upstream "${release_tag}"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```


### What changes are included in this PR?

* SC2086: Quote variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50670