### PR TITLE
GH-50760: [CI][Python] Create venv for test-fedora-42-python-3

### DIFF
--- a/ci/docker/linux-dnf-python-3.dockerfile
+++ b/ci/docker/linux-dnf-python-3.dockerfile
@@ -24,18 +24,20 @@ RUN dnf install -y \
         python3-pip \
         python3-devel
 
-RUN ln -s /usr/bin/python3 /usr/local/bin/python && \
-    ln -s /usr/bin/pip3 /usr/local/bin/pip
-
-RUN pip install -U pip setuptools wheel
-
 COPY python/requirements-build.txt \
      python/requirements-test.txt \
      /arrow/python/
 
-RUN pip install \
-    -r arrow/python/requirements-build.txt \
-    -r arrow/python/requirements-test.txt
+# venv instead of system Python, otherwise pip can't upgrade
+# packages installed by RPM (error: uninstall-no-record-file)
+ENV ARROW_PYTHON_VENV /arrow-dev
+
+RUN python3 -m venv ${ARROW_PYTHON_VENV} && \
+    . ${ARROW_PYTHON_VENV}/bin/activate && \
+    pip install -U pip setuptools wheel && \
+    pip install \
+      -r arrow/python/requirements-build.txt \
+      -r arrow/python/requirements-test.txt
 
 ENV ARROW_ACERO=ON \
     ARROW_BUILD_STATIC=OFF \


### PR DESCRIPTION
### Rationale for this change
The nightly job `test-fedora-42-python-3` fails with `Cannot uninstall packaging 24.2`
`╰─> The package's contents are unknown: no RECORD file was found for packaging.`

### What changes are included in this PR?
venv in `linux-dnf-python-3.dockerfile` to install Python requirements there

### Are these changes tested?
Yes, crossbow job passes.

### Are there any user-facing changes?
No.
* GitHub Issue: #50760