### PR TITLE
GH-47774: [C++] Force-inlince Status::~Status() to improve reading performance

### DIFF
--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -148,7 +148,7 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
  public:
   // Create a success status.
   constexpr Status() noexcept : state_(NULLPTR) {}
-  ~Status() noexcept {
+  ARROW_FORCE_INLINE ~Status() noexcept {
     if (ARROW_PREDICT_FALSE(state_ != NULL)) {
       if (!state_->is_constant) {
         DeleteState();


### PR DESCRIPTION
# GH-47774: [C++] Force-inline `Status::~Status` to improve read performance

### Rationale for this change

`Status` is returned by nearly every API on hot paths (e.g. IPC/Parquet reading), so its destructor runs extremely frequently. The destructor body is already optimized for the common success case: it only checks `state_ != NULL` (with `ARROW_PREDICT_FALSE`) and returns immediately for an OK status, delegating the rare error cleanup to the out-of-line `DeleteState()`.

However, without an explicit inlining hint, some compilers/optimization levels may not inline this destructor, turning the trivial `state_ == NULL` fast path into a real function call at every call site. Forcing it inline removes this call overhead on hot read paths and improves read throughput.

In our perf test (reads a parquet file of 6.7GB), `Status::~Status` cost about 20 seconds, as the following flamegraph shows:
<img width="1381" height="254" alt="image" src="https://github.com/user-attachments/assets/c62601b8-6d1f-455a-9ee5-9edc4ea57852" />

After inlining `Status::~Status`, the hotspot disappeared. End-to-end latency was also reduced by 20 seconds, as expected.

<img width="1367" height="263" alt="image" src="https://github.com/user-attachments/assets/78ec8f84-f9b7-4d74-b767-9046c1d40eaf" />


### What changes are included in this PR?

- Annotate `Status::~Status()` in `cpp/src/arrow/status.h` with `ARROW_FORCE_INLINE` (`__attribute__((always_inline)) inline` on GCC/Clang, `__forceinline` on MSVC), so the cheap null-check fast path is always inlined while the cold error path still goes through the non-inlined `DeleteState()`.

### Are these changes tested?

Yes, by existing tests. This change does not alter any behavior of `Status`; the existing `Status` unit tests and the full C++ test suite cover it. The performance improvement can be observed with the existing read-path benchmarks.

### Are there any user-facing changes?

No. This is an internal performance optimization with no API or behavior change.

* GitHub Issue: #47774