### PR TITLE
GH-49949: [C++][S3] Don't call HeadBucket when creating directories

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -3238,10 +3238,14 @@ Status S3FileSystem::CreateDir(const std::string& s, bool recursive) {
 
   FileInfo file_info;
   if (recursive) {
-    // Ensure bucket exists
-    ARROW_ASSIGN_OR_RAISE(bool bucket_exists, impl_->BucketExists(path.bucket));
-    if (!bucket_exists) {
-      RETURN_NOT_OK(impl_->CreateBucket(path.bucket));
+    // Only probe the bucket if we could create it: HeadBucket is denied for
+    // credentials scoped to a prefix inside the bucket (GH-49949). A missing
+    // bucket then surfaces as an error from the directory write that follows.
+    if (options().allow_bucket_creation) {
+      ARROW_ASSIGN_OR_RAISE(bool bucket_exists, impl_->BucketExists(path.bucket));
+      if (!bucket_exists) {
+        RETURN_NOT_OK(impl_->CreateBucket(path.bucket));
+      }
     }
 
     auto key_i = path.key_parts.begin();

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -49,9 +49,8 @@
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/PutObjectRequest.h>
-// PutBucketPolicyRequest.h marks an inline method definition with AWS_S3_API,
-// which expands to __declspec(dllimport) under USE_IMPORT_EXPORT.  GCC rejects
-// that outright, while MSVC only warns, so the header is unusable on MinGW.
+// AWS_S3_API on an inline definition in this header expands to
+// __declspec(dllimport), which GCC rejects and MSVC merely warns about.
 #ifndef __MINGW32__
 #  include <aws/s3/model/PutBucketPolicyRequest.h>
 #endif
@@ -1246,7 +1245,7 @@ TEST_F(TestS3FS, CreateDir) {
                  FileType::Directory);
 }
 
-// Needs PutBucketPolicyRequest, which does not compile on MinGW (see above).
+// PutBucketPolicyRequest.h is not included on MinGW.
 #ifndef __MINGW32__
 TEST_F(TestS3FS, CreateDirPrefixScopedCredentials) {
   // Grant anonymous access to the "allowed/" prefix only.  HeadBucket needs a

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -48,8 +48,13 @@
 #include <aws/s3/model/DeleteObjectsRequest.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
-#include <aws/s3/model/PutBucketPolicyRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
+// PutBucketPolicyRequest.h marks an inline method definition with AWS_S3_API,
+// which expands to __declspec(dllimport) under USE_IMPORT_EXPORT.  GCC rejects
+// that outright, while MSVC only warns, so the header is unusable on MinGW.
+#ifndef __MINGW32__
+#  include <aws/s3/model/PutBucketPolicyRequest.h>
+#endif
 #include <aws/sts/STSClient.h>
 
 #include "arrow/filesystem/filesystem.h"
@@ -1241,6 +1246,8 @@ TEST_F(TestS3FS, CreateDir) {
                  FileType::Directory);
 }
 
+// Needs PutBucketPolicyRequest, which does not compile on MinGW (see above).
+#ifndef __MINGW32__
 TEST_F(TestS3FS, CreateDirPrefixScopedCredentials) {
   // Grant anonymous access to the "allowed/" prefix only.  HeadBucket needs a
   // bucket-wide grant, so it is denied for these credentials.
@@ -1286,6 +1293,7 @@ TEST_F(TestS3FS, CreateDirPrefixScopedCredentials) {
   // Outside of the granted prefix the write itself is denied
   ASSERT_RAISES(IOError, fs->CreateDir("bucket/denied/newdir", /*recursive=*/true));
 }
+#endif
 
 TEST_F(TestS3FS, DeleteFile) {
   // Bucket

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -48,6 +48,7 @@
 #include <aws/s3/model/DeleteObjectsRequest.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
+#include <aws/s3/model/PutBucketPolicyRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/sts/STSClient.h>
 
@@ -1240,6 +1241,52 @@ TEST_F(TestS3FS, CreateDir) {
                  FileType::Directory);
 }
 
+TEST_F(TestS3FS, CreateDirPrefixScopedCredentials) {
+  // Grant anonymous access to the "allowed/" prefix only.  HeadBucket needs a
+  // bucket-wide grant, so it is denied for these credentials.
+  const std::string policy = R"({
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {"AWS": ["*"]},
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": ["arn:aws:s3:::bucket/allowed", "arn:aws:s3:::bucket/allowed/*"]
+    }, {
+      "Effect": "Allow",
+      "Principal": {"AWS": ["*"]},
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::bucket"],
+      "Condition": {"StringLike": {"s3:prefix": ["allowed/*"]}}
+    }]
+  })";
+  {
+    Aws::S3::Model::PutBucketPolicyRequest req;
+    req.SetBucket(ToAwsString("bucket"));
+    req.SetBody(std::make_shared<std::stringstream>(policy));
+    ASSERT_OK(OutcomeToStatus("PutBucketPolicy", client_->PutBucketPolicy(req)));
+  }
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.scheme = minio_->scheme();
+  options.endpoint_override = minio_->connect_string();
+  options.retry_strategy = std::make_shared<ShortRetryStrategy>();
+  if (enable_tls_) {
+    options.tls_ca_file_path = minio_->ca_file_path();
+  }
+  ASSERT_OK_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+
+  // The bucket itself is not readable...
+  ASSERT_RAISES(IOError, fs->GetFileInfo("bucket"));
+  // ...but a directory below the granted prefix can still be created.
+  ASSERT_OK(fs->CreateDir("bucket/allowed/newdir", /*recursive=*/true));
+  AssertObjectContents(client_.get(), "bucket", "allowed/", "");
+  AssertObjectContents(client_.get(), "bucket", "allowed/newdir/", "");
+
+  // Outside of the granted prefix the write itself is denied
+  ASSERT_RAISES(IOError, fs->CreateDir("bucket/denied/newdir", /*recursive=*/true));
+}
+
 TEST_F(TestS3FS, DeleteFile) {
   // Bucket
   ASSERT_RAISES(IOError, fs_->DeleteFile("bucket"));
@@ -1721,6 +1768,10 @@ TEST_F(TestS3FS, NoCreateDeleteBucket) {
   ASSERT_RAISES(IOError, maybe_create_dir);
   ASSERT_THAT(maybe_create_dir.message(),
               ::testing::HasSubstr("Bucket 'test-no-create' not found"));
+
+  // Creating a directory inside a nonexistent bucket fails when writing the
+  // directory entry, since the bucket is not probed beforehand
+  ASSERT_RAISES(IOError, fs_->CreateDir("test-no-create/newdir", /*recursive=*/true));
 
   auto maybe_delete_dir = fs_->DeleteDir("test-no-delete");
   ASSERT_RAISES(IOError, maybe_delete_dir);


### PR DESCRIPTION
### Rationale for this change

`CreateDir(..., recursive=true)` calls HeadBucket to decide whether the bucket needs creating. Credentials scoped to a prefix in the bucket are denied that call, so the directory creation fails even though the caller can write there.

### What changes are included in this PR?

Only call HeadBucket when `allow_bucket_creation` is on. There is nothing to do with the answer otherwise, and a missing bucket still fails when the directory entry is written.

### Are these changes tested?

Yes. A new test sets a bucket policy granting anonymous access to a single prefix, which leaves HeadBucket denied, then creates a directory under that prefix. It fails with the reported error without the fix. The test is skipped on MinGW, where the AWS SDK's `PutBucketPolicyRequest.h` marks an inline definition with `AWS_S3_API` (`__declspec(dllimport)`) and GCC rejects it.

### Are there any user-facing changes?

With `allow_bucket_creation` off and a bucket that does not exist, the error now comes from PutObject instead of `Bucket 'x' not found. To create buckets, enable the allow_bucket_creation option.`
* GitHub Issue: #49949