### PR TITLE
GH-50756: [C++][FlightSQL][ODBC] Fix Clang 20 compilation on macOS 26

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -279,7 +279,6 @@ SQLRETURN SQLError(SQLHENV env, SQLHDBC conn, SQLHSTMT stmt, SQLWCHAR* sql_state
 
   // Use the last record
   SQLINTEGER diag_number;
-  SQLSMALLINT diag_number_length;
 
   SQLRETURN ret = arrow::flight::sql::odbc::SQLGetDiagField(
       handle_type, handle, 0, SQL_DIAG_NUMBER, &diag_number, sizeof(SQLINTEGER), 0);
@@ -642,7 +641,7 @@ SQLRETURN SQLGetDiagRec(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSMALLINT r
   }
 
   // Convert from ODBC 1 based record number to internal diagnostics 0 indexed storage
-  const size_t record_index = static_cast<size_t>(rec_number - 1);
+  const auto record_index = static_cast<uint32_t>(rec_number - 1);
   if (!diagnostics->HasRecord(record_index)) {
     return SQL_NO_DATA;
   }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/timestamp_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/accessors/timestamp_array_accessor.cc
@@ -95,7 +95,7 @@ RowStatus TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::MoveSingleCellImpl
           ? ((value + 1) / divisor) - 1
           // Towards zero is already floor
           : value / divisor;
-  tm timestamp = {0};
+  tm timestamp{};
 
   GetTimeForSecondsSinceEpoch(converted_result_seconds, timestamp);
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/config/configuration.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/config/configuration.cc
@@ -64,7 +64,8 @@ std::string ReadDsnString(const std::string& dsn, const std::string_view& key,
   }
 
   std::string result("");
-  SetAttributeSQLWCHAR(buf.data(), ret * GetSqlWCharSize(), result);
+  SetAttributeSQLWCHAR(buf.data(), ret * static_cast<SQLINTEGER>(GetSqlWCharSize()),
+                       result);
   return result;
 }
 
@@ -110,7 +111,8 @@ std::vector<std::string> ReadAllKeys(const std::string& dsn) {
 
     std::string key("");
     SQLINTEGER key_len = static_cast<SQLINTEGER>(cur - begin);
-    SetAttributeSQLWCHAR(begin, key_len * GetSqlWCharSize(), key);
+    SetAttributeSQLWCHAR(begin, key_len * static_cast<SQLINTEGER>(GetSqlWCharSize()),
+                         key);
     keys.emplace_back(key);
     begin = ++cur;
   }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding.h
@@ -17,11 +17,13 @@
 
 #pragma once
 
-#include <boost/locale/encoding_utf.hpp>
 #include <cassert>
 #include <cstring>
+#include <iterator>
+#include <string>
 #include <vector>
 #include "arrow/flight/sql/odbc/odbc_impl/exceptions.h"
+#include "arrow/vendored/utfcpp/checked.h"
 
 #if defined(__APPLE__)
 #  include <atomic>
@@ -69,10 +71,15 @@ inline size_t wcsstrlen(const void* wcs_string) {
 template <typename CHAR_TYPE>
 inline void Utf8ToWcs(const char* utf8_string, size_t length,
                       std::vector<uint8_t>* result) {
-  auto string = boost::locale::conv::utf_to_utf<CHAR_TYPE>(
-      utf8_string, utf8_string + length, boost::locale::conv::stop);
+  std::basic_string<CHAR_TYPE> string;
+  if constexpr (sizeof(CHAR_TYPE) == sizeof(char16_t)) {
+    ::utf8::utf8to16(utf8_string, utf8_string + length, std::back_inserter(string));
+  } else {
+    static_assert(sizeof(CHAR_TYPE) == sizeof(char32_t));
+    ::utf8::utf8to32(utf8_string, utf8_string + length, std::back_inserter(string));
+  }
 
-  uint32_t length_in_bytes = static_cast<uint32_t>(string.size() * GetSqlWCharSize());
+  auto length_in_bytes = static_cast<uint32_t>(string.size() * sizeof(CHAR_TYPE));
   const uint8_t* data = (uint8_t*)string.data();
 
   result->reserve(length_in_bytes);
@@ -101,14 +108,16 @@ template <typename CHAR_TYPE>
 inline void WcsToUtf8(const void* wcs_string, size_t length_in_code_units,
                       std::vector<uint8_t>* result) {
   const auto* begin = static_cast<const CHAR_TYPE*>(wcs_string);
-  auto byte_string = boost::locale::conv::utf_to_utf<char>(
-      begin, begin + length_in_code_units, boost::locale::conv::stop);
 
-  uint32_t length_in_bytes = static_cast<uint32_t>(byte_string.size());
-  const uint8_t* data = (uint8_t*)byte_string.data();
+  std::string string;
+  if constexpr (sizeof(CHAR_TYPE) == sizeof(char16_t)) {
+    ::utf8::utf16to8(begin, begin + length_in_code_units, std::back_inserter(string));
+  } else {
+    static_assert(sizeof(CHAR_TYPE) == sizeof(char32_t));
+    ::utf8::utf32to8(begin, begin + length_in_code_units, std::back_inserter(string));
+  }
 
-  result->reserve(length_in_bytes);
-  result->assign(data, data + length_in_bytes);
+  result->assign(string.begin(), string.end());
 }
 
 inline void WcsToUtf8(const void* wcs_string, size_t length_in_code_units,

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding.h
@@ -17,13 +17,11 @@
 
 #pragma once
 
+#include <boost/locale/encoding_utf.hpp>
 #include <cassert>
-#include <codecvt>
 #include <cstring>
-#include <locale>
 #include <vector>
 #include "arrow/flight/sql/odbc/odbc_impl/exceptions.h"
-#include "arrow/util/macros.h"
 
 #if defined(__APPLE__)
 #  include <atomic>
@@ -68,13 +66,11 @@ inline size_t wcsstrlen(const void* wcs_string) {
   }
 }
 
-// GH-46576: suppress unicode warnings
-ARROW_SUPPRESS_DEPRECATION_WARNING
 template <typename CHAR_TYPE>
 inline void Utf8ToWcs(const char* utf8_string, size_t length,
                       std::vector<uint8_t>* result) {
-  thread_local std::wstring_convert<std::codecvt_utf8<CHAR_TYPE>, CHAR_TYPE> converter;
-  auto string = converter.from_bytes(utf8_string, utf8_string + length);
+  auto string = boost::locale::conv::utf_to_utf<CHAR_TYPE>(
+      utf8_string, utf8_string + length, boost::locale::conv::stop);
 
   uint32_t length_in_bytes = static_cast<uint32_t>(string.size() * GetSqlWCharSize());
   const uint8_t* data = (uint8_t*)string.data();
@@ -82,7 +78,6 @@ inline void Utf8ToWcs(const char* utf8_string, size_t length,
   result->reserve(length_in_bytes);
   result->assign(data, data + length_in_bytes);
 }
-ARROW_UNSUPPRESS_DEPRECATION_WARNING
 
 inline void Utf8ToWcs(const char* utf8_string, size_t length,
                       std::vector<uint8_t>* result) {
@@ -102,14 +97,12 @@ inline void Utf8ToWcs(const char* utf8_string, std::vector<uint8_t>* result) {
   return Utf8ToWcs(utf8_string, strlen(utf8_string), result);
 }
 
-// GH-46576: suppress unicode warnings
-ARROW_SUPPRESS_DEPRECATION_WARNING
 template <typename CHAR_TYPE>
 inline void WcsToUtf8(const void* wcs_string, size_t length_in_code_units,
                       std::vector<uint8_t>* result) {
-  thread_local std::wstring_convert<std::codecvt_utf8<CHAR_TYPE>, CHAR_TYPE> converter;
-  auto byte_string = converter.to_bytes((CHAR_TYPE*)wcs_string,
-                                        (CHAR_TYPE*)wcs_string + length_in_code_units);
+  const auto* begin = static_cast<const CHAR_TYPE*>(wcs_string);
+  auto byte_string = boost::locale::conv::utf_to_utf<char>(
+      begin, begin + length_in_code_units, boost::locale::conv::stop);
 
   uint32_t length_in_bytes = static_cast<uint32_t>(byte_string.size());
   const uint8_t* data = (uint8_t*)byte_string.data();
@@ -117,7 +110,6 @@ inline void WcsToUtf8(const void* wcs_string, size_t length_in_code_units,
   result->reserve(length_in_bytes);
   result->assign(data, data + length_in_bytes);
 }
-ARROW_UNSUPPRESS_DEPRECATION_WARNING
 
 inline void WcsToUtf8(const void* wcs_string, size_t length_in_code_units,
                       std::vector<uint8_t>* result) {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding_utils.h
@@ -22,9 +22,7 @@
 #include "arrow/flight/sql/odbc/odbc_impl/odbc_includes.h"
 
 #include <algorithm>
-#include <codecvt>
 #include <cstring>
-#include <locale>
 #include <memory>
 #include <string>
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.cc
@@ -412,7 +412,6 @@ FlightSqlConnection::FlightSqlConnection(OdbcVersion odbc_version,
                                          const std::string& driver_version)
     : info_(client_options_, call_options_, sql_client_, driver_version),
       diagnostics_("Apache Arrow", "Flight SQL", odbc_version),
-      odbc_version_(odbc_version),
       closed_(true) {
   attribute_[CONNECTION_DEAD] = static_cast<uint32_t>(SQL_TRUE);
   attribute_[LOGIN_TIMEOUT] = static_cast<uint32_t>(0);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h
@@ -47,7 +47,6 @@ class FlightSqlConnection : public Connection {
   std::unique_ptr<FlightSqlClient> sql_client_;
   GetInfoCache info_;
   Diagnostics diagnostics_;
-  OdbcVersion odbc_version_;
   bool closed_;
 
   void PopulateMetadataSettings(const Connection::ConnPropertyMap& conn_property_map);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_result_set.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_result_set.cc
@@ -76,7 +76,8 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
     }
 
     for (size_t column_num = 0; column_num < columns_.size(); ++column_num) {
-      columns_[column_num].ResetAccessor(current_chunk_.data->column(column_num));
+      columns_[column_num].ResetAccessor(
+          current_chunk_.data->column(static_cast<int>(column_num)));
     }
   }
 
@@ -101,7 +102,8 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
       }
 
       for (size_t column_num = 0; column_num < columns_.size(); ++column_num) {
-        columns_[column_num].ResetAccessor(current_chunk_.data->column(column_num));
+        columns_[column_num].ResetAccessor(
+            current_chunk_.data->column(static_cast<int>(column_num)));
       }
       current_row_ = 0;
       continue;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/json_converter.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/json_converter.cc
@@ -39,7 +39,7 @@ Status ConvertScalarToStringAndWrite(const ScalarT& scalar,
                                      rapidjson::Writer<rapidjson::StringBuffer>& writer) {
   ARROW_ASSIGN_OR_RAISE(auto string_scalar, scalar.CastTo(arrow::utf8()))
   const auto& view = reinterpret_cast<StringScalar*>(string_scalar.get())->view();
-  writer.String(view.data(), view.length(), true);
+  writer.String(view.data(), static_cast<rapidjson::SizeType>(view.length()), true);
   return Status::OK();
 }
 
@@ -50,7 +50,7 @@ Status ConvertBinaryToBase64StringAndWrite(
   size_t encoded_size = base64::encoded_size(view.length());
   std::vector<char> encoded(std::max(encoded_size, static_cast<size_t>(1)));
   base64::encode(&encoded[0], view.data(), view.length());
-  writer.String(&encoded[0], encoded_size, true);
+  writer.String(&encoded[0], static_cast<rapidjson::SizeType>(encoded_size), true);
   return Status::OK();
 }
 
@@ -164,7 +164,7 @@ class ScalarToJson : public ScalarVisitor {
 
   Status Visit(const StringScalar& scalar) override {
     const auto& view = scalar.view();
-    writer_.String(view.data(), view.length());
+    writer_.String(view.data(), static_cast<rapidjson::SizeType>(view.length()));
 
     return Status::OK();
   }
@@ -175,7 +175,7 @@ class ScalarToJson : public ScalarVisitor {
 
   Status Visit(const LargeStringScalar& scalar) override {
     const auto& view = scalar.view();
-    writer_.String(view.data(), view.length());
+    writer_.String(view.data(), static_cast<rapidjson::SizeType>(view.length()));
 
     return Status::OK();
   }
@@ -227,14 +227,16 @@ class ScalarToJson : public ScalarVisitor {
 
   Status Visit(const Decimal128Scalar& scalar) override {
     const auto& view = scalar.ToString();
-    writer_.RawValue(view.data(), view.length(), rapidjson::kNumberType);
+    writer_.RawValue(view.data(), static_cast<rapidjson::SizeType>(view.length()),
+                     rapidjson::kNumberType);
 
     return Status::OK();
   }
 
   Status Visit(const Decimal256Scalar& scalar) override {
     const auto& view = scalar.ToString();
-    writer_.RawValue(view.data(), view.length(), rapidjson::kNumberType);
+    writer_.RawValue(view.data(), static_cast<rapidjson::SizeType>(view.length()),
+                     rapidjson::kNumberType);
 
     return Status::OK();
   }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/main.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/main.cc
@@ -184,8 +184,9 @@ void TestGetColumnsV3(const std::shared_ptr<Connection>& connection) {
 
   while (result_set->Move(1, 0, 0, nullptr) == 1) {
     for (size_t i = 0; i < column_count; ++i) {
-      result_set->GetData(1 + i, arrow::flight::sql::odbc::CDataType_CHAR, 0, 0,
-                          result.data(), buffer_length, &result_length);
+      result_set->GetData(static_cast<int>(i + 1),
+                          arrow::flight::sql::odbc::CDataType_CHAR, 0, 0, result.data(),
+                          buffer_length, &result_length);
       std::cout << (result_length != -1 ? result.data() : "NULL") << '\t';
     }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_descriptor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_descriptor.cc
@@ -510,8 +510,7 @@ void ODBCDescriptor::PopulateFromResultSetMetadata(ResultSetMetadata* rsmd) {
     records_[i].case_sensitive =
         rsmd->IsCaseSensitive(one_based_index) ? SQL_TRUE : SQL_FALSE;
     // TODO - update datetime_interval_precision when rsmd adds this
-    auto num_prec_radix =
-        static_cast<SQLINTEGER>(rsmd->GetNumPrecRadix(one_based_index));
+    auto num_prec_radix = static_cast<SQLINTEGER>(rsmd->GetNumPrecRadix(one_based_index));
     records_[i].num_prec_radix = num_prec_radix > 0 ? num_prec_radix : 0;
     // TODO - update datetime_interval_code when rsmd adds this
     records_[i].fixed_prec_scale =

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_descriptor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_descriptor.cc
@@ -485,7 +485,7 @@ void ODBCDescriptor::PopulateFromResultSetMetadata(ResultSetMetadata* rsmd) {
   highest_one_based_bound_record_ = records_.size() + 1;
 
   for (size_t i = 0; i < records_.size(); ++i) {
-    size_t one_based_index = i + 1;
+    int one_based_index = static_cast<int>(i + 1);
     int16_t concise_type = rsmd->GetConciseType(one_based_index);
 
     records_[i].base_column_name = rsmd->GetBaseColumnName(one_based_index);
@@ -509,10 +509,11 @@ void ODBCDescriptor::PopulateFromResultSetMetadata(ResultSetMetadata* rsmd) {
         rsmd->IsAutoUnique(one_based_index) ? SQL_TRUE : SQL_FALSE;
     records_[i].case_sensitive =
         rsmd->IsCaseSensitive(one_based_index) ? SQL_TRUE : SQL_FALSE;
-    records_[i].datetime_interval_precision;  // TODO - update when rsmd adds this
-    SQLINTEGER num_prec_radix = rsmd->GetNumPrecRadix(one_based_index);
+    // TODO - update datetime_interval_precision when rsmd adds this
+    auto num_prec_radix =
+        static_cast<SQLINTEGER>(rsmd->GetNumPrecRadix(one_based_index));
     records_[i].num_prec_radix = num_prec_radix > 0 ? num_prec_radix : 0;
-    records_[i].datetime_interval_code;  // TODO
+    // TODO - update datetime_interval_code when rsmd adds this
     records_[i].fixed_prec_scale =
         rsmd->IsFixedPrecScale(one_based_index) ? SQL_TRUE : SQL_FALSE;
     records_[i].nullable = rsmd->IsNullable(one_based_index);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -339,14 +339,15 @@ bool ODBCStatement::Fetch(size_t rows, SQLULEN* row_count_ptr,
     // Note that the number of ARD records can both be more or less
     // than the number of columns.
     for (size_t i = 0; i < ird_->GetRecords().size(); i++) {
+      const int column_number = static_cast<int>(i + 1);
       if (i < current_ard_->GetRecords().size() &&
           current_ard_->GetRecords()[i].is_bound) {
         const DescriptorRecord& ard_record = current_ard_->GetRecords()[i];
-        current_result_->BindColumn(i + 1, ard_record.type, ard_record.precision,
+        current_result_->BindColumn(column_number, ard_record.type, ard_record.precision,
                                     ard_record.scale, ard_record.data_ptr,
                                     GetLength(ard_record), ard_record.indicator_ptr);
       } else {
-        current_result_->BindColumn(i + 1,
+        current_result_->BindColumn(column_number,
                                     arrow::flight::sql::odbc::CDataType_CHAR
                                     /* arbitrary type, not used */,
                                     0, 0, nullptr, 0, nullptr);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/util.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/util.h
@@ -25,7 +25,6 @@
 #include "arrow/flight/types.h"
 
 #include <boost/xpressive/xpressive.hpp>
-#include <codecvt>
 #include <functional>
 #include <optional>
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/win_system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/win_system_dsn.cc
@@ -36,8 +36,6 @@
 #include "arrow/util/logging.h"
 
 #include <odbcinst.h>
-#include <codecvt>
-#include <locale>
 #include <sstream>
 
 namespace arrow::flight::sql::odbc {


### PR DESCRIPTION
### Rationale for this change

Fix Clang 20 compilation on macOS 26.

### What changes are included in this PR?

Fix four kinds of compile errors mentioned in the issue GH-50756.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50756