### PR TITLE
GH-50803: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_windows_build.sh

### DIFF
--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -19,22 +19,28 @@
 
 set -ex
 
-: ${ARROW_HOME:=$(pwd)}
+# SC2223: Quote the default assignment to prevent globbing
+: "${ARROW_HOME:=$(pwd)}"
 # Make sure it is absolute and exported
-export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
+# SC2155: Declare and assign separately to avoid masking return values
+ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
+export ARROW_HOME
 
 pacman --noconfirm -Syy
 
-RWINLIB_LIB_DIR="lib"
-: ${MINGW_ARCH:="mingw32 mingw64 ucrt64"}
+# SC2034: Removed unused variable RWINLIB_LIB_DIR
+# SC2223: Quote the default assignment to prevent globbing
+: "${MINGW_ARCH:="mingw32 mingw64 ucrt64"}"
 
 export MINGW_ARCH
 
-cp $ARROW_HOME/ci/scripts/PKGBUILD .
+# SC2086: Double quote to prevent globbing and word splitting
+cp "$ARROW_HOME/ci/scripts/PKGBUILD" .
 printenv
 makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --cleanbuild
 
-VERSION=$(grep Version $ARROW_HOME/r/DESCRIPTION | cut -d " " -f 2)
+# SC2086: Double quote to prevent globbing and word splitting
+VERSION=$(grep Version "$ARROW_HOME/r/DESCRIPTION" | cut -d " " -f 2)
 DST_DIR="r-libarrow-windows-x86_64-$VERSION"
 
 # Collect the build artifacts and make the shape of zip file that rwinlib expects
@@ -47,12 +53,16 @@ cd build
 MSYS_LIB_DIR="/c/rtools${RTOOLS_VERSION}"
 
 # Untar the builds we made
-ls *.xz | xargs -n 1 tar -xJf
-mkdir -p $DST_DIR
+# SC2011: Use find -print0 | xargs -0 to handle non-alphanumeric filenames
+# SC2035: Use ./* glob so names with dashes won't become options
+find . -maxdepth 1 -name "*.xz" -print0 | xargs -0 -n 1 tar -xJf
+# SC2086: Double quote to prevent globbing and word splitting
+mkdir -p "$DST_DIR"
 # Grab the headers from one, either one is fine
 # (if we're building twice to combine old and new toolchains, this may already exist)
-if [ ! -d $DST_DIR/include ]; then
-  mv $(echo $MINGW_ARCH | cut -d ' ' -f 1)/include $DST_DIR
+# SC2046: Quote command substitution; SC2086: double-quote variables
+if [ ! -d "$DST_DIR/include" ]; then
+  mv "$(echo "$MINGW_ARCH" | cut -d ' ' -f 1)/include" "$DST_DIR"
 fi
 
 # mingw64 -> x64
@@ -60,34 +70,34 @@ fi
 # ucrt64 -> x64-ucrt
 
 if [ -d mingw64/lib/ ]; then
-  ls $MSYS_LIB_DIR/mingw64/lib/
+  ls "$MSYS_LIB_DIR/mingw64/lib/"
   # Make the rest of the directory structure
-  mkdir -p $DST_DIR/lib/x64
+  mkdir -p "$DST_DIR/lib/x64"
   # Move the 64-bit versions of libarrow into the expected location
-  mv mingw64/lib/*.a $DST_DIR/lib/x64
+  mv mingw64/lib/*.a "$DST_DIR/lib/x64"
   # These are from https://dl.bintray.com/rtools/mingw{32,64}/
-  cp $MSYS_LIB_DIR/mingw64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/x64
+  cp "$MSYS_LIB_DIR"/mingw64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "$DST_DIR/lib/x64"
 fi
 
 # Same for the 32-bit versions
 if [ -d mingw32/lib/ ]; then
-  ls $MSYS_LIB_DIR/mingw32/lib/
-  mkdir -p $DST_DIR/lib/i386
-  mv mingw32/lib/*.a $DST_DIR/lib/i386
-  cp $MSYS_LIB_DIR/mingw32/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/i386
+  ls "$MSYS_LIB_DIR/mingw32/lib/"
+  mkdir -p "$DST_DIR/lib/i386"
+  mv mingw32/lib/*.a "$DST_DIR/lib/i386"
+  cp "$MSYS_LIB_DIR"/mingw32/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "$DST_DIR/lib/i386"
 fi
 
 # Do the same also for ucrt64
 if [ -d ucrt64/lib/ ]; then
-  ls $MSYS_LIB_DIR/ucrt64/lib/
-  mkdir -p $DST_DIR/lib/x64-ucrt
-  mv ucrt64/lib/*.a $DST_DIR/lib/x64-ucrt
-  cp $MSYS_LIB_DIR/ucrt64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/x64-ucrt
+  ls "$MSYS_LIB_DIR/ucrt64/lib/"
+  mkdir -p "$DST_DIR/lib/x64-ucrt"
+  mv ucrt64/lib/*.a "$DST_DIR/lib/x64-ucrt"
+  cp "$MSYS_LIB_DIR"/ucrt64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "$DST_DIR/lib/x64-ucrt"
 fi
 
 # Create build artifact
-zip -r ${DST_DIR}.zip $DST_DIR
+zip -r "${DST_DIR}.zip" "$DST_DIR"
 
 # Copy that to a file name/path that does not vary by version number so we
 # can easily find it in the R package tests on CI
-cp ${DST_DIR}.zip ../libarrow.zip
+cp "${DST_DIR}.zip" ../libarrow.zip


### PR DESCRIPTION
### Rationale for this change

This is a sub-issue of #44748.

Fix all errors reported by `shellcheck` in `ci/scripts/r_windows_build.sh`.

### What changes are included in this PR?

The following shellcheck error codes are addressed:

- **SC2223**: Quoted the default variable assignments (`: ${VAR:=...}` → `: "${VAR:=...}"`) to prevent unintended globbing on lines 22 and 29.
- **SC2155**: Split `export ARROW_HOME="$(cd ...)"` into two separate lines (declare, then export) to avoid masking the return value of the `cd` subshell.
- **SC2034**: Removed the unused variable `RWINLIB_LIB_DIR="lib"` which was declared but never referenced anywhere in the script.
- **SC2086**: Double-quoted all variable references used in path operations to prevent globbing and word splitting.
- **SC2011 + SC2035**: Replaced `ls *.xz | xargs -n 1 tar -xJf` with `find . -maxdepth 1 -name "*.xz" -print0 | xargs -0 -n 1 tar -xJf` to safely handle non-alphanumeric filenames and prevent glob arguments from being treated as flags.
- **SC2046**: Quoted the command substitution `$(echo "$MINGW_ARCH" | cut ...)` in the `mv` call to prevent word splitting on the result.

### Are these changes tested?

Verified by running `shellcheck v0.11.0` against the modified file locally. The tool now exits with code **0** (no warnings or errors).

No functional logic was changed — all modifications are quoting and idiom improvements only.

* GitHub Issue: #50803