### PR TITLE
GH-50739: [C++] Make simdjson required for static linking

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2851,9 +2851,7 @@ if(ARROW_WITH_SIMDJSON)
                      FORCE_ANY_NEWER_VERSION
                      TRUE
                      REQUIRED_VERSION
-                     ${ARROW_SIMDJSON_REQUIRED_VERSION}
-                     IS_RUNTIME_DEPENDENCY
-                     FALSE)
+                     ${ARROW_SIMDJSON_REQUIRED_VERSION})
   if(SIMDJSON_VENDORED)
     add_library(arrow::simdjson ALIAS simdjson)
   else()

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -61,6 +61,12 @@ if(ARROW_WITH_LZ4)
   endif()
 endif()
 
+if(ARROW_WITH_SIMDJSON)
+  if(simdjson_SOURCE STREQUAL "SYSTEM")
+    list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS simdjson::simdjson)
+  endif()
+endif()
+
 if(ARROW_WITH_SNAPPY)
   if(Snappy_SOURCE STREQUAL "SYSTEM")
     list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS ${Snappy_TARGET})


### PR DESCRIPTION
### Rationale for this change

Unlike RapidJSON, simdjson is not header-only and needs to be linked to explicitly when linking against libarrow.a.

This should fix the JNI builds on the C++ Extra workflow.

### Are these changes tested?

Yes, by existing CI builds.

### Are there any user-facing changes?

No.

* GitHub Issue: #50739