### PR TITLE
GH-50578: [C++][FlightRPC][ODBC] Always return SQL_NO_DATA from GetMoreResults

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -784,11 +784,7 @@ SQLRETURN ODBCStatement::GetData(SQLSMALLINT record_number, SQLSMALLINT c_type,
 
 SQLRETURN ODBCStatement::GetMoreResults() {
   // Multiple result sets are not supported by Arrow protocol.
-  if (current_result_) {
-    return SQL_NO_DATA;
-  } else {
-    throw DriverException("Function sequence error", "HY010");
-  }
+  return SQL_NO_DATA;
 }
 
 void ODBCStatement::GetColumnCount(SQLSMALLINT* column_count_ptr) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -1984,14 +1984,7 @@ TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
 }
 
 TYPED_TEST(StatementTest, TestSQLMoreResultsWithoutQuery) {
-#ifdef __linux__
   ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(this->stmt));
-#else  // Windows & Mac
-  // Verify function sequence error state is reported when SQLMoreResults is called
-  // without executing any queries
-  ASSERT_EQ(SQL_ERROR, SQLMoreResults(this->stmt));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
-#endif
 }
 
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputString) {


### PR DESCRIPTION
### Rationale for this change

Fixes a bug in the implementation of ODBC `GetMoreResults` in the FlightSQL ODBC driver. According to https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/statement-transitions?view=sql-server-ver17#sqlmoreresults, we should return `SQL_NO_DATA` for some states we previously were throwing another error in. This appears to be exposed by a behavior of only the Windows ODBC driver manager: `GetMoreResults` always gets called even for metadata queries.

### What changes are included in this PR?

- Changed implementation and test: `GetMoreResults` now always returns `SQL_NO_DATA`.

### Are these changes tested?

Yes, in CI.

### Are there any user-facing changes?

No.

* GitHub Issue: #50578