### PR TITLE
GH-50718: [C++][CI] Fix valgrind use of uninitialised value on FixedSizeListTestCase

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3419,6 +3419,10 @@ struct FixedSizeListTestCase {
   std::string json;
 };
 
+void PrintTo(const FixedSizeListTestCase& test_case, std::ostream* os) {
+  *os << "{type=" << test_case.type->ToString() << ", json=" << test_case.json << "}";
+}
+
 class TestFixedSizeListRoundTrip
     : public ::testing::TestWithParam<FixedSizeListTestCase> {};
 


### PR DESCRIPTION
### Rationale for this change

Fix a valgrind error.

### What changes are included in this PR?

Add `PrintTo` method to `FixedSizeListTestCase`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50718