### PR TITLE
GH-50737: [C++][Parquet] mark `MakeStatistics` method without `ColumnDescriptor` as deprecated

### DIFF
--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -401,7 +401,9 @@ std::shared_ptr<TypedStatistics<DType>> MakeStatistics(
 /// \param[in] num_values number of values
 /// \param[in] null_count number of null values
 /// \param[in] distinct_count number of distinct values
+/// \note Deprecated in 26.0.0. Use a ColumnDescriptor-based overload instead.
 template <typename DType>
+PARQUET_DEPRECATED("Deprecated in 26.0.0. Use a ColumnDescriptor-based overload instead.")
 std::shared_ptr<TypedStatistics<DType>> MakeStatistics(const typename DType::c_type& min,
                                                        const typename DType::c_type& max,
                                                        int64_t num_values,


### PR DESCRIPTION
### Rationale for this change

I offer two reasons for marking this method as deprecated:
1. It accepts a `distinct_count` parameter but lacks `has_distinct_count`, making it impossible to represent missing distinct counts, which could lead to misuse.
2. When I try to add `nan_count`, I found that it lacks a `ColumnDescriptor` parameter, making it impossible to obtain the logical type and determine the value of `has_nan_count` based on Parquet's logical type (FLOAT16).

### What changes are included in this PR?

Mark `MakeStatistics` method without `ColumnDescriptor` as deprecated.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes. 

Mark `MakeStatistics` method without `ColumnDescriptor` as deprecated.
* GitHub Issue: #50737