### PR TITLE
GH-50766: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_docker_configure.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -340,6 +340,7 @@ repos:
           ?^ci/scripts/python_wheel_xlinux_build\.sh$|
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_deps\.sh$|
+          ?^ci/scripts/r_docker_configure\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -18,28 +18,28 @@
 
 set -ex
 
-: ${R_BIN:=R}
+: "${R_BIN:=R}"
 # This is where our docker setup puts things; set this to run outside of docker
-: ${ARROW_SOURCE_HOME:=/arrow}
+: "${ARROW_SOURCE_HOME:=/arrow}"
 
 # The Dockerfile should have put this file here
 if [ -f "${ARROW_SOURCE_HOME}/ci/etc/rprofile" ]; then
   # Ensure parallel R package installation, set CRAN repo mirror,
   # and use pre-built binaries where possible
-  cat ${ARROW_SOURCE_HOME}/ci/etc/rprofile >> $(${R_BIN} RHOME)/etc/Rprofile.site
+  cat "${ARROW_SOURCE_HOME}/ci/etc/rprofile" >> "$(${R_BIN} RHOME)/etc/Rprofile.site"
 fi
 
 # Ensure parallel compilation of C/C++ code
-echo "MAKEFLAGS=-j$(${R_BIN} -s -e 'cat(parallel::detectCores())')" >> $(R RHOME)/etc/Renviron.site
+echo "MAKEFLAGS=-j$(${R_BIN} -s -e 'cat(parallel::detectCores())')" >> "$(R RHOME)/etc/Renviron.site"
 
 # Figure out what package manager we have
-if [ "`which dnf`" ]; then
+if [ "$(which dnf)" ]; then
   PACKAGE_MANAGER=dnf
-elif [ "`which yum`" ]; then
+elif [ "$(which yum)" ]; then
   PACKAGE_MANAGER=yum
-elif [ "`which zypper`" ]; then
+elif [ "$(which zypper)" ]; then
   PACKAGE_MANAGER=zypper
-elif [ "`which apk`" ]; then
+elif [ "$(which apk)" ]; then
   PACKAGE_MANAGER=apk
 else
   PACKAGE_MANAGER=apt-get
@@ -47,9 +47,9 @@ else
 fi
 
 # Enable ccache if requested based on http://dirk.eddelbuettel.com/blog/2017/11/27/
-: ${R_CUSTOM_CCACHE:=FALSE}
-R_CUSTOM_CCACHE=`echo $R_CUSTOM_CCACHE | tr '[:upper:]' '[:lower:]'`
-if [ ${R_CUSTOM_CCACHE} = "true" ]; then
+: "${R_CUSTOM_CCACHE:=FALSE}"
+R_CUSTOM_CCACHE=$(echo "$R_CUSTOM_CCACHE" | tr '[:upper:]' '[:lower:]')
+if [ "${R_CUSTOM_CCACHE}" = "true" ]; then
   # install ccache
   if [ "$PACKAGE_MANAGER" = "apk" ]; then
     $PACKAGE_MANAGER add ccache
@@ -80,9 +80,9 @@ fi
 # Install rsync for bundling cpp source and curl to make sure it is installed on all images,
 # cmake is now a listed sys req.
 if [ "$PACKAGE_MANAGER" = "apk" ]; then
-  $PACKAGE_MANAGER add rsync cmake curl
+  "$PACKAGE_MANAGER" add rsync cmake curl
 else
-  $PACKAGE_MANAGER install -y rsync cmake curl
+  "$PACKAGE_MANAGER" install -y rsync cmake curl
 fi
 
 

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -52,10 +52,10 @@ R_CUSTOM_CCACHE=$(echo "$R_CUSTOM_CCACHE" | tr '[:upper:]' '[:lower:]')
 if [ "${R_CUSTOM_CCACHE}" = "true" ]; then
   # install ccache
   if [ "$PACKAGE_MANAGER" = "apk" ]; then
-    $PACKAGE_MANAGER add ccache
+    "$PACKAGE_MANAGER" add ccache
   else
-    $PACKAGE_MANAGER install -y epel-release || true
-    $PACKAGE_MANAGER install -y ccache
+    "$PACKAGE_MANAGER" install -y epel-release || true
+    "$PACKAGE_MANAGER" install -y ccache
   fi
 
   mkdir -p ~/.R


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2006 (style): Use $(...) notation instead of legacy backticks
* SC2046: Quote this to prevent word splitting.
* SC2086: Double quote to prevent globbing and word splitting.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.

```
shellcheck ci/scripts/r_docker_configure.sh

In ci/scripts/r_docker_configure.sh line 21:
: ${R_BIN:=R}
  ^---------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_docker_configure.sh line 23:
: ${ARROW_SOURCE_HOME:=/arrow}
  ^--------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_docker_configure.sh line 29:
  cat ${ARROW_SOURCE_HOME}/ci/etc/rprofile >> $(${R_BIN} RHOME)/etc/Rprofile.site
      ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                              ^---------------^ SC2046 (warning): Quote this to prevent word splitting.

Did you mean:
  cat "${ARROW_SOURCE_HOME}"/ci/etc/rprofile >> $(${R_BIN} RHOME)/etc/Rprofile.site


In ci/scripts/r_docker_configure.sh line 33:
echo "MAKEFLAGS=-j$(${R_BIN} -s -e 'cat(parallel::detectCores())')" >> $(R RHOME)/etc/Renviron.site
                                                                       ^--------^ SC2046 (warning): Quote this to prevent word splitting.


In ci/scripts/r_docker_configure.sh line 36:
if [ "`which dnf`" ]; then
      ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
if [ "$(which dnf)" ]; then


In ci/scripts/r_docker_configure.sh line 38:
elif [ "`which yum`" ]; then
        ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which yum)" ]; then


In ci/scripts/r_docker_configure.sh line 40:
elif [ "`which zypper`" ]; then
        ^------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which zypper)" ]; then


In ci/scripts/r_docker_configure.sh line 42:
elif [ "`which apk`" ]; then
        ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which apk)" ]; then


In ci/scripts/r_docker_configure.sh line 50:
: ${R_CUSTOM_CCACHE:=FALSE}
  ^-----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_docker_configure.sh line 51:
R_CUSTOM_CCACHE=`echo $R_CUSTOM_CCACHE | tr '[:upper:]' '[:lower:]'`
                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                      ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
R_CUSTOM_CCACHE=$(echo "$R_CUSTOM_CCACHE" | tr '[:upper:]' '[:lower:]')


In ci/scripts/r_docker_configure.sh line 52:
if [ ${R_CUSTOM_CCACHE} = "true" ]; then
     ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "${R_CUSTOM_CCACHE}" = "true" ]; then

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
```

### What changes are included in this PR?

* SC2006  Use `$(...)` notation instead of legacy backticks
* SC2046: Quote variable to prevent word splitting.
* SC2086: Quote variable expansions.
* SC2223: Quote default variable assignments.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50766