### PR TITLE
GH-50688: [CI] Force aws-sdk-cpp rebuild from brew to be compatible with aws-crt-cpp

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -245,6 +245,11 @@ jobs:
           # Remove once the runner ships a newer Homebrew.
           brew update
           brew bundle --file=cpp/Brewfile
+          # Workaround for https://github.com/apache/arrow/issues/50688
+          # Homebrew's aws-sdk-cpp bottle seems to be ABI-incompatible with
+          # aws-crt-cpp 0.43.0. Rebuild it against the
+          # installed aws-crt-cpp until the bottle is revision bumped.
+          brew reinstall --build-from-source aws-sdk-cpp
       - name: Install MinIO
         run: |
           $(brew --prefix bash)/bin/bash \

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -204,6 +204,11 @@ jobs:
           # Remove once the runner ships a newer Homebrew.
           brew update
           brew bundle --file=cpp/Brewfile
+          # Workaround for https://github.com/apache/arrow/issues/50688
+          # Homebrew's aws-sdk-cpp bottle seems to be ABI-incompatible with
+          # aws-crt-cpp 0.43.0. Rebuild it against the
+          # installed aws-crt-cpp until the bottle is revision bumped.
+          brew reinstall --build-from-source aws-sdk-cpp
           python -m pip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt


### PR DESCRIPTION
### Rationale for this change

A brew bump to aws-crt-cpp seems to be causing segfaults due to aws-sdk-cpp not being rebuilt upstream.

### What changes are included in this PR?

Force a rebuild for aws-sdk-cpp so it does not fail.

### Are these changes tested?

Yes, previously failing CI jobs are now passing

### Are there any user-facing changes?

No

* GitHub Issue: #50688