### PR TITLE
GH-50726: [CI][Docs] Use bundled simdjson in the docs job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/docs.yml'
+      - 'ci/docker/debian-13-cpp.dockerfile'
       - 'cpp/apidoc/**'
       - 'docs/**'
 
@@ -41,7 +42,7 @@ env:
 jobs:
 
   complete:
-    name: AMD64 Debian 12 Complete Documentation
+    name: AMD64 Debian 13 Complete Documentation
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 150

--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -139,4 +139,5 @@ ENV ARROW_ACERO=ON \
     ORC_SOURCE=BUNDLED \
     PATH=/usr/lib/ccache/:$PATH \
     PYTHON=python3 \
+    simdjson_SOURCE=BUNDLED \
     xsimd_SOURCE=BUNDLED


### PR DESCRIPTION
### Rationale for this change

Debian GNU/Linux trixie ships simdjson 3.12.0 but we requires simdjson 4.0.0 or later.

### What changes are included in this PR?

Add `simdjson_SOURCE=BUNDLE`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50726