### PR TITLE
GH-50654: [C++] Support simdjson without exceptions

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2823,6 +2823,8 @@ function(build_simdjson)
 
   fetchcontent_makeavailable(simdjson)
 
+  target_compile_definitions(simdjson PUBLIC SIMDJSON_EXCEPTIONS=0)
+
   # The macOS 11.3 SDK has incomplete C++20 concepts support, which prevents
   # simdjson headers from compiling. Disable simdjson concepts for this SDK.
   if(CMAKE_OSX_SYSROOT AND CMAKE_OSX_SYSROOT MATCHES "MacOSX11\\.3\\.sdk$")

--- a/cpp/src/arrow/json/object_parser.cc
+++ b/cpp/src/arrow/json/object_parser.cc
@@ -30,7 +30,9 @@ class ObjectParser::Impl {
     padded_json_ = simdjson::padded_string(json);
 
     // Store parsed document
-    document_ = parser_.iterate(padded_json_);
+    if (auto error = parser_.iterate(padded_json_).get(document_)) {
+      return Status::Invalid("JSON parse error: ", simdjson::error_message(error));
+    }
 
     // Validate root is an object
     auto object = document_.get_object();
@@ -69,7 +71,12 @@ class ObjectParser::Impl {
                              "': ", simdjson::error_message(str_result.error()));
     }
 
-    return std::string(str_result.value());
+    std::string_view str;
+    if (auto error = std::move(str_result).get(str)) {
+      return Status::Invalid("Error getting string for key '", key,
+                             "': ", simdjson::error_message(error));
+    }
+    return std::string(str);
   }
 
   Result<std::unordered_map<std::string, std::string>> GetStringMap() {
@@ -80,13 +87,10 @@ class ObjectParser::Impl {
     auto object = document_.get_object();
 
     for (auto field : object) {
-      auto key_result = field.unescaped_key();
-
-      auto key = key_result.value();
-
-      if (key_result.error()) {
-        return Status::Invalid("Error getting value for key '", std::string(key),
-                               "': ", simdjson::error_message(key_result.error()));
+      std::string_view key;
+      if (auto error = field.unescaped_key().get(key)) {
+        return Status::Invalid("Error getting object key: ",
+                               simdjson::error_message(error));
       }
 
       auto value = field.value();
@@ -102,7 +106,13 @@ class ObjectParser::Impl {
                                "': (code=", static_cast<int>(str_result.error()), ")");
       }
 
-      map.emplace(std::string(key), std::string(str_result.value()));
+      std::string_view str;
+      if (auto error = std::move(str_result).get(str)) {
+        return Status::Invalid("Error getting value for key '", std::string(key),
+                               "': ", simdjson::error_message(error));
+      }
+
+      map.emplace(std::string(key), std::string(str));
     }
 
     return map;
@@ -132,7 +142,13 @@ class ObjectParser::Impl {
                              "': ", simdjson::error_message(bool_result.error()));
     }
 
-    return bool_result.value();
+    bool value;
+    if (auto error = std::move(bool_result).get(value)) {
+      return Status::Invalid("Error getting bool for key '", key,
+                             "': ", simdjson::error_message(error));
+    }
+
+    return value;
   }
 
  private:


### PR DESCRIPTION
### Rationale for this change

This change enables building Arrow with `SIMDJSON_EXCEPTIONS=0` by updating the JSON object parser to use simdjson's non-throwing API.

### What changes are included?

- Enable `SIMDJSON_EXCEPTIONS=0` for the bundled simdjson dependency.
- Replace uses of `simdjson_result::value()` in `ObjectParser` with the non-throwing `get()` API.
- Preserve existing error handling by returning Arrow `Status` values on simdjson errors.

### Are these changes tested?

Yes.

Fixes: #50654 
* GitHub Issue: #50654