### PR TITLE
GH-50666: [Release][CI] Use Ubuntu 24.04 for source verification jobs

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2044,9 +2044,14 @@ services:
       TEST_APT: 0  # would require docker-in-docker
       TEST_YUM: 0
       USE_CONDA: 1
+    # Ubuntu 24.04 needs extra tzdata-legacy, unavailable in 22.04 wheel image
     command: >
       /bin/bash -c "
-        apt update -y && apt install -y curl git gnupg tzdata wget &&
+        apt update -y &&
+        apt install -y curl git gnupg tzdata wget &&
+        if apt-cache show tzdata-legacy >/dev/null 2>&1; then
+          apt install -y tzdata-legacy;
+        fi &&
         git config --global --add safe.directory /arrow &&
         /arrow/dev/release/verify-release-candidate.sh $${VERIFY_VERSION} $${VERIFY_RC}"
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -272,7 +272,6 @@ tasks:
 
 {% for distribution, version in [("conda", "latest"),
                                  ("almalinux", "10"),
-                                 ("ubuntu", "22.04"),
                                  ("ubuntu", "24.04")] %}
   {% for target in ["cpp",
                     "integration",
@@ -284,6 +283,9 @@ tasks:
     params:
       env:
         {{ distribution.upper() }}: "{{ version }}"
+        {% if distribution == "conda" %}
+        UBUNTU: "24.04"
+        {% endif %}
       target: {{ target }}
       distro: {{ distribution }}
   {% endfor %}


### PR DESCRIPTION
### Rationale for this change
See #50666, for now move from Ubuntu 22.04 to Ubuntu 24.04 for source verification only.

### What changes are included in this PR?
a) Remove these four jobs that already have 24.04 equivalents:
`verify-rc-source-{cpp/integration/python/ruby}-cpp-linux-ubuntu-22.04-amd64`
b) Move Ubuntu 22.04 to 24.04 for these jobs:
`verify-rc-source-{cpp/integration/python/ruby}-linux-conda-latest-amd64`

### Are these changes tested?
Yes, Ubuntu 24.04 integration and Python verification complete OK locally.

### Are there any user-facing changes?
No.
* GitHub Issue: #50666