### PR TITLE
GH-50752: [C++][Compute] Fix unused variable warning when ARROW_WITH_RE2 is disabled

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -1750,9 +1750,9 @@ struct FindSubstringExec {
 
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const MatchSubstringOptions& options = MatchSubstringState::Get(ctx);
-    const bool is_utf8 = is_string_or_string_view(batch[0].type()->id());
     if (options.ignore_case) {
 #ifdef ARROW_WITH_RE2
+      const bool is_utf8 = is_string_or_string_view(batch[0].type()->id());
       ARROW_ASSIGN_OR_RAISE(auto matcher,
                             FindSubstringRegex::Make(options, is_utf8, true));
       applicator::ScalarUnaryNotNullStateful<OffsetType, InputPhysicalType,


### PR DESCRIPTION
### Rationale for this change

This change fixes the following build error:

```
/arrow/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc:1753:16: error: unused variable ‘is_utf8’ [-Werror=unused-variable]
 1753 |     const bool is_utf8 = is_string_or_string_view(batch[0].type()->id());
      |                ^~~~~~~
```

The `is_utf8` variable introduced by commit 374db36 is unused when `ARROW_WITH_RE2=OFF` is specified.

```diff
  static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
    const MatchSubstringOptions& options = MatchSubstringState::Get(ctx);
+   const bool is_utf8 = is_string_or_string_view(batch[0].type()->id());
    if (options.ignore_case) {
      ARROW_ASSIGN_OR_RAISE(auto matcher,
-                           FindSubstringRegex::Make(options, InputType::is_utf8, true));
-     applicator::ScalarUnaryNotNullStateful<OffsetType, InputType, FindSubstringRegex>
+                           FindSubstringRegex::Make(options, is_utf8, true));
+     applicator::ScalarUnaryNotNullStateful<OffsetType, InputPhysicalType,
+                                            FindSubstringRegex>
          kernel{std::move(matcher)};
      return kernel.Exec(ctx, batch, out);
      return Status::NotImplemented("ignore_case requires RE2");
    }
-   applicator::ScalarUnaryNotNullStateful<OffsetType, InputType, FindSubstring> kernel{
-       FindSubstring(PlainSubstringMatcher(options))};
+   applicator::ScalarUnaryNotNullStateful<OffsetType, InputPhysicalType, FindSubstring>
+       kernel{FindSubstring(PlainSubstringMatcher(options))};
    return kernel.Exec(ctx, batch, out);
  }
};
```

Therefore, I move the declaration of `is_utf8` inside the `#ifdef ARROW_WITH_RE2` block to prevent this error.

### What changes are included in this PR?

I move the declaration of `is_utf8` inside the `#ifdef ARROW_WITH_RE2` block to prevent this error.

This PR does not includes breaking changes to public APIs.
This PR does not contains a "Critical Fix".

### Are these changes tested?

Yes.
This change only moves the declaration of `is_utf8` and does not change any logic.

Therefore, the existing tests introduced by 374db36 should continue to pass. These tests are already covered by CI, and CI passes successfully with this change.

No new tests are added because this change only moves a variable declaration and does not affect behavior.
I have confirmed that C++ CI checks pass on my fork.
See: https://github.com/komainu8/arrow/actions/runs/30619400223/job/91120073626

### Are there any user-facing changes?

No.

* GitHub Issue: #50752