### PR TITLE
GH-49524: [CI][Integration] Bump HDFS versions tested to use latest v2 and newest v3

### DIFF
--- a/.env
+++ b/.env
@@ -63,7 +63,7 @@ CUDA=11.7.1
 DASK=latest
 GCC=
 HDFS=3.5.0
-JDK=11
+JDK=17
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=18
 MAVEN=3.9.9

--- a/.env
+++ b/.env
@@ -62,7 +62,7 @@ CMAKE=3.26.0
 CUDA=11.7.1
 DASK=latest
 GCC=
-HDFS=3.2.1
+HDFS=3.4.3
 JDK=11
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=18

--- a/.env
+++ b/.env
@@ -62,7 +62,7 @@ CMAKE=3.26.0
 CUDA=11.7.1
 DASK=latest
 GCC=
-HDFS=3.4.3
+HDFS=3.5.0
 JDK=11
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=18

--- a/ci/docker/conda-python-hdfs.dockerfile
+++ b/ci/docker/conda-python-hdfs.dockerfile
@@ -21,7 +21,7 @@ ARG arch_short
 ARG python=3.11
 FROM --platform=linux/${arch} ${repo}:${arch_short}-conda-python-${python}
 
-ARG jdk=11
+ARG jdk=17
 ARG maven=3.9.9
 RUN mamba install -q -y \
         maven=${maven} \

--- a/ci/docker/conda-python-hdfs.dockerfile
+++ b/ci/docker/conda-python-hdfs.dockerfile
@@ -30,7 +30,7 @@ RUN mamba install -q -y \
     mamba clean --all --yes
 
 # installing libhdfs (JNI)
-ARG hdfs=3.2.1
+ARG hdfs=3.5.0
 ENV HADOOP_HOME=/opt/hadoop-${hdfs} \
     HADOOP_OPTS=-Djava.library.path=/opt/hadoop-${hdfs}/lib/native \
     PATH=$PATH:/opt/hadoop-${hdfs}/bin:/opt/hadoop-${hdfs}/sbin

--- a/ci/docker/conda-python-spark.dockerfile
+++ b/ci/docker/conda-python-spark.dockerfile
@@ -21,7 +21,7 @@ ARG arch_short
 ARG python=3.11
 FROM --platform=linux/${arch} ${repo}:${arch_short}-conda-python-${python}
 
-ARG jdk=11
+ARG jdk=17
 ARG maven=3.9.9
 
 ARG numpy=latest

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -771,7 +771,7 @@ tasks:
       image: conda-python-dask
 {% endfor %}
 
-{% for hdfs_version in ["2.10.2", "3.4.3"] %}
+{% for hdfs_version in ["2.10.2", "3.5.0"] %}
   test-conda-python-3.11-hdfs-{{ hdfs_version }}:
     ci: github
     template: docker-tests/github.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -771,7 +771,7 @@ tasks:
       image: conda-python-dask
 {% endfor %}
 
-{% for hdfs_version in ["2.9.2", "3.2.1"] %}
+{% for hdfs_version in ["2.10.2", "3.4.3"] %}
   test-conda-python-3.11-hdfs-{{ hdfs_version }}:
     ci: github
     template: docker-tests/github.linux.yml


### PR DESCRIPTION
### Rationale for this change

When the issue was originally opened, the [test-conda-python-3.10-hdfs-2.9.2](https://github.com/ursacomputing/crossbow/actions/runs/22944679479/job/66593987920) failed sporadically on a PR when upgrading some dependencies due to time out rebuilding the docker image.
A big chunk of time was spent on the job just downloading HDFS 2.9.2.

HDFS 2.9.2 was released on 2018. We test 2.9.2 and 3.2.1, released on 2019.

### What changes are included in this PR?

Bump to newer versions, latests are 3.5.0 (2026) and from the v2 series, 2.10.2 (2022).
Bump default JDK to 17. The only other place where we currently use the JDK version on env was for Spark where we already are manually using `JDK=17` on tasks.yml so no real change for any other job.

### Are these changes tested?

Yes via the archery jobs

### Are there any user-facing changes?

No

* GitHub Issue: #49524