### PR TITLE
GH-50750: [C++][Parquet] Remove code marked as deprecated except flight in versions 23.0.0 and earlier

### DIFF
--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -277,15 +277,6 @@ std::shared_ptr<Array> RandomArrayGenerator::Date64(int64_t size, int64_t min,
                                                       memory_pool);
 }
 
-std::shared_ptr<Array> RandomArrayGenerator::Float16(int64_t size, uint16_t min,
-                                                     uint16_t max,
-                                                     double null_probability,
-                                                     int64_t alignment,
-                                                     MemoryPool* memory_pool) {
-  return this->Float16(size, Float16::FromBits(min), Float16::FromBits(max),
-                       null_probability, /*nan_probability=*/0, alignment, memory_pool);
-}
-
 std::shared_ptr<Array> RandomArrayGenerator::Float16(
     int64_t size, util::Float16 min, util::Float16 max, double null_probability,
     double nan_probability, int64_t alignment, MemoryPool* memory_pool) {

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -192,27 +192,6 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \brief Generate a random HalfFloatArray
   ///
   /// \param[in] size the size of the array to generate
-  /// \param[in] min the lower bound of the distribution
-  /// \param[in] max the upper bound of the distribution
-  /// \param[in] null_probability the probability of a value being null
-  /// \param[in] alignment alignment for memory allocations (in bytes)
-  /// \param[in] memory_pool memory pool to allocate memory from
-  ///
-  /// \return a generated Array
-  ///
-  /// \deprecated Deprecated in 22.0.0. Use the other Float16() method that accepts
-  /// nan_probability as a parameter
-  ARROW_DEPRECATED(
-      "Deprecated in 22.0.0. Use the other Float16() method that accepts nan_probability "
-      "as a parameter")
-  std::shared_ptr<Array> Float16(int64_t size, uint16_t min, uint16_t max,
-                                 double null_probability = 0,
-                                 int64_t alignment = kDefaultBufferAlignment,
-                                 MemoryPool* memory_pool = default_memory_pool());
-
-  /// \brief Generate a random HalfFloatArray
-  ///
-  /// \param[in] size the size of the array to generate
   /// \param[in] min the lower bound of the uniform distribution
   /// \param[in] max the upper bound of the uniform distribution
   /// \param[in] null_probability the probability of a value being null

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1414,28 +1414,6 @@ std::shared_ptr<RowGroupReader> FileReaderImpl::RowGroup(int row_group_index) {
 // ----------------------------------------------------------------------
 // Public factory functions
 
-Status FileReader::GetRecordBatchReader(std::shared_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto tmp, GetRecordBatchReader());
-  out->reset(tmp.release());
-  return Status::OK();
-}
-
-Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                        std::shared_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto tmp, GetRecordBatchReader(row_group_indices));
-  out->reset(tmp.release());
-  return Status::OK();
-}
-
-Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                        const std::vector<int>& column_indices,
-                                        std::shared_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto tmp,
-                        GetRecordBatchReader(row_group_indices, column_indices));
-  out->reset(tmp.release());
-  return Status::OK();
-}
-
 Status FileReader::ReadTable(std::shared_ptr<Table>* out) {
   ARROW_ASSIGN_OR_RAISE(*out, ReadTable());
   return Status::OK();
@@ -1468,22 +1446,6 @@ Status FileReader::ReadRowGroups(const std::vector<int>& row_groups,
 Status FileReader::ReadRowGroups(const std::vector<int>& row_groups,
                                  std::shared_ptr<Table>* out) {
   ARROW_ASSIGN_OR_RAISE(*out, ReadRowGroups(row_groups));
-  return Status::OK();
-}
-
-Status FileReader::Make(::arrow::MemoryPool* pool,
-                        std::unique_ptr<ParquetFileReader> reader,
-                        const ArrowReaderProperties& properties,
-                        std::unique_ptr<FileReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(*out, Make(pool, std::move(reader), properties));
-  return Status::OK();
-}
-
-Status FileReader::Make(::arrow::MemoryPool* pool,
-                        std::unique_ptr<ParquetFileReader> reader,
-                        std::unique_ptr<FileReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(*out,
-                        Make(pool, std::move(reader), default_arrow_reader_properties()));
   return Status::OK();
 }
 

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -116,21 +116,6 @@ class RowGroupReader;
 class PARQUET_EXPORT FileReader {
  public:
   /// Factory function to create a FileReader from a ParquetFileReader and properties
-  /// \deprecated Deprecated in 23.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 23.0.0. Use arrow::Result version instead.")
-  static ::arrow::Status Make(::arrow::MemoryPool* pool,
-                              std::unique_ptr<ParquetFileReader> reader,
-                              const ArrowReaderProperties& properties,
-                              std::unique_ptr<FileReader>* out);
-
-  /// Factory function to create a FileReader from a ParquetFileReader
-  /// \deprecated Deprecated in 23.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 23.0.0. Use arrow::Result version instead.")
-  static ::arrow::Status Make(::arrow::MemoryPool* pool,
-                              std::unique_ptr<ParquetFileReader> reader,
-                              std::unique_ptr<FileReader>* out);
-
-  /// Factory function to create a FileReader from a ParquetFileReader and properties
   static ::arrow::Result<std::unique_ptr<FileReader>> Make(
       ::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader,
       const ArrowReaderProperties& properties);
@@ -191,33 +176,6 @@ class PARQUET_EXPORT FileReader {
   virtual ::arrow::Result<std::unique_ptr<::arrow::RecordBatchReader>>
   GetRecordBatchReader(const std::vector<int>& row_group_indices,
                        const std::vector<int>& column_indices) = 0;
-
-  /// \brief Return a RecordBatchReader of row groups selected from
-  /// row_group_indices, whose columns are selected by column_indices.
-  ///
-  /// Note that the ordering in row_group_indices and column_indices
-  /// matter. FileReaders must outlive their RecordBatchReaders.
-  ///
-  /// \param row_group_indices which row groups to read (order determines read order).
-  /// \param column_indices which columns to read (order determines output schema).
-  /// \param[out] out record batch stream from parquet data.
-  ///
-  /// \returns error Status if either row_group_indices or column_indices
-  ///     contains an invalid index
-  /// \deprecated Deprecated in 21.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 21.0.0. Use arrow::Result version instead.")
-  ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                       const std::vector<int>& column_indices,
-                                       std::shared_ptr<::arrow::RecordBatchReader>* out);
-
-  /// \deprecated Deprecated in 21.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 21.0.0. Use arrow::Result version instead.")
-  ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                       std::shared_ptr<::arrow::RecordBatchReader>* out);
-
-  /// \deprecated Deprecated in 21.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 21.0.0. Use arrow::Result version instead.")
-  ::arrow::Status GetRecordBatchReader(std::shared_ptr<::arrow::RecordBatchReader>* out);
 
   /// \brief Return a generator of record batches.
   ///

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -108,12 +108,6 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
  public:
   class PARQUET_EXPORT Builder {
    public:
-    PARQUET_DEPRECATED("name argument is ignored, use default constructor instead")
-    explicit Builder(const std::string& name) : encrypted_(true) {}
-
-    PARQUET_DEPRECATED("path argument is ignored, use default constructor instead")
-    explicit Builder(const schema::ColumnPath& path) : encrypted_(true) {}
-
     Builder() = default;
 
     /// Set a column-specific key.


### PR DESCRIPTION
### Rationale for this change

Remove some deprecated code.

### What changes are included in this PR?

Remove these:
1. `arrow::random::RandomArrayGenerator::Float16(..., uint16_t min, uint16_t max, ...)`
2. `parquet::arrow::FileReader::GetRecordBatchReader(..., out)` overloads
3. `parquet::ColumnEncryptionProperties::Builder(name/path)` constructors
4. `parquet::arrow::FileReader::Make(..., out)` overloads

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes. Some public deprecated methods are removed.

* GitHub Issue: #50750