### PR TITLE
GH-50658: [C++][Dev] Add RunEndEncoded support to gdb_arrow.py

### DIFF
--- a/cpp/gdb_arrow.py
+++ b/cpp/gdb_arrow.py
@@ -95,7 +95,8 @@ def identity(v):
 
 
 def has_null_bitmap(type_id):
-    return type_id not in (Type.NA, Type.SPARSE_UNION, Type.DENSE_UNION)
+    return type_id not in (Type.NA, Type.SPARSE_UNION, Type.DENSE_UNION,
+                           Type.RUN_END_ENCODED)
 
 
 @lru_cache()
@@ -1069,6 +1070,7 @@ type_reprs = {
     'SparseUnionType': 'sparse_union',
     'DenseUnionType': 'dense_union',
     'DictionaryType': 'dictionary',
+    'RunEndEncodedType': 'run_end_encoded',
     }
 
 
@@ -1168,6 +1170,20 @@ class ListTypePrinter(TypePrinter):
             return f"{self._format_type()}<uninitialized or corrupt>"
         else:
             return f"{self._format_type()}({child})"
+
+
+class RunEndEncodedTypePrinter(TypePrinter):
+    """
+    Pretty-printer for run-end encoded types.
+    """
+
+    def to_string(self):
+        fields = self.fields
+        if len(fields) != 2:
+            return f"{self._format_type()}<uninitialized or corrupt>"
+        run_end_type = fields[0].type
+        value_type = fields[1].type
+        return f"{self._format_type()}({run_end_type}, {value_type})"
 
 
 class FixedSizeListTypePrinter(ListTypePrinter):
@@ -1999,6 +2015,12 @@ class FixedSizeListTypeClass(DataTypeClass):
     scalar_printer = BaseListScalarPrinter
 
 
+class RunEndEncodedTypeClass(DataTypeClass):
+    is_parametric = True
+    type_printer = RunEndEncodedTypePrinter
+    scalar_printer = BaseListScalarPrinter
+
+
 class MapTypeClass(DataTypeClass):
     is_parametric = True
     type_printer = MapTypePrinter
@@ -2085,6 +2107,8 @@ type_traits_by_id = {
     Type.LARGE_LIST: DataTypeTraits(BaseListTypeClass, 'LargeListType'),
     Type.FIXED_SIZE_LIST: DataTypeTraits(FixedSizeListTypeClass,
                                          'FixedSizeListType'),
+    Type.RUN_END_ENCODED: DataTypeTraits(RunEndEncodedTypeClass,
+                                         'RunEndEncodedType'),
     Type.MAP: DataTypeTraits(MapTypeClass, 'MapType'),
 
     Type.STRUCT: DataTypeTraits(StructTypeClass, 'StructType'),

--- a/python/pyarrow/src/arrow/python/gdb.cc
+++ b/python/pyarrow/src/arrow/python/gdb.cc
@@ -222,6 +222,9 @@ void TestSession() {
   FixedSizeListType fixed_size_list_type(float64(), 3);
   auto heap_fixed_size_list_type = fixed_size_list(float64(), 3);
 
+  RunEndEncodedType run_end_encoded_type(int32(), utf8());
+  auto heap_run_end_encoded_type = run_end_encoded(int32(), utf8());
+
   DictionaryType dict_type_unordered(int16(), utf8());
   DictionaryType dict_type_ordered(int16(), utf8(), /*ordered=*/true);
   auto heap_dict_type = dictionary(int16(), utf8());
@@ -389,6 +392,14 @@ void TestSession() {
   FixedSizeListScalar fixed_size_list_scalar_null{
       list_value_array, fixed_size_list(int32(), 3), /*is_valid=*/false};
 
+  auto run_end_encoded_scalar_type = run_end_encoded(int32(), utf8());
+  RunEndEncodedScalar run_end_encoded_scalar{MakeScalar("foo"),
+                                             run_end_encoded_scalar_type};
+  RunEndEncodedScalar run_end_encoded_scalar_null{run_end_encoded_scalar_type};
+  std::shared_ptr<Scalar> heap_run_end_encoded_scalar =
+      std::make_shared<RunEndEncodedScalar>(MakeScalar("foo"),
+                                            run_end_encoded_scalar_type);
+
   auto struct_scalar_type = struct_({field("ints", int32()), field("strs", utf8())});
   StructScalar struct_scalar{
       ScalarVector{MakeScalar(int32_t(42)), MakeScalar("some text")}, struct_scalar_type};
@@ -447,6 +458,14 @@ void TestSession() {
 
   auto heap_list_array = SliceArrayFromJSON(list(int64()), "[[1, 2], null, []]");
   ListArray list_array{heap_list_array->data()};
+
+  // Encodes ["foo", "foo", null, null, null].
+  auto run_end_encoded_run_ends = SliceArrayFromJSON(int32(), "[2, 5]");
+  auto run_end_encoded_values = SliceArrayFromJSON(utf8(), R"(["foo", null])");
+  std::shared_ptr<Array> heap_run_end_encoded_array = *RunEndEncodedArray::Make(
+      /*logical_length=*/5, run_end_encoded_run_ends, run_end_encoded_values);
+  RunEndEncodedArray run_end_encoded_array{heap_run_end_encoded_array->data()};
+  auto heap_run_end_encoded_array_sliced = heap_run_end_encoded_array->Slice(1, 3);
 
   const char* json_double_array = "[-1.5, null]";
   auto heap_double_array = SliceArrayFromJSON(float64(), json_double_array);

--- a/python/pyarrow/tests/test_gdb.py
+++ b/python/pyarrow/tests/test_gdb.py
@@ -408,6 +408,9 @@ def test_types_stack(gdb_arrow):
     check_stack_repr(gdb_arrow, "fixed_size_list_type",
                      "arrow::fixed_size_list(arrow::float64(), 3)")
     check_stack_repr(
+        gdb_arrow, "run_end_encoded_type",
+        "arrow::run_end_encoded(arrow::int32(), arrow::utf8())")
+    check_stack_repr(
         gdb_arrow, "map_type_unsorted",
         "arrow::map(arrow::utf8(), arrow::binary(), keys_sorted=false)")
     check_stack_repr(
@@ -468,6 +471,9 @@ def test_types_heap(gdb_arrow):
                     "arrow::large_list(arrow::large_utf8())")
     check_heap_repr(gdb_arrow, "heap_fixed_size_list_type",
                     "arrow::fixed_size_list(arrow::float64(), 3)")
+    check_heap_repr(
+        gdb_arrow, "heap_run_end_encoded_type",
+        "arrow::run_end_encoded(arrow::int32(), arrow::utf8())")
     check_heap_repr(
         gdb_arrow, "heap_map_type",
         "arrow::map(arrow::utf8(), arrow::binary(), keys_sorted=false)")
@@ -744,6 +750,14 @@ def test_scalars_stack(gdb_arrow):
         gdb_arrow, "fixed_size_list_scalar_null",
         ('arrow::FixedSizeListScalar of type '
          'arrow::fixed_size_list(arrow::int32(), 3), null value'))
+    check_stack_repr(
+        gdb_arrow, "run_end_encoded_scalar",
+        ('arrow::RunEndEncodedScalar of value '
+         'arrow::StringScalar of size 3, value "foo"'))
+    check_stack_repr(
+        gdb_arrow, "run_end_encoded_scalar_null",
+        ('arrow::RunEndEncodedScalar of type '
+         'arrow::run_end_encoded(arrow::int32(), arrow::utf8()), null value'))
 
     check_stack_repr(
         gdb_arrow, "struct_scalar",
@@ -810,6 +824,10 @@ def test_scalars_heap(gdb_arrow):
         gdb_arrow, "heap_map_scalar_null",
         ('arrow::MapScalar of type arrow::map(arrow::utf8(), arrow::int32(), '
          'keys_sorted=false), null value'))
+    check_heap_repr(
+        gdb_arrow, "heap_run_end_encoded_scalar",
+        ('arrow::RunEndEncodedScalar of value '
+         'arrow::StringScalar of size 3, value "foo"'))
 
 
 def test_array_data(gdb_arrow):
@@ -828,6 +846,11 @@ def test_arrays_stack(gdb_arrow):
         gdb_arrow, "list_array",
         ("arrow::ListArray of type arrow::list(arrow::int64()), "
          "length 3, offset 0, null count 1"))
+    check_stack_repr(
+        gdb_arrow, "run_end_encoded_array",
+        ("arrow::RunEndEncodedArray of type "
+         "arrow::run_end_encoded(arrow::int32(), arrow::utf8()), "
+         "length 5, offset 0, null count 0"))
 
 
 def test_arrays_heap(gdb_arrow):
@@ -1081,6 +1104,16 @@ def test_arrays_heap(gdb_arrow):
         gdb_arrow, "heap_list_array",
         ("arrow::ListArray of type arrow::list(arrow::int64()), "
          "length 3, offset 0, null count 1"))
+    check_heap_repr(
+        gdb_arrow, "heap_run_end_encoded_array",
+        ("arrow::RunEndEncodedArray of type "
+         "arrow::run_end_encoded(arrow::int32(), arrow::utf8()), "
+         "length 5, offset 0, null count 0"))
+    check_heap_repr(
+        gdb_arrow, "heap_run_end_encoded_array_sliced",
+        ("arrow::RunEndEncodedArray of type "
+         "arrow::run_end_encoded(arrow::int32(), arrow::utf8()), "
+         "length 3, offset 1, null count 0"))
 
 
 def test_schema(gdb_arrow):


### PR DESCRIPTION
### Rationale for this change
The Arrow GDB pretty-printers do not support run-end encoded data types.

### What changes are included in this PR?
Add GDB pretty-printer support and tests for `run-end encoded` types, scalars, and arrays.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.

* GitHub Issue: #50658