### PR TITLE
GH-50697: [C++][FlightRPC] ODBC installer support fixes

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -329,7 +329,7 @@ takes precedence over ccache if a storage backend is configured" ON)
                 ARROW_FLIGHT)
 
   define_option(ARROW_FLIGHT_SQL_ODBC
-                "Build the Arrow Flight SQL ODBC extension"
+                "Build the Arrow Flight SQL ODBC driver"
                 OFF
                 DEPENDS
                 ARROW_FLIGHT_SQL

--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -173,6 +173,7 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
 
     set(CPACK_WIX_UI_BANNER
         "${CMAKE_CURRENT_SOURCE_DIR}/install/windows/arrow-wix-banner.bmp")
+    set(ODBC_DOC_INSTALL_DIR "doc")
   else()
     if(APPLE)
       set(CPACK_PACKAGE_FILE_NAME
@@ -191,13 +192,8 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
 
       set(ODBC_INSTALL_DIR "arrow-odbc/lib")
       set(ODBC_DOC_INSTALL_DIR "arrow-odbc/doc")
-    else()
-      # Linux
-      # GH-49595: TODO implement DEB installer
-      # GH-47977: TODO implement RPM installer
-      message(STATUS "ODBC_PACKAGE_FORMAT DEB not implemented, see GH-49595")
-      message(STATUS "ODBC_PACKAGE_FORMAT RPM not implemented, see GH-47977")
     endif()
+    # GH-49595: TODO implement DEB installer under `linux-packages`
 
     # Install ODBC
     install(TARGETS arrow_flight_sql_odbc_shared
@@ -225,14 +221,14 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
                         GROUP_READ
                         WORLD_EXECUTE
                         WORLD_READ)
-
-    # Install documentation files
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../LICENSE.txt"
-                  "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../NOTICE.txt"
-                  "${CMAKE_CURRENT_SOURCE_DIR}/connection-options.md"
-            DESTINATION "${ODBC_DOC_INSTALL_DIR}"
-            COMPONENT Docs)
   endif()
+
+  # Install documentation files
+  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../LICENSE.txt"
+                "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../NOTICE.txt"
+                "${CMAKE_CURRENT_SOURCE_DIR}/connection-options.md"
+          DESTINATION "${ODBC_DOC_INSTALL_DIR}"
+          COMPONENT Docs)
 
   get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
   set(CPACK_COMPONENTS_ALL "ArrowFlightSQLODBC" "Docs")
@@ -250,7 +246,6 @@ if(ARROW_FLIGHT_SQL_ODBC_INSTALLER)
     # macOS and Linux
     set(CPACK_GENERATOR "productbuild")
   endif()
-  # GH-47877 TODO: create Linux Installer using cpack
 
   # Load CPack after all CPACK* variables are set
   include(CPack)

--- a/cpp/src/arrow/flight/sql/odbc/README.md
+++ b/cpp/src/arrow/flight/sql/odbc/README.md
@@ -144,6 +144,15 @@ After ODBC has been registered, you can run the ODBC tests. It is recommended to
       .\cpp\build\< release | debug >\< Release | Debug>\arrow-flight-sql-odbc-test.exe
       ```
 
+## Installers
+
+ODBC Windows and macOS installers are uploaded to the CI artifacts for developer use.
+
+| Operating System | Package Format |
+|------------------|----------------|
+| Windows          | MSI            |
+| macOS            | PKG            |
+
 ## Known Limitations
 
 - Conversion from timestamp data type with specified time zone value to strings is not supported at the moment. This doesn't impact driver's usage of retrieving timestamp data from Power BI on Windows, and Excel on macOS and Windows. See GH-47504 for more context.

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -509,6 +509,7 @@ odbcinst -u -d -n "Apache Arrow Flight SQL ODBC Driver"
 %files -n %{name}%{so_version}-flight-sql-odbc-libs
 %defattr(-,root,root,-)
 %doc README.md
+%doc cpp/src/arrow/flight/sql/odbc/connection-options.md
 %license LICENSE.txt NOTICE.txt
 %{_datadir}/arrow/flight/sql/odbc/arrow-flight-sql-odbc-template.ini
 %{_libdir}/libarrow_flight_sql_odbc.so.*
@@ -526,6 +527,7 @@ Libraries and header files for Apache Arrow Flight SQL ODBC driver.
 %files flight-sql-odbc-devel
 %defattr(-,root,root,-)
 %doc README.md
+%doc cpp/src/arrow/flight/sql/odbc/connection-options.md
 %license LICENSE.txt NOTICE.txt
 %{_includedir}/arrow/flight/sql/odbc/
 %{_libdir}/cmake/ArrowFlightSqlOdbc/

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -527,7 +527,6 @@ Libraries and header files for Apache Arrow Flight SQL ODBC driver.
 %files flight-sql-odbc-devel
 %defattr(-,root,root,-)
 %doc README.md
-%doc cpp/src/arrow/flight/sql/odbc/connection-options.md
 %license LICENSE.txt NOTICE.txt
 %{_includedir}/arrow/flight/sql/odbc/
 %{_libdir}/cmake/ArrowFlightSqlOdbc/


### PR DESCRIPTION
### Rationale for this change

GH-50697

I have tested the RPM ODBC installer on AlmaLinux 9. The ODBC driver works as expected on AlmaLinux 9. The only issue I found was that the `connection-options.md` guide was not included in the package installation. This PR adds `connection-options.md` to the RPM ODBC package so users can reference the connection options documentation after installation.

Summary of testing results:

1. Clean install - driver works as expected and registered successfully, arrow installer installs `isql` and `unixODBC` during installation.
2. Uninstall - driver is uninstalled and unregistered automatically, arrow installer flags and uninstalls `isql` and `unixODBC` as unused dependency during installation. 
If user wants to avoid this behavior, they can add `--noautoremove` flag to make `dnf` keep `isql` and `unixODBC` during ODBC uninstallation.
3. Upgrade - driver can be upgraded to new version. 
4. Data retrieval works as expected, no dependency issues found.

### What changes are included in this PR?
- Add `connection-options.md` to the RPM ODBC package installation.
   - Example location after install: `/usr/share/doc/arrow2600-flight-sql-odbc-libs/connection-options.md`
- Fix Windows ODBC installer to include docs `LICENSE.txt` and `NOTICE.txt`
- Add ODBC installer description to ODBC `README.md`

### Are these changes tested?

Yes

### Are there any user-facing changes?
Yes

* GitHub Issue: #50697