### PR TITLE
GH-50636: [C++] Replace std::span/ranges usage to fix macOS CRAN

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -231,19 +231,19 @@ void VisitConstantRanges(const ArrayType& array, std::span<uint64_t> indices,
   if (indices.empty()) {
     return;
   }
-  auto range_start = indices.begin();
-  auto range_cur = range_start;
-  auto last_value = GetView::LogicalValue(array.GetView(*range_cur - offset));
-  while (++range_cur != indices.end()) {
-    auto v = GetView::LogicalValue(array.GetView(*range_cur - offset));
+  size_t range_start = 0;
+  size_t range_cur = 0;
+  auto last_value = GetView::LogicalValue(array.GetView(indices[range_cur] - offset));
+  while (++range_cur != indices.size()) {
+    auto v = GetView::LogicalValue(array.GetView(indices[range_cur] - offset));
     if (v != last_value) {
-      visit({range_start, range_cur});
+      visit(indices.subspan(range_start, range_cur - range_start));
       range_start = range_cur;
       last_value = v;
     }
   }
   if (range_start != range_cur) {
-    visit({range_start, range_cur});
+    visit(indices.subspan(range_start, range_cur - range_start));
   }
 }
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -732,12 +732,12 @@ class PARQUET_NO_EXPORT FixedSizeListReader : public ListReader<int32_t> {
       const int32_t expected_size = has_elements ? list_size : 0;
       std::span<const int32_t> run_offsets(offsets + start,
                                            static_cast<size_t>(length + 1));
-      const auto first_invalid_offset = std::ranges::adjacent_find(
-          run_offsets,
+      const auto first_invalid_offset = std::adjacent_find(
+          run_offsets.begin(), run_offsets.end(),
           [&](int32_t left, int32_t right) { return right - left != expected_size; });
       if (first_invalid_offset != run_offsets.end()) {
         const int64_t x =
-            start + std::ranges::distance(run_offsets.begin(), first_invalid_offset);
+            start + std::distance(run_offsets.begin(), first_invalid_offset);
         const int32_t size = offsets[x + 1] - offsets[x];
         if (has_elements) {
           return Status::Invalid("Expected all lists to be of size=", list_size,


### PR DESCRIPTION
### Rationale for this change
Fix #50636 - `test-r-macos-as-cran` nightly job fails compiling `visit({range_start, range_cur})` introduced in #50248.
```console
/Users/runner/work/crossbow/crossbow/arrow/cpp/src/arrow/compute/kernels/vector_sort.cc:325:11: note: candidate function not viable: cannot convert initializer list argument to 'std::span<uint64_t>' (aka 'span<unsigned long long>')
  325 |           [&](std::span<uint64_t> indices) { SortNextColumn(indices, offset); });
```
The job pins [macOS SDK 11.3](https://github.com/ursacomputing/crossbow/actions/runs/30420027426/job/90474737457#step:9:14), so libc++ there does not have C++20 iterator-pair span constructor available yet ([available with libc++ 14](https://libcxx.llvm.org/Status/Cxx20.html)).
Similar problem as in recent #50295

### What changes are included in this PR?
Replace std::span iterator-pair constructor with subspan in `vector_sort.cc`
Also replace std::ranges in `parquet/arrow/reader.cc` introduced in #50271

### Are these changes tested?
Yes, builds locally and crossbow `test-r-macos-as-cran` job succeeds.

### Are there any user-facing changes?
No.
* GitHub Issue: #50636