### PR TITLE
GH-50803: [CI][Dev] Fix shellcheck errors in the ci/scripts/r_windows_build.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -346,6 +346,7 @@ repos:
           ?^ci/scripts/r_sanitize\.sh$|
           ?^ci/scripts/r_test\.sh$|
           ?^ci/scripts/r_valgrind\.sh$|
+          ?^ci/scripts/r_windows_build\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -19,22 +19,21 @@
 
 set -ex
 
-: ${ARROW_HOME:=$(pwd)}
+: "${ARROW_HOME:=$(pwd)}"
 # Make sure it is absolute and exported
-export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
+ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
+export ARROW_HOME
 
 pacman --noconfirm -Syy
 
-RWINLIB_LIB_DIR="lib"
-: ${MINGW_ARCH:="mingw32 mingw64 ucrt64"}
-
+: "${MINGW_ARCH:=mingw32 mingw64 ucrt64}"
 export MINGW_ARCH
 
-cp $ARROW_HOME/ci/scripts/PKGBUILD .
+cp "${ARROW_HOME}/ci/scripts/PKGBUILD" .
 printenv
 makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --cleanbuild
 
-VERSION=$(grep Version $ARROW_HOME/r/DESCRIPTION | cut -d " " -f 2)
+VERSION="$(grep Version "${ARROW_HOME}/r/DESCRIPTION" | cut -d " " -f 2)"
 DST_DIR="r-libarrow-windows-x86_64-$VERSION"
 
 # Collect the build artifacts and make the shape of zip file that rwinlib expects
@@ -47,12 +46,12 @@ cd build
 MSYS_LIB_DIR="/c/rtools${RTOOLS_VERSION}"
 
 # Untar the builds we made
-ls *.xz | xargs -n 1 tar -xJf
-mkdir -p $DST_DIR
+find . -maxdepth 1 -type f -name '*.xz' -print0 | xargs -0 -n1 tar -xJf
+mkdir -p "${DST_DIR}"
 # Grab the headers from one, either one is fine
 # (if we're building twice to combine old and new toolchains, this may already exist)
-if [ ! -d $DST_DIR/include ]; then
-  mv $(echo $MINGW_ARCH | cut -d ' ' -f 1)/include $DST_DIR
+if [ ! -d "${DST_DIR}/include" ]; then
+  mv "$(echo "${MINGW_ARCH}" | cut -d ' ' -f 1)/include" "${DST_DIR}"
 fi
 
 # mingw64 -> x64
@@ -60,34 +59,34 @@ fi
 # ucrt64 -> x64-ucrt
 
 if [ -d mingw64/lib/ ]; then
-  ls $MSYS_LIB_DIR/mingw64/lib/
+  ls "${MSYS_LIB_DIR}/mingw64/lib/"
   # Make the rest of the directory structure
-  mkdir -p $DST_DIR/lib/x64
+  mkdir -p "${DST_DIR}/lib/x64"
   # Move the 64-bit versions of libarrow into the expected location
-  mv mingw64/lib/*.a $DST_DIR/lib/x64
+  mv mingw64/lib/*.a "${DST_DIR}/lib/x64"
   # These are from https://dl.bintray.com/rtools/mingw{32,64}/
-  cp $MSYS_LIB_DIR/mingw64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/x64
+  cp "${MSYS_LIB_DIR}"/mingw64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "${DST_DIR}/lib/x64"
 fi
 
 # Same for the 32-bit versions
 if [ -d mingw32/lib/ ]; then
-  ls $MSYS_LIB_DIR/mingw32/lib/
-  mkdir -p $DST_DIR/lib/i386
-  mv mingw32/lib/*.a $DST_DIR/lib/i386
-  cp $MSYS_LIB_DIR/mingw32/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/i386
+  ls "${MSYS_LIB_DIR}/mingw32/lib/"
+  mkdir -p "${DST_DIR}/lib/i386"
+  mv mingw32/lib/*.a "${DST_DIR}/lib/i386"
+  cp "${MSYS_LIB_DIR}"/mingw32/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "${DST_DIR}/lib/i386"
 fi
 
 # Do the same also for ucrt64
 if [ -d ucrt64/lib/ ]; then
-  ls $MSYS_LIB_DIR/ucrt64/lib/
-  mkdir -p $DST_DIR/lib/x64-ucrt
-  mv ucrt64/lib/*.a $DST_DIR/lib/x64-ucrt
-  cp $MSYS_LIB_DIR/ucrt64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/x64-ucrt
+  ls "${MSYS_LIB_DIR}/ucrt64/lib/"
+  mkdir -p "${DST_DIR}/lib/x64-ucrt"
+  mv ucrt64/lib/*.a "${DST_DIR}/lib/x64-ucrt"
+  cp "${MSYS_LIB_DIR}"/ucrt64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "$DST_DIR"/lib/x64-ucrt
 fi
 
 # Create build artifact
-zip -r ${DST_DIR}.zip $DST_DIR
+zip -r "${DST_DIR}.zip" "$DST_DIR"
 
 # Copy that to a file name/path that does not vary by version number so we
 # can easily find it in the R package tests on CI
-cp ${DST_DIR}.zip ../libarrow.zip
+cp "${DST_DIR}.zip" ../libarrow.zip


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2011: Use find -print0 or find -exec to better handle non-alphanumeric filenames.
* SC2034: foo appears unused. Verify it or export it.
* SC2035: Use `./*glob*` or `-- *glob*` so names with dashes won't become options.
* SC2046: Quote this to prevent word splitting.
* SC2086: Double quote to prevent globbing and word splitting.
* SC2155: Declare and assign separately to avoid masking return values.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.


```
shellcheck ci/scripts/r_windows_build.sh

In ci/scripts/r_windows_build.sh line 22:
: ${ARROW_HOME:=$(pwd)}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_windows_build.sh line 24:
export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
       ^--------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ci/scripts/r_windows_build.sh line 28:
RWINLIB_LIB_DIR="lib"
^-------------^ SC2034 (warning): RWINLIB_LIB_DIR appears unused. Verify use (or export if used externally).


In ci/scripts/r_windows_build.sh line 29:
: ${MINGW_ARCH:="mingw32 mingw64 ucrt64"}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/r_windows_build.sh line 33:
cp $ARROW_HOME/ci/scripts/PKGBUILD .
   ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "$ARROW_HOME"/ci/scripts/PKGBUILD .


In ci/scripts/r_windows_build.sh line 37:
VERSION=$(grep Version $ARROW_HOME/r/DESCRIPTION | cut -d " " -f 2)
                       ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
VERSION=$(grep Version "$ARROW_HOME"/r/DESCRIPTION | cut -d " " -f 2)


In ci/scripts/r_windows_build.sh line 50:
ls *.xz | xargs -n 1 tar -xJf
^-- SC2011 (warning): Use 'find .. -print0 | xargs -0 ..' or 'find .. -exec .. +' to allow non-alphanumeric filenames.
   ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In ci/scripts/r_windows_build.sh line 51:
mkdir -p $DST_DIR
         ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "$DST_DIR"


In ci/scripts/r_windows_build.sh line 54:
if [ ! -d $DST_DIR/include ]; then
          ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ ! -d "$DST_DIR"/include ]; then


In ci/scripts/r_windows_build.sh line 55:
  mv $(echo $MINGW_ARCH | cut -d ' ' -f 1)/include $DST_DIR
     ^-- SC2046 (warning): Quote this to prevent word splitting.
            ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                   ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mv $(echo "$MINGW_ARCH" | cut -d ' ' -f 1)/include "$DST_DIR"


In ci/scripts/r_windows_build.sh line 63:
  ls $MSYS_LIB_DIR/mingw64/lib/
     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  ls "$MSYS_LIB_DIR"/mingw64/lib/


In ci/scripts/r_windows_build.sh line 65:
  mkdir -p $DST_DIR/lib/x64
           ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mkdir -p "$DST_DIR"/lib/x64


In ci/scripts/r_windows_build.sh line 67:
  mv mingw64/lib/*.a $DST_DIR/lib/x64
                     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mv mingw64/lib/*.a "$DST_DIR"/lib/x64


In ci/scripts/r_windows_build.sh line 69:
  cp $MSYS_LIB_DIR/mingw64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/x64
     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                                                       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp "$MSYS_LIB_DIR"/mingw64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "$DST_DIR"/lib/x64


In ci/scripts/r_windows_build.sh line 74:
  ls $MSYS_LIB_DIR/mingw32/lib/
     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  ls "$MSYS_LIB_DIR"/mingw32/lib/


In ci/scripts/r_windows_build.sh line 75:
  mkdir -p $DST_DIR/lib/i386
           ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mkdir -p "$DST_DIR"/lib/i386


In ci/scripts/r_windows_build.sh line 76:
  mv mingw32/lib/*.a $DST_DIR/lib/i386
                     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mv mingw32/lib/*.a "$DST_DIR"/lib/i386


In ci/scripts/r_windows_build.sh line 77:
  cp $MSYS_LIB_DIR/mingw32/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/i386
     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                                                       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp "$MSYS_LIB_DIR"/mingw32/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "$DST_DIR"/lib/i386


In ci/scripts/r_windows_build.sh line 82:
  ls $MSYS_LIB_DIR/ucrt64/lib/
     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  ls "$MSYS_LIB_DIR"/ucrt64/lib/


In ci/scripts/r_windows_build.sh line 83:
  mkdir -p $DST_DIR/lib/x64-ucrt
           ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mkdir -p "$DST_DIR"/lib/x64-ucrt


In ci/scripts/r_windows_build.sh line 84:
  mv ucrt64/lib/*.a $DST_DIR/lib/x64-ucrt
                    ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mv ucrt64/lib/*.a "$DST_DIR"/lib/x64-ucrt


In ci/scripts/r_windows_build.sh line 85:
  cp $MSYS_LIB_DIR/ucrt64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a $DST_DIR/lib/x64-ucrt
     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                                                      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp "$MSYS_LIB_DIR"/ucrt64/lib/lib{snappy,zstd,lz4,brotli*,bz2,crypto,curl,ss*,utf8proc,re2,nghttp2}.a "$DST_DIR"/lib/x64-ucrt


In ci/scripts/r_windows_build.sh line 89:
zip -r ${DST_DIR}.zip $DST_DIR
       ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
zip -r "${DST_DIR}".zip "$DST_DIR"


In ci/scripts/r_windows_build.sh line 93:
cp ${DST_DIR}.zip ../libarrow.zip
   ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "${DST_DIR}".zip ../libarrow.zip

For more information:
  https://www.shellcheck.net/wiki/SC2011 -- Use 'find .. -print0 | xargs -0 ....
  https://www.shellcheck.net/wiki/SC2034 -- RWINLIB_LIB_DIR appears unused. V...
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
```  


### What changes are included in this PR?

* SC2011: Replace `ls | xargs` with `find -print0`/`-exec` for safe filename handling.
* SC2034: Remove or export unused variables.
* SC2035: Prefix globs with `./` (or `--`) to avoid option misinterpretation.
* SC2046: Quote command substitutions to prevent word splitting.
* SC2086: Quote variable expansions to prevent globbing and word splitting.
* SC2155: Separate variable declaration from assignment.
* SC2223: Quote parameter expansion in default assignments to prevent globbing.


### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50803