### PR TITLE
GH-50771: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_install_system_dependencies.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -341,6 +341,7 @@ repos:
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_deps\.sh$|
           ?^ci/scripts/r_docker_configure\.sh$|
+          ?^ci/scripts/r_install_system_dependencies\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|

--- a/ci/scripts/r_install_system_dependencies.sh
+++ b/ci/scripts/r_install_system_dependencies.sh
@@ -19,16 +19,16 @@
 
 set -ex
 
-: ${ARROW_SOURCE_HOME:=/arrow}
+: "${ARROW_SOURCE_HOME:=/arrow}"
 
 # Figure out what package manager we have
-if [ "`which dnf`" ]; then
+if [ "$(which dnf)" ]; then
   PACKAGE_MANAGER=dnf
-elif [ "`which yum`" ]; then
+elif [ "$(which yum)" ]; then
   PACKAGE_MANAGER=yum
-elif [ "`which zypper`" ]; then
+elif [ "$(which zypper)" ]; then
   PACKAGE_MANAGER=zypper
-elif [ "`which apk`" ]; then
+elif [ "$(which apk)" ]; then
   PACKAGE_MANAGER=apk
 else
   PACKAGE_MANAGER=apt-get
@@ -47,16 +47,16 @@ case "$PACKAGE_MANAGER" in
     apt-get install -y libcurl4-openssl-dev libpng-dev libssl-dev libuv1-dev libxml2-dev
     ;;
   apk)
-    $PACKAGE_MANAGER add curl-dev openssl-dev libuv-dev libxml2-dev
+    "$PACKAGE_MANAGER" add curl-dev openssl-dev libuv-dev libxml2-dev
     ;;
   *)
-    $PACKAGE_MANAGER install -y libcurl-devel openssl-devel libuv-devel libxml2-devel
+    "$PACKAGE_MANAGER" install -y libcurl-devel openssl-devel libuv-devel libxml2-devel
     ;;
 esac
 
 if [ "$ARROW_S3" == "ON" ] || [ "$ARROW_GCS" == "ON" ] || [ "$ARROW_R_DEV" == "TRUE" ]; then
   # The Dockerfile should have put this file here
-  if [ "$ARROW_S3" == "ON" ] && [ -f "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" ] && [ "`which wget`" ]; then
+  if [ "$ARROW_S3" == "ON" ] && [ -f "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" ] && [ "$(which wget)" ]; then
     "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" latest /usr/local
   fi
 
@@ -65,17 +65,17 @@ if [ "$ARROW_S3" == "ON" ] || [ "$ARROW_GCS" == "ON" ] || [ "$ARROW_R_DEV" == "T
       zypper)
         # python3 is Python 3.6 on OpenSUSE 15.3.
         # PyArrow supports Python 3.11 or later.
-        $PACKAGE_MANAGER install -y python311-pip
+        "$PACKAGE_MANAGER" install -y python311-pip
         ln -s /usr/bin/python3.11 /usr/local/bin/python
         ln -s /usr/bin/pip3.11 /usr/local/bin/pip
         ;;
       apk)
-        $PACKAGE_MANAGER add py3-pip
+        "$PACKAGE_MANAGER" add py3-pip
         ln -s /usr/bin/python3 /usr/local/bin/python
         ln -s /usr/bin/pip3 /usr/local/bin/pip
         ;;
       *)
-        $PACKAGE_MANAGER install -y python3-pip
+        "$PACKAGE_MANAGER" install -y python3-pip
         ln -s /usr/bin/python3 /usr/local/bin/python
         ln -s /usr/bin/pip3 /usr/local/bin/pip
         ;;


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2223: This default assignment may cause DoS due to globbing. Quote it.
* SC2006: Use $(...) notation instead of legacy backticked `...`.


```
shellcheck r_install_system_dependencies.sh
r_install_system_dependencies.sh: r_install_system_dependencies.sh: openBinaryFile: does not exist (No such file or directory)
palolovalley:arrow hsato$ shellcheck ci/scripts/r_install_system_dependencies.sh

In ci/scripts/r_install_system_dependencies.sh line 22:
: ${ARROW_SOURCE_HOME:=/arrow}
  ^--------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_install_system_dependencies.sh line 25:
if [ "`which dnf`" ]; then
      ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
if [ "$(which dnf)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 27:
elif [ "`which yum`" ]; then
        ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which yum)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 29:
elif [ "`which zypper`" ]; then
        ^------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which zypper)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 31:
elif [ "`which apk`" ]; then
        ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which apk)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 59:
  if [ "$ARROW_S3" == "ON" ] && [ -f "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" ] && [ "`which wget`" ]; then
                                                                                                ^----------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
  if [ "$ARROW_S3" == "ON" ] && [ -f "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" ] && [ "$(which wget)" ]; then

For more information:
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```


### What changes are included in this PR?

* SC2006  Use `$(...)` notation instead of legacy backticks `...`
* SC2223: Quote default variable assignments.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50771