### PR TITLE
GH-50778: [C++][Parquet] Fix chunked level histogram accumulation

### DIFF
--- a/cpp/src/parquet/size_statistics.cc
+++ b/cpp/src/parquet/size_statistics.cc
@@ -168,7 +168,7 @@ void UpdateLevelHistogram(std::span<const int16_t> levels, std::span<int64_t> hi
     auto it = levels.begin();
     while (it != levels.end()) {
       const auto chunk_size = std::min<int64_t>(levels.end() - it, kChunkSize);
-      hist1 += std::accumulate(levels.begin(), levels.begin() + chunk_size, int16_t{0});
+      hist1 += std::accumulate(it, it + chunk_size, int16_t{0});
       it += chunk_size;
     }
     histogram[0] += num_levels - hist1;

--- a/cpp/src/parquet/size_statistics_test.cc
+++ b/cpp/src/parquet/size_statistics_test.cc
@@ -51,6 +51,14 @@ TEST(SizeStatistics, UpdateLevelHistogram) {
     EXPECT_THAT(histogram, ::testing::ElementsAre(3, 5));
   }
   {
+    // Cross the chunk boundary used by the max_level = 1 fast path.
+    std::vector<int16_t> levels(1 << 14, 1);
+    levels.push_back(0);
+    std::vector<int64_t> histogram(2, 0);
+    UpdateLevelHistogram(levels, histogram);
+    EXPECT_THAT(histogram, ::testing::ElementsAre(1, 1 << 14));
+  }
+  {
     // max_level > 1
     std::vector<int64_t> histogram(3, 0);
     UpdateLevelHistogram(std::vector<int16_t>{0, 1, 2, 2, 0}, histogram);


### PR DESCRIPTION
### Rationale for this change
`UpdateLevelHistogram` incorrectly accumulated from the beginning of the input on every iteration of its `max_level == 1` fast path. Inputs spanning multiple chunks therefore counted the first chunk repeatedly. 

Fix https://github.com/apache/arrow/issues/50778.

### What changes are included in this PR?
- Accumulate the current chunk using `it` rather than `levels.begin()`.
- Add a UT
### Are these changes tested?
Yes, passing the new UT and existing UT.

### Are there any user-facing changes?
No.

* GitHub Issue: #50778