### PR TITLE
GH-50702: [Python] Fix .pyx changes requiring two builds to take effect

### DIFF
--- a/cpp/cmake_modules/UseCython.cmake
+++ b/cpp/cmake_modules/UseCython.cmake
@@ -154,9 +154,7 @@ function(compile_pyx
             "${CMAKE_CURRENT_BINARY_DIR}/${output_file}"
             "${CMAKE_CURRENT_SOURCE_DIR}/${pyx_file}"
     DEPENDS ${pyx_location}
-            # Do not specify byproducts for now since they don't work with the older
-            # version of cmake available in the apt repositories.
-            #BYPRODUCTS ${_generated_files}
+    BYPRODUCTS ${_generated_files}
     COMMENT ${comment})
 
   # Remove their visibility to the user.


### PR DESCRIPTION
### Rationale for this change

I noticed while editing a .pyx file that my changes weren't 
showing up after a rebuild — I had to build twice. Traced it 
to `BYPRODUCTS` being commented out in `UseCython.cmake`.

### What changes are included in this PR?

I uncommented `BYPRODUCTS ${_generated_files}` in 
`cpp/cmake_modules/UseCython.cmake`. Without it, CMake doesn't 
realize the .cpp was updated in the same build pass, so it 
skips recompiling the .so until the next build.

The line was commented out for older CMake compatibility — but 
the project requires CMake >= 3.25 now, and BYPRODUCTS has 
worked since 3.2, so that's no longer a concern.

### Are these changes tested?

This is a build system fix so there's no unit test for it. 
The CI builds pyarrow from source and runs the full test suite, 
which will validate the build still works correctly.

### Are there any user-facing changes?

No — this only improves the dev experience when iterating on 
.pyx files. One build instead of two.

* GitHub Issue: #50702