### PR TITLE
GH-50777: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -344,6 +344,7 @@ repos:
           ?^ci/scripts/r_install_system_dependencies\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/r_sanitize\.sh$|
+          ?^ci/scripts/r_test\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -18,15 +18,19 @@
 
 set -ex
 
-: ${R_BIN:=R}
+: "${R_BIN:=R}"
 
-source_dir=${1}/r
+source_dir="${1}/r"
 
-pushd ${source_dir}
+pushd "${source_dir}"
 
 printenv
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  # We don't need to follow this external file.
+  # See also: https://www.shellcheck.net/wiki/SC1091
+  #
+  # shellcheck source=/dev/null
   . "${ARROW_PYTHON_VENV}/bin/activate"
 fi
 
@@ -47,8 +51,8 @@ if [ "$ARROW_R_FORCE_TESTS" = "true" ]; then
 fi
 
 if [ "$ARROW_USE_PKG_CONFIG" != "false" ]; then
-  export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
-  export R_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+  export LD_LIBRARY_PATH="${ARROW_HOME}/lib:${LD_LIBRARY_PATH}"
+  export R_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
 fi
 
 export _R_CHECK_COMPILATION_FLAGS_KNOWN_="${_R_CHECK_COMPILATION_FLAGS_KNOWN_} ${ARROW_R_CXXFLAGS}"
@@ -126,7 +130,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   print(args)
 
   rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600)"
-echo "$SCRIPT" | ${R_BIN} --no-save
+echo "$SCRIPT" | "${R_BIN}" --no-save
 
 AFTER=$(ls -alh ~/)
 if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC1091: Not following: (error message here)
* SC2086: Double quote to prevent globbing and word splitting.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.

```
shellcheck ci/scripts/r_test.sh

In ci/scripts/r_test.sh line 21:
: ${R_BIN:=R}
  ^---------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_test.sh line 25:
pushd ${source_dir}
      ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${source_dir}"


In ci/scripts/r_test.sh line 30:
  . "${ARROW_PYTHON_VENV}/bin/activate"
    ^-- SC1091 (info): Not following: ./bin/activate: openBinaryFile: does not exist (No such file or directory)

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./bin/activate: op...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
```  

### What changes are included in this PR?

* SC1091: Add a ShellCheck directive to disable source file checking.
* SC2086: Quote variables.
* SC2223: Quote variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #50777