### PR TITLE
GH-50744: [R] Add read_ipc_file and write_ipc_file to _pkgdown.yml reference index

### DIFF
--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -183,6 +183,7 @@ reference:
   - read_delim_arrow
   - read_parquet
   - read_feather
+  - read_ipc_file
   - read_ipc_stream
   - read_json_arrow
 
@@ -193,6 +194,7 @@ reference:
     - write_csv_arrow
     - write_parquet
     - write_feather
+    - write_ipc_file
     - write_ipc_stream
     - write_to_raw
 


### PR DESCRIPTION
### Rationale for this change

Errors due to functions missing from pkgdown docs

### What changes are included in this PR?

Adds them

### Are these changes tested?

Will run CI

### Are there any user-facing changes?

No
* GitHub Issue: #50744