### PR TITLE
GH-50688: [CI] Remove brew update to fix macOS arrow-s3fs-test segfaults

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -241,9 +241,6 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         run: |
-          # Workaround for https://github.com/grpc/grpc/issues/41755
-          # Remove once the runner ships a newer Homebrew.
-          brew update
           brew bundle --file=cpp/Brewfile
       - name: Install MinIO
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -200,9 +200,6 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          # Workaround for https://github.com/grpc/grpc/issues/41755
-          # Remove once the runner ships a newer Homebrew.
-          brew update
           brew bundle --file=cpp/Brewfile
           python -m pip install \
             -r python/requirements-build.txt \


### PR DESCRIPTION
### Rationale for this change
Fix #50688, per analysis of #50712, `arrow-s3fs-test` segfaults because of incompatible aws-sdk-cpp and aws-crt-cpp bottles on current homebrew-core (Homebrew/homebrew-core#295531 bumped aws-crt-cpp to 0.43.0 without rebuilding the aws-sdk-cpp bottle).
`brew update` was added in #49491 and is no longer needed (grpc/protobuf v34 got fixed in homebrew-core in March Homebrew/homebrew-core@552efcae and current runner ships that Homebrew snapshot including that).

### What changes are included in this PR?
Remove brew update to avoid incompatible aws-sdk-cpp and aws-crt-cpp bottles.

### Are these changes tested?
Yes, fork succeeded on Python and cpp workflows, now CI here succeeds too.

### Are there any user-facing changes?
No.
* GitHub Issue: #50688