### PR TITLE
GH-50777: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -343,6 +343,7 @@ repos:
           ?^ci/scripts/r_docker_configure\.sh$|
           ?^ci/scripts/r_install_system_dependencies\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
+          ?^ci/scripts/r_test\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -18,15 +18,16 @@
 
 set -ex
 
-: ${R_BIN:=R}
+: "${R_BIN:=R}"
 
 source_dir=${1}/r
 
-pushd ${source_dir}
+pushd "${source_dir}"
 
 printenv
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  # shellcheck source=/dev/null
   . "${ARROW_PYTHON_VENV}/bin/activate"
 fi
 


### PR DESCRIPTION
### Rationale for this change

This is part of sub-issue #44748 to clean up ShellCheck warnings in Apache Arrow shell scripts.

* SC1091: Not following: ./bin/activate: openBinaryFile: does not exist (No such file or directory)
* SC2086: Double quote to prevent globbing and word splitting.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.

### What changes are included in this PR?

* SC1091: Add `# shellcheck source=/dev/null` directive.
* SC2086: Quote variable expansions (`pushd "${source_dir}"`).
* SC2223: Quote default variable assignments (`: "${R_BIN:=R}"`).
* Update `.pre-commit-config.yaml` to enable ShellCheck for `ci/scripts/r_test.sh`.

### Are these changes tested?

Yes. Executed:
- `shellcheck ci/scripts/r_test.sh` (0 warnings)
- `git diff --check` (clean)

### Are there any user-facing changes?

No.

Closes #50777
* GitHub Issue: #50777