### PR TITLE
GH-50862: [C++][Gandiva] Fix Gandiva tests on riscv64 with an LLVM JIT relocation error

### DIFF
--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -140,6 +140,9 @@ Result<llvm::orc::JITTargetMachineBuilder> MakeTargetMachineBuilder(
     const Configuration& conf) {
   llvm::orc::JITTargetMachineBuilder jtmb(
       (llvm::Triple(llvm::sys::getDefaultTargetTriple())));
+#if defined(__riscv)
+  jtmb.setRelocationModel(llvm::Reloc::PIC_);
+#endif
   if (conf.target_host_cpu()) {
     jtmb.setCPU(cpu_name.str());
     jtmb.addFeatures(cpu_attrs);

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -140,9 +140,7 @@ Result<llvm::orc::JITTargetMachineBuilder> MakeTargetMachineBuilder(
     const Configuration& conf) {
   llvm::orc::JITTargetMachineBuilder jtmb(
       (llvm::Triple(llvm::sys::getDefaultTargetTriple())));
-#if defined(__riscv)
   jtmb.setRelocationModel(llvm::Reloc::PIC_);
-#endif
   if (conf.target_host_cpu()) {
     jtmb.setCPU(cpu_name.str());
     jtmb.addFeatures(cpu_attrs);


### PR DESCRIPTION
### Rationale for this change

On riscv64, Gandiva fails at runtime with:
```text
JIT session error: relocation target ... is out of range of R_RISCV_HI20 fixup ...
```

### What changes are included in this PR?

I set the PIC relocation model on the JIT TargetMachine manually to restore pre https://github.com/apache/arrow/pull/49063 behavior. LLJIT normally sets Reloc::PIC_ for JITLink targets in prepareForConstruction, but #49063 builds the object-cache TargetMachine before that runs, so it gets the target-default (Static) model.

### Are these changes tested?

Yes, by the existing Gandiva tests, on riscv64 hardware.

### Are there any user-facing changes?

No public API changes. Gandiva expression evaluation now works on riscv64.

* GitHub Issue: #50862