### PR TITLE
EXP: [Python] Use DeprecationWarning instead of FutureWarning

### DIFF
--- a/docs/source/python/api/formats.rst
+++ b/docs/source/python/api/formats.rst
@@ -47,7 +47,7 @@ Feather Files (Deprecated)
 
 .. currentmodule:: pyarrow.feather
 
-.. deprecated:: 24.0.0
+.. deprecated:: 25.0.0
    The Feather API is deprecated. Use the :ref:`IPC <ipc>` API instead.
 
 .. autosummary::

--- a/docs/source/python/feather.rst
+++ b/docs/source/python/feather.rst
@@ -22,7 +22,7 @@
 Feather File Format
 ===================
 
-.. deprecated:: 24.0.0
+.. deprecated:: 25.0.0
    The ``pyarrow.feather`` module is deprecated. Feather V2 is the Arrow IPC
    file format. Use :mod:`pyarrow.ipc` instead. See :ref:`ipc` for details.
 

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -32,7 +32,7 @@ class FeatherDataset:
     """
     Encapsulates details of reading a list of Feather files.
 
-    .. deprecated:: 24.0.0
+    .. deprecated:: 25.0.0
        Use :func:`pyarrow.dataset.dataset` with ``format='ipc'`` instead.
 
     Parameters
@@ -45,9 +45,9 @@ class FeatherDataset:
 
     def __init__(self, path_or_paths, validate_schema=True):
         warnings.warn(
-            "pyarrow.feather.FeatherDataset is deprecated as of 24.0.0. "
+            "pyarrow.feather.FeatherDataset is deprecated as of 25.0.0. "
             "Use pyarrow.dataset.dataset() with format='ipc' instead.",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=2
         )
         self.paths = path_or_paths
@@ -127,7 +127,7 @@ def write_feather(df, dest, compression=None, compression_level=None,
     """
     Write a pandas.DataFrame to Feather format.
 
-    .. deprecated:: 24.0.0
+    .. deprecated:: 25.0.0
        Use :func:`pyarrow.ipc.new_file` /
        :class:`pyarrow.ipc.RecordBatchFileWriter` instead.
        Feather V2 is the Arrow IPC file format.
@@ -153,10 +153,10 @@ def write_feather(df, dest, compression=None, compression_level=None,
         limited legacy format
     """
     warnings.warn(
-        "pyarrow.feather.write_feather is deprecated as of 24.0.0. "
+        "pyarrow.feather.write_feather is deprecated as of 25.0.0. "
         "Use pyarrow.ipc.new_file() / RecordBatchFileWriter instead. "
         "Feather V2 is the Arrow IPC file format.",
-        FutureWarning,
+        DeprecationWarning,
         stacklevel=2
     )
     if _pandas_api.have_pandas:
@@ -223,7 +223,7 @@ def read_feather(source, columns=None, use_threads=True,
     Read a pandas.DataFrame from Feather format. To read as pyarrow.Table use
     feather.read_table.
 
-    .. deprecated:: 24.0.0
+    .. deprecated:: 25.0.0
        Use :func:`pyarrow.ipc.open_file` /
        :class:`pyarrow.ipc.RecordBatchFileReader` instead.
        Feather V2 is the Arrow IPC file format.
@@ -250,10 +250,10 @@ def read_feather(source, columns=None, use_threads=True,
         The contents of the Feather file as a pandas.DataFrame
     """
     warnings.warn(
-        "pyarrow.feather.read_feather is deprecated as of 24.0.0. "
+        "pyarrow.feather.read_feather is deprecated as of 25.0.0. "
         "Use pyarrow.ipc.open_file() / RecordBatchFileReader instead. "
         "Feather V2 is the Arrow IPC file format.",
-        FutureWarning,
+        DeprecationWarning,
         stacklevel=2
     )
     return (_read_table_internal(
@@ -302,7 +302,7 @@ def read_table(source, columns=None, memory_map=False, use_threads=True):
     """
     Read a pyarrow.Table from Feather format
 
-    .. deprecated:: 24.0.0
+    .. deprecated:: 25.0.0
        Use :func:`pyarrow.ipc.open_file` /
        :class:`pyarrow.ipc.RecordBatchFileReader` instead.
        Feather V2 is the Arrow IPC file format.
@@ -325,10 +325,10 @@ def read_table(source, columns=None, memory_map=False, use_threads=True):
         The contents of the Feather file as a pyarrow.Table
     """
     warnings.warn(
-        "pyarrow.feather.read_table is deprecated as of 24.0.0. "
+        "pyarrow.feather.read_table is deprecated as of 25.0.0. "
         "Use pyarrow.ipc.open_file() / RecordBatchFileReader instead. "
         "Feather V2 is the Arrow IPC file format.",
-        FutureWarning,
+        DeprecationWarning,
         stacklevel=2
     )
     return _read_table_internal(source, columns=columns,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1927,7 +1927,7 @@ def test_fragments_parquet_subset_with_nested_fields(tempdir):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings("ignore:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("ignore:pyarrow.feather:DeprecationWarning")
 def test_fragments_repr(tempdir, dataset):
     # partitioned parquet dataset
     fragment = list(dataset.get_fragments())[0]
@@ -3700,7 +3700,7 @@ def test_column_names_encoding(tempdir, dataset_reader):
     assert dataset_transcoded.to_table().equals(expected_table)
 
 
-@pytest.mark.filterwarnings("ignore:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("ignore:pyarrow.feather:DeprecationWarning")
 def test_feather_format(tempdir, dataset_reader):
     from pyarrow.feather import write_feather
 
@@ -4082,7 +4082,7 @@ def test_dataset_project_null_column(tempdir, dataset_reader):
     assert dataset_reader.to_table(dataset).equals(expected)
 
 
-@pytest.mark.filterwarnings("ignore:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("ignore:pyarrow.feather:DeprecationWarning")
 def test_dataset_project_columns(tempdir, dataset_reader):
     # basic column re-projection with expressions
     from pyarrow import feather
@@ -4434,7 +4434,7 @@ def test_write_dataset_with_dataset(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.filterwarnings("ignore:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("ignore:pyarrow.feather:DeprecationWarning")
 def test_write_dataset_existing_data(tempdir):
     directory = tempdir / 'ds'
     table = pa.table({'b': ['x', 'y', 'z'], 'c': [1, 2, 3]})
@@ -5099,7 +5099,7 @@ def test_write_dataset_arrow_schema_metadata(tempdir):
     assert result["a"].type.tz == "Europe/Brussels"
 
 
-@pytest.mark.filterwarnings("ignore:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("ignore:pyarrow.feather:DeprecationWarning")
 def test_write_dataset_schema_metadata(tempdir):
     # ensure that schema metadata gets written
     from pyarrow import feather

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -42,9 +42,9 @@ except ImportError:
     pass
 
 # Suppress deprecation warnings for existing tests since pyarrow.feather
-# is deprecated as of 24.0.0
+# is deprecated as of 25.0.0
 pytestmark = pytest.mark.filterwarnings(
-    "ignore:pyarrow.feather:FutureWarning"
+    "ignore:pyarrow.feather:DeprecationWarning"
 )
 
 
@@ -894,39 +894,39 @@ def test_feather_datetime_resolution_arrow_to_pandas(tempdir):
 # --- Deprecation warning tests ---
 
 @pytest.mark.pandas
-@pytest.mark.filterwarnings("default:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("default:pyarrow.feather:DeprecationWarning")
 def test_feather_deprecation_warnings(tempdir):
     table = pa.table({"a": [1, 2, 3]})
     path = str(tempdir / "test.feather")
 
-    with pytest.warns(FutureWarning, match="write_feather is deprecated"):
+    with pytest.warns(DeprecationWarning, match="write_feather is deprecated"):
         write_feather(table, path)
 
-    with pytest.warns(FutureWarning, match="read_table is deprecated"):
+    with pytest.warns(DeprecationWarning, match="read_table is deprecated"):
         read_table(path)
 
-    with pytest.warns(FutureWarning, match="read_feather is deprecated"):
+    with pytest.warns(DeprecationWarning, match="read_feather is deprecated"):
         read_feather(path)
 
 
-@pytest.mark.filterwarnings("default:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("default:pyarrow.feather:DeprecationWarning")
 def test_feather_dataset_deprecated():
-    with pytest.warns(FutureWarning, match="FeatherDataset is deprecated"):
+    with pytest.warns(DeprecationWarning, match="FeatherDataset is deprecated"):
         FeatherDataset([])
 
 
 @pytest.mark.pandas
-@pytest.mark.filterwarnings("default:pyarrow.feather:FutureWarning")
+@pytest.mark.filterwarnings("default:pyarrow.feather:DeprecationWarning")
 def test_read_feather_no_double_warning(tempdir):
-    """Verify read_feather emits exactly one FutureWarning, not two."""
+    """Verify read_feather emits exactly one DeprecationWarning, not two."""
     table = pa.table({"a": [1, 2, 3]})
     path = str(tempdir / "test.feather")
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", FutureWarning)
+        warnings.simplefilter("ignore", DeprecationWarning)
         write_feather(table, path)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         read_feather(path)
-        future_warnings = [x for x in w if issubclass(x.category,
-                                                      FutureWarning)]
-        assert len(future_warnings) == 1
+        deprecation_warnings = [x for x in w if issubclass(x.category,
+                                                           DeprecationWarning)]
+        assert len(deprecation_warnings) == 1


### PR DESCRIPTION
### Rationale for this change
Prototype for follow-up discussion in https://github.com/apache/arrow/issues/49232#issuecomment-5095507228

### What changes are included in this PR?
Test approach of `DeprecationWarning` in place of current `FutureWarning`
Additionally corrected notes like `deprecated as of 24.0.0` to `25.0.0` instead

### Are these changes tested?
Yes, successful on for and main CI 

### Are there any user-facing changes?
Yes...