### PR TITLE
GH-50699: [C++] Fix ComputeLogicalNullCount crash for null-typed dictionaries

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -178,6 +178,12 @@ TEST_F(TestArray, TestNullCount) {
                              true, true);
     CheckDictionaryNullCount(dict_type, "[null, true, null, false]", "[null, 1, 0, 2, 3]",
                              1, 3, true, true);
+
+    // a null-typed dictionary is all-null and has no validity bitmap
+    dict_type = dictionary(index_type, null());
+    CheckDictionaryNullCount(dict_type, "[null]", "[]", 0, 0, false, true);
+    CheckDictionaryNullCount(dict_type, "[null]", "[0, 0]", 0, 2, false, true);
+    CheckDictionaryNullCount(dict_type, "[null]", "[0, 0, null]", 1, 3, true, true);
   }
 }
 
@@ -199,6 +205,16 @@ TEST_F(TestArray, TestSlicePreservesAllNullCount) {
   ASSERT_EQ(dict_arr->ComputeLogicalNullCount(), 8);
   ASSERT_EQ(dict_arr->Slice(2, 8)->null_count(), 0);
   ASSERT_EQ(dict_arr->Slice(2, 8)->ComputeLogicalNullCount(), 6);
+
+  // A null-typed dictionary has no validity bitmap, so the logical null count of a
+  // slice comes from the slice's own length rather than from a per-index scan.
+  std::shared_ptr<arrow::Array> null_dict_arr =
+      DictArrayFromJSON(dictionary(int64(), null()), /*indices=*/"[0, null, 0, 0, 0]",
+                        /*dictionary=*/"[null]");
+  ASSERT_EQ(null_dict_arr->null_count(), 1);
+  ASSERT_EQ(null_dict_arr->ComputeLogicalNullCount(), 5);
+  ASSERT_EQ(null_dict_arr->Slice(2, 3)->null_count(), 0);
+  ASSERT_EQ(null_dict_arr->Slice(2, 3)->ComputeLogicalNullCount(), 3);
 }
 
 TEST_F(TestArray, TestLength) {

--- a/cpp/src/arrow/util/dict_util.cc
+++ b/cpp/src/arrow/util/dict_util.cc
@@ -54,8 +54,15 @@ int64_t LogicalNullCount(const ArraySpan& span) {
 }  // namespace
 
 int64_t LogicalNullCount(const ArraySpan& span) {
-  if (span.dictionary().GetNullCount() == 0 || span.length == 0) {
+  const auto& dictionary_span = span.dictionary();
+  if (dictionary_span.GetNullCount() == 0 || span.length == 0) {
     return span.GetNullCount();
+  }
+  if (!dictionary_span.HasValidityBitmap()) {
+    // The dictionary has nulls but no validity bitmap to inspect, which means all
+    // of its values are null (a null-typed dictionary). Every index, valid or not,
+    // is then logically null.
+    return span.length;
   }
 
   const auto& dict_array_type = internal::checked_cast<const DictionaryType&>(*span.type);


### PR DESCRIPTION
### Rationale for this change

The dictionary of a `dictionary(..., null())` array is a `NullArray`, which reports `null_count == length` but has no validity bitmap. `dict_util::LogicalNullCount` only skipped its per-index scan when the dictionary's null count was 0, so for these arrays the scan read through a null bitmap pointer and crashed.

### What changes are included in this PR?

Return the array's length when the dictionary has nulls but no validity bitmap. Every value in such a dictionary is null, so there is nothing to scan.

### Are these changes tested?

Yes, in `TestArray.TestNullCount` for all index types, and in `TestArray.TestSlicePreservesAllNullCount` for a slice. Two of the new cases crash without the fix.

### Are there any user-facing changes?

`ComputeLogicalNullCount()` no longer crashes on these arrays, and neither does the `count` kernel, which calls it.

**This PR contains a "Critical Fix".** It fixes a crash on valid input.
* GitHub Issue: #50699