### PR TITLE
MINOR: [CI][C++] Fix Docker caching on JNI builds

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -64,6 +64,11 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  ARCHERY_DEBUG: 1
+  ARROW_ENABLE_TIMING_TESTS: OFF
+  DOCKER_VOLUME_PREFIX: ".docker/"
+
 jobs:
   check-labels:
     uses: ./.github/workflows/check_labels.yml
@@ -122,10 +127,6 @@ jobs:
               -e CMAKE_CXX_STANDARD=23
             runs-on: ubuntu-latest
             title: AMD64 Debian C++23
-    env:
-      ARCHERY_DEBUG: 1
-      ARROW_ENABLE_TIMING_TESTS: OFF
-      DOCKER_VOLUME_PREFIX: ".docker/"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v7

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -486,9 +486,6 @@ jobs:
       fail-fast: false
     env:
       ARCH: amd64
-      ARCHERY_DEBUG: 1
-      ARROW_ENABLE_TIMING_TESTS: OFF
-      DOCKER_VOLUME_PREFIX: ".docker/"
       UBUNTU: 24.04
     steps:
       - name: Checkout Arrow

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -64,6 +64,11 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  ARCHERY_DEBUG: 1
+  ARROW_ENABLE_TIMING_TESTS: OFF
+  DOCKER_VOLUME_PREFIX: ".docker/"
+
 jobs:
   check-labels:
     uses: ./.github/workflows/check_labels.yml
@@ -128,10 +133,6 @@ jobs:
               -e ARROW_CXXFLAGS=-march=x86-64
             runs-on: ubuntu-latest
             title: AMD64 Debian SIMD Level NONE
-    env:
-      ARCHERY_DEBUG: 1
-      ARROW_ENABLE_TIMING_TESTS: OFF
-      DOCKER_VOLUME_PREFIX: ".docker/"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v7

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -492,9 +492,6 @@ jobs:
       fail-fast: false
     env:
       ARCH: amd64
-      ARCHERY_DEBUG: 1
-      ARROW_ENABLE_TIMING_TESTS: OFF
-      DOCKER_VOLUME_PREFIX: ".docker/"
       UBUNTU: 24.04
     steps:
       - name: Checkout Arrow


### PR DESCRIPTION
### Rationale for this change

Docker caching didn't work on JNI builds as the Docker volume storage didn't match the cached directory.

### What changes are included in this PR?

Move the `DOCKER_VOLUME_PREFIX` definition at the C++ Extra workflow top level so that it also affects Docker-based JNI jobs.

### Are these changes tested?

Yes, by existing CI runs.

Before:
* [JNI ubuntu-latest amd64](https://github.com/apache/arrow/actions/runs/30545623441/job/90881219129?pr=50742#logs): 51 minutes
* [JNI ubuntu-24.04-arm arm64/v8](https://github.com/apache/arrow/actions/runs/30545623441/job/90881219157?pr=50742#logs): 34 minutes

After:
* [JNI ubuntu-latest amd64](https://github.com/apache/arrow/actions/runs/30545623441/job/90914579171?pr=50742#logs): 14 minutes
* [JNI ubuntu-24.04-arm arm64/v8](https://github.com/apache/arrow/actions/runs/30545623441/job/90914578906?pr=50742#logs): 10 minutes

### Are there any user-facing changes?

No.
