### PR TITLE
GH-50773: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_sanitize.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,6 +342,7 @@ repos:
           ?^ci/scripts/r_deps\.sh$|
           ?^ci/scripts/r_docker_configure\.sh$|
           ?^ci/scripts/r_install_system_dependencies\.sh$|
+          ?^ci/scripts/r_install_system_dependencies\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,8 +342,8 @@ repos:
           ?^ci/scripts/r_deps\.sh$|
           ?^ci/scripts/r_docker_configure\.sh$|
           ?^ci/scripts/r_install_system_dependencies\.sh$|
-          ?^ci/scripts/r_install_system_dependencies\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
+          ?^ci/scripts/r_sanitize\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|

--- a/ci/scripts/r_sanitize.sh
+++ b/ci/scripts/r_sanitize.sh
@@ -18,12 +18,12 @@
 
 set -ex
 
-: ${R_BIN:=RDsan}
+: "${R_BIN:=RDsan}"
 
 source_dir=${1}/r
 rhome=$(${R_BIN} RHOME)
 
-pushd ${source_dir}
+pushd "${source_dir}"
 
 # Unity builds were causing the CI job to run out of memory
 export CMAKE_UNITY_BUILD=OFF
@@ -33,10 +33,10 @@ export ARROW_R_DEV=TRUE
 export CMAKE_BUILD_TYPE=RelWithDebInfo
 
 ncores=$(${R_BIN} -s -e 'cat(parallel::detectCores())')
-echo "MAKEFLAGS=-j${ncores}" >> ${rhome}/etc/Renviron.site
+echo "MAKEFLAGS=-j${ncores}" >> "${rhome}/etc/Renviron.site"
 
 # build first so that any stray compiled files in r/src are ignored
-${R_BIN} CMD build --no-build-vignettes --no-manual .
+"${R_BIN}" CMD build --no-build-vignettes --no-manual .
 
 # But unset the env var so that it doesn't cause us to run extra dev tests
 unset ARROW_R_DEV
@@ -47,12 +47,13 @@ export ARROW_R_VERBOSE_TEST=TRUE
 # We prune dependencies for these, so we need to disable forcing suggests
 export _R_CHECK_FORCE_SUGGESTS_=FALSE
 
-export SUPPRESSION_FILE=$(readlink -f "tools/ubsan.supp")
+SUPPRESSION_FILE="$(readlink -f tools/ubsan.supp)"
+export SUPPRESSION_FILE
 export UBSAN_OPTIONS="print_stacktrace=1,suppressions=${SUPPRESSION_FILE}"
 # From the old rhub image https://github.com/r-hub/rhub-linux-builders/blob/master/fedora-clang-devel-san/Dockerfile
 export ASAN_OPTIONS="alloc_dealloc_mismatch=0:detect_leaks=0:detect_odr_violation=0"
 
-${R_BIN} CMD check --no-manual --no-vignettes --no-build-vignettes arrow*.tar.gz
+"${R_BIN}" CMD check --no-manual --no-vignettes --no-build-vignettes arrow*.tar.gz
 
 # Find sanitizer issues, print the file(s) they are part of, and fail the job
 find . -type f -name "*Rout" -exec grep -l "runtime error\|SUMMARY: UndefinedBehaviorSanitizer" {} \; > sanitizer_errors.txt


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2223: This default assignment may cause DoS due to globbing. Quote it.
* SC2006: Use $(...) notation instead of legacy backticked `...`.


```
shellcheck r_install_system_dependencies.sh
r_install_system_dependencies.sh: r_install_system_dependencies.sh: openBinaryFile: does not exist (No such file or directory)
palolovalley:arrow hsato$ shellcheck ci/scripts/r_install_system_dependencies.sh

In ci/scripts/r_install_system_dependencies.sh line 22:
: ${ARROW_SOURCE_HOME:=/arrow}
  ^--------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_install_system_dependencies.sh line 25:
if [ "`which dnf`" ]; then
      ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
if [ "$(which dnf)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 27:
elif [ "`which yum`" ]; then
        ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which yum)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 29:
elif [ "`which zypper`" ]; then
        ^------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which zypper)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 31:
elif [ "`which apk`" ]; then
        ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
elif [ "$(which apk)" ]; then


In ci/scripts/r_install_system_dependencies.sh line 59:
  if [ "$ARROW_S3" == "ON" ] && [ -f "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" ] && [ "`which wget`" ]; then
                                                                                                ^----------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
  if [ "$ARROW_S3" == "ON" ] && [ -f "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" ] && [ "$(which wget)" ]; then

For more information:
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```


### What changes are included in this PR?

* SC2223: Quote default variable assignments.
* SC2006: Use `$(...)` notation instead of legacy backticked `...`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50773