### PR TITLE
GH-50726: [CI][Docs] Use bundled simdjson for documentation builds

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1547,6 +1547,7 @@ services:
       LANG: "C.UTF-8"
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
+      simdjson_SOURCE: "BUNDLED"
       PYTEST_ARGS: "--doctest-modules --doctest-cython"
       PYTEST_RST_ARGS: "--doctest-glob=*.rst"
     volumes: *conda-volumes
@@ -1912,6 +1913,7 @@ services:
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
       BUILD_DOCS_R: "ON"
+      simdjson_SOURCE: "BUNDLED"
     volumes: *debian-volumes
     command: >
       /bin/bash -c "


### PR DESCRIPTION
## Summary

The documentation CI jobs (`debian-docs` and `conda-python-docs`) fail during CMake configuration because `simdjson_SOURCE` is not explicitly set. As a result, CMake inherits the default dependency source (`SYSTEM` or `CONDA`) and attempts to use an installed `simdjson` package that may not satisfy Arrow's `simdjson >= 4.0.0` requirement.

This change explicitly configures the documentation build services to use the bundled `simdjson` implementation by setting `simdjson_SOURCE=BUNDLED` in `compose.yaml`.

## Testing

- Verified that `docker compose config` correctly propagates `simdjson_SOURCE=BUNDLED` for both `debian-docs` and `conda-python-docs`.
- Verified CMake dependency resolution with `-Dsimdjson_SOURCE=BUNDLED`, confirming that the bundled `simdjson` (v4.6.4) is selected instead of an older system package.
- No user-facing changes.

## Checklist

- [x] My change addresses the issue described in GH-50726.
- [x] The change is limited to the documentation CI configuration.
- [x] No unrelated files were modified.
* GitHub Issue: #50726