### PR TITLE
GH-50758: [CI][C++] Use LLVM 22 on Debian experimental

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -446,7 +446,7 @@ tasks:
         ARCH: "amd64"
         DEBIAN: "experimental"
         GCC: "15"
-        LLVM: "20"
+        LLVM: "22"
       image: debian-cpp
 
   test-fedora-42-cpp:


### PR DESCRIPTION
### Rationale for this change
Fix #50758 - `llvm-toolchain-20` package was [removed from Debian experimental on Jul 14](https://tracker.debian.org/news/1774937/removed-12018-1-from-experimental/), so the nightly `test-debian-experimental-cpp-gcc-15` fails with `E: Unable to locate package clang-20` / `llvm-20-dev`.

### What changes are included in this PR?
Update LLVM 20 to 22 on Debian experimental in `dev/tasks/tasks.yml`

### Are these changes tested?
Yes, built locally and verified via crossbow.
 
### Are there any user-facing changes?
No.
* GitHub Issue: #50758