### PR TITLE
GH-50674: [Release] Add support for recovering Yum repositories

### DIFF
--- a/dev/release/binary-recover.sh
+++ b/dev/release/binary-recover.sh
@@ -43,11 +43,26 @@ fi
 # To deactivate one category, deactivate the category and all of its dependents.
 # To explicitly select one category, set RECOVER_DEFAULT=0 RECOVER_X=1.
 : "${RECOVER_DEFAULT:=1}"
+: "${RECOVER_ALMALINUX:=${RECOVER_DEFAULT}}"
+: "${RECOVER_AMAZON_LINUX:=${RECOVER_DEFAULT}}"
+: "${RECOVER_CENTOS:=${RECOVER_DEFAULT}}"
 : "${RECOVER_DEBIAN:=${RECOVER_DEFAULT}}"
 : "${RECOVER_UBUNTU:=${RECOVER_DEFAULT}}"
 
 rake_tasks=()
 apt_targets=()
+if [ "${RECOVER_ALMALINUX}" -gt 0 ]; then
+  rake_tasks+=(yum:recover)
+  yum_targets+=(almalinux)
+fi
+if [ "${RECOVER_AMAZON_LINUX}" -gt 0 ]; then
+  rake_tasks+=(yum:recover)
+  yum_targets+=(amazon-linux)
+fi
+if [ "${RECOVER_CENTOS}" -gt 0 ]; then
+  rake_tasks+=(yum:recover)
+  yum_targets+=(centos)
+fi
 if [ "${RECOVER_DEBIAN}" -gt 0 ]; then
   rake_tasks+=(apt:recover)
   apt_targets+=(debian)
@@ -74,4 +89,8 @@ docker_run \
   RC="" \
   STAGING="${STAGING:-no}" \
   VERBOSE="${VERBOSE:-no}" \
-  VERSION=""
+  VERSION="" \
+  YUM_TARGETS="$(
+    IFS=,
+    echo "${yum_targets[*]}"
+  )"

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1771,7 +1771,6 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
   end
 
   def define_apt_release_tasks
-
     namespace :apt do
       desc "Release APT repository"
       task :release do
@@ -1796,7 +1795,7 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
             download_distribution(:artifactory,
                                   distribution,
                                   code_name_dir,
-                                  :base,
+                                  :all,
                                   pattern: pattern,
                                   prefix: "pool/#{code_name}")
           end
@@ -1852,6 +1851,10 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
 
   def yum_release_repositories_dir
     "#{release_dir}/yum/repositories"
+  end
+
+  def yum_recover_repositories_dir
+    "#{recover_dir}/yum/repositories"
   end
 
   def available_yum_targets
@@ -2189,10 +2192,82 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
     end
   end
 
+  def define_yum_recover_tasks
+    namespace :yum do
+      namespace :recover do
+        desc "Download repositories"
+        task :download do
+          yum_targets.each do |distribution, version|
+            not_checksum_pattern = /.+(?<!\.asc|\.sha512)\z/
+            target_dir = File.join(yum_recover_repositories_dir,
+                                   distribution,
+                                   version)
+            pattern = not_checksum_pattern
+            download_distribution(:artifactory,
+                                  distribution,
+                                  target_dir,
+                                  :all,
+                                  pattern: pattern,
+                                  prefix: version)
+          end
+        end
+
+        desc "Update repositories"
+        task :update do
+          yum_targets.each do |distribution, version|
+            version_dir = File.join(yum_recover_repositories_dir,
+                                    distribution,
+                                    version)
+            next if File.symlink?(version_dir)
+            next unless File.exist?(version_dir)
+            Dir.glob("#{version_dir}/*") do |arch_dir|
+              next unless File.directory?(arch_dir)
+              sh("createrepo_c",
+                 arch_dir,
+                 out: default_output,
+                 verbose: verbose?)
+            end
+          end
+        end
+
+        desc "Upload repositories"
+        task :upload do
+          yum_targets.each do |distribution, version|
+            version_dir = File.join(yum_recover_repositories_dir,
+                                    distribution,
+                                    version)
+            next if File.symlink?(version_dir)
+            next unless File.exist?(version_dir)
+            Dir.glob("#{version_dir}/*/repodata") do |repodata_dir|
+              next unless File.directory?(repodata_dir)
+              arch = File.basename(File.dirname(repodata_dir))
+              prefix = "#{version}/#{arch}/repodata"
+              uploader = ArtifactoryUploader.new(api_key: artifactory_api_key,
+                                                 destination_prefix: prefix,
+                                                 distribution: distribution,
+                                                 source: repodata_dir,
+                                                 staging: staging?)
+              uploader.upload
+            end
+          end
+        end
+      end
+
+      desc "Recover Yum repositories"
+      yum_recover_tasks = [
+        "yum:recover:download",
+        "yum:recover:update",
+        "yum:recover:upload",
+      ]
+      task :recover => yum_recover_tasks
+    end
+  end
+
   def define_yum_tasks
     define_yum_staging_tasks
     define_yum_rc_tasks
     define_yum_release_tasks
+    define_yum_recover_tasks
   end
 
   def define_summary_tasks

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -714,3 +714,20 @@ Be sure to go through on the following checklist:
       dev/release/post-07-remove-old-artifacts.sh
 
    Note: This step must be done by a PMC member.
+
+Trouble shooting
+================
+
+How to recover broken metadata of APT/Yum repositories
+------------------------------------------------------
+
+Our release system has only one RC space for APT/Yum
+repositories. apache/arrow and apache/arrow-adbc shares the RC
+space. So metadata APT/Yum repositories may be broken when we cut an
+RC for apache/arrow and apache/arrow-adbc at the same time.
+
+We can re-generate and upload metadata by the following command line:
+
+.. code-block:: shell
+
+   dev/release/binary-recover.sh


### PR DESCRIPTION
### Rationale for this change

We need this when we break our Yum repositories.

### What changes are included in this PR?

We can recover Yum repositories too by `dev/release/binary-recover.sh`.

### Are these changes tested?

Yes. I recovered our Yum repositories with this.

### Are there any user-facing changes?

No.
* GitHub Issue: #50674