### PR TITLE
GH-50822 [C++][Parquet] Make DELTA_BYTE_ARRAY value reconstruction storage-agnostic

### DIFF
--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -863,7 +863,7 @@ class PlainFLBADecoder : public PlainDecoder<FLBAType>, public FLBADecoder {
   int Decode(uint8_t* buffer, int max_values) override {
     max_values = std::min(max_values, this->num_values_);
     const int64_t bytes_to_decode = static_cast<int64_t>(this->type_length_) * max_values;
-    if (bytes_to_decode > this->len_ || bytes_to_decode > INT_MAX) {
+    if (bytes_to_decode > this->len_) {
       ParquetException::EofException();
     }
     if (bytes_to_decode > 0) {
@@ -1231,35 +1231,6 @@ int DictDecoderImpl<FLBAType>::DecodeArrow(
   return num_values - null_count;
 }
 
-// Dictionary decoder for FIXED_LEN_BYTE_ARRAY that can decode directly into a
-// caller-owned, densely packed byte buffer. DictDecoderImpl<FLBAType> on its own
-// does not inherit FLBADecoder, so this thin subclass adds the dense Decode
-// overload (mirroring the DeltaByteArray and ByteStreamSplit FLBA decoders).
-class DictFLBADecoder : public DictDecoderImpl<FLBAType>, public FLBADecoder {
- public:
-  using Base = DictDecoderImpl<FLBAType>;
-  using Base::Decode;  // keep Decode(FixedLenByteArray*, int)
-  using Base::DictDecoderImpl;
-
-  // Read one index per value and copy that dictionary entry's type_length bytes
-  // contiguously into the caller's buffer. Mirrors DecodeArrow without nulls.
-  int Decode(uint8_t* buffer, int max_values) override {
-    max_values = std::min(max_values, this->num_values_);
-    const auto* dict_values = this->dictionary_->data_as<FLBA>();
-    const int64_t type_length = this->type_length_;
-    for (int i = 0; i < max_values; ++i) {
-      int32_t index;
-      if (ARROW_PREDICT_FALSE(!this->idx_decoder_.Get(&index))) {
-        throw ParquetException("Dict decoding failed");
-      }
-      PARQUET_THROW_NOT_OK(this->IndexInBounds(index));
-      memcpy(buffer + i * type_length, dict_values[index].ptr,
-             static_cast<size_t>(type_length));
-    }
-    this->num_values_ -= max_values;
-    return max_values;
-  }
-};
 template <typename Type>
 int DictDecoderImpl<Type>::DecodeArrow(
     int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset,
@@ -1476,6 +1447,36 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType> {
     }
     *out_num_values = values_decoded;
     return Status::OK();
+  }
+};
+
+// Dictionary decoder for FIXED_LEN_BYTE_ARRAY that can decode directly into a
+// caller-owned, densely packed byte buffer. DictDecoderImpl<FLBAType> on its own
+// does not inherit FLBADecoder, so this thin subclass adds the dense Decode
+// overload (mirroring the DeltaByteArray and ByteStreamSplit FLBA decoders).
+class DictFLBADecoder : public DictDecoderImpl<FLBAType>, public FLBADecoder {
+ public:
+  using Base = DictDecoderImpl<FLBAType>;
+  using Base::Decode;  // keep Decode(FixedLenByteArray*, int)
+  using Base::DictDecoderImpl;
+
+  // Read one index per value and copy that dictionary entry's type_length bytes
+  // contiguously into the caller's buffer. Mirrors DecodeArrow without nulls.
+  int Decode(uint8_t* buffer, int max_values) override {
+    max_values = std::min(max_values, this->num_values_);
+    const auto* dict_values = this->dictionary_->data_as<FLBA>();
+    const int64_t type_length = this->type_length_;
+    for (int i = 0; i < max_values; ++i) {
+      int32_t index;
+      if (ARROW_PREDICT_FALSE(!this->idx_decoder_.Get(&index))) {
+        throw ParquetException("Dict decoding failed");
+      }
+      PARQUET_THROW_NOT_OK(this->IndexInBounds(index));
+      memcpy(buffer + i * type_length, dict_values[index].ptr,
+             static_cast<size_t>(type_length));
+    }
+    this->num_values_ -= max_values;
+    return max_values;
   }
 };
 
@@ -2444,13 +2445,6 @@ class ByteStreamSplitDecoder<FLBAType> : public ByteStreamSplitDecoderBase<FLBAT
 };
 
 }  // namespace
-
-// Default for the dense (densely packed) FLBA decode. Encodings override this;
-// the base throws so an unimplemented encoding fails with a clear message.
-int FLBADecoder::Decode(uint8_t* /*buffer*/, int /*max_values*/) {
-  throw ParquetException(
-      "Dense FIXED_LEN_BYTE_ARRAY decoding is not implemented for this encoding");
-}
 
 // ----------------------------------------------------------------------
 // Factory functions

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -854,16 +854,15 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType> {
 class PlainFLBADecoder : public PlainDecoder<FLBAType>, public FLBADecoder {
  public:
   using Base = PlainDecoder<FLBAType>;
-  using Base::PlainDecoder;
   using Base::Decode;  // keep Decode(FixedLenByteArray*, int)
+  using Base::PlainDecoder;
 
   // PLAIN-encoded FLBA values are already contiguous in the page buffer, so
   // decode them with a single memcpy into the caller's buffer. This is the same
   // copy used by PlainDecoder<FLBAType>::DecodeArrow, without the builder.
   int Decode(uint8_t* buffer, int max_values) override {
     max_values = std::min(max_values, this->num_values_);
-    const int64_t bytes_to_decode =
-        static_cast<int64_t>(this->type_length_) * max_values;
+    const int64_t bytes_to_decode = static_cast<int64_t>(this->type_length_) * max_values;
     if (bytes_to_decode > this->len_ || bytes_to_decode > INT_MAX) {
       ParquetException::EofException();
     }
@@ -1239,8 +1238,8 @@ int DictDecoderImpl<FLBAType>::DecodeArrow(
 class DictFLBADecoder : public DictDecoderImpl<FLBAType>, public FLBADecoder {
  public:
   using Base = DictDecoderImpl<FLBAType>;
-  using Base::DictDecoderImpl;
   using Base::Decode;  // keep Decode(FixedLenByteArray*, int)
+  using Base::DictDecoderImpl;
 
   // Read one index per value and copy that dictionary entry's type_length bytes
   // contiguously into the caller's buffer. Mirrors DecodeArrow without nulls.

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -855,6 +855,26 @@ class PlainFLBADecoder : public PlainDecoder<FLBAType>, public FLBADecoder {
  public:
   using Base = PlainDecoder<FLBAType>;
   using Base::PlainDecoder;
+  using Base::Decode;  // keep Decode(FixedLenByteArray*, int)
+
+  // PLAIN-encoded FLBA values are already contiguous in the page buffer, so
+  // decode them with a single memcpy into the caller's buffer. This is the same
+  // copy used by PlainDecoder<FLBAType>::DecodeArrow, without the builder.
+  int Decode(uint8_t* buffer, int max_values) override {
+    max_values = std::min(max_values, this->num_values_);
+    const int64_t bytes_to_decode =
+        static_cast<int64_t>(this->type_length_) * max_values;
+    if (bytes_to_decode > this->len_ || bytes_to_decode > INT_MAX) {
+      ParquetException::EofException();
+    }
+    if (bytes_to_decode > 0) {
+      memcpy(buffer, this->data_, static_cast<size_t>(bytes_to_decode));
+    }
+    this->data_ += bytes_to_decode;
+    this->len_ -= static_cast<int>(bytes_to_decode);
+    this->num_values_ -= max_values;
+    return max_values;
+  }
 };
 
 // ----------------------------------------------------------------------
@@ -1212,6 +1232,35 @@ int DictDecoderImpl<FLBAType>::DecodeArrow(
   return num_values - null_count;
 }
 
+// Dictionary decoder for FIXED_LEN_BYTE_ARRAY that can decode directly into a
+// caller-owned, densely packed byte buffer. DictDecoderImpl<FLBAType> on its own
+// does not inherit FLBADecoder, so this thin subclass adds the dense Decode
+// overload (mirroring the DeltaByteArray and ByteStreamSplit FLBA decoders).
+class DictFLBADecoder : public DictDecoderImpl<FLBAType>, public FLBADecoder {
+ public:
+  using Base = DictDecoderImpl<FLBAType>;
+  using Base::DictDecoderImpl;
+  using Base::Decode;  // keep Decode(FixedLenByteArray*, int)
+
+  // Read one index per value and copy that dictionary entry's type_length bytes
+  // contiguously into the caller's buffer. Mirrors DecodeArrow without nulls.
+  int Decode(uint8_t* buffer, int max_values) override {
+    max_values = std::min(max_values, this->num_values_);
+    const auto* dict_values = this->dictionary_->data_as<FLBA>();
+    const int64_t type_length = this->type_length_;
+    for (int i = 0; i < max_values; ++i) {
+      int32_t index;
+      if (ARROW_PREDICT_FALSE(!this->idx_decoder_.Get(&index))) {
+        throw ParquetException("Dict decoding failed");
+      }
+      PARQUET_THROW_NOT_OK(this->IndexInBounds(index));
+      memcpy(buffer + i * type_length, dict_values[index].ptr,
+             static_cast<size_t>(type_length));
+    }
+    this->num_values_ -= max_values;
+    return max_values;
+  }
+};
 template <typename Type>
 int DictDecoderImpl<Type>::DecodeArrow(
     int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset,
@@ -2232,6 +2281,23 @@ class DeltaByteArrayFLBADecoder : public DeltaByteArrayDecoderImpl<FLBAType>,
     }
     return decoded_values_size;
   }
+
+  // Same internal decode as above, but copy the bytes contiguously into the
+  // caller's buffer instead of materializing per-value pointers.
+  int Decode(uint8_t* buffer, int max_values) override {
+    std::vector<ByteArray> decode_byte_array(max_values);
+    const int decoded_values_size = GetInternal(decode_byte_array.data(), max_values);
+    const uint32_t type_length = static_cast<uint32_t>(this->type_length_);
+
+    for (int i = 0; i < decoded_values_size; i++) {
+      if (ARROW_PREDICT_FALSE(decode_byte_array[i].len != type_length)) {
+        throw ParquetException("Fixed length byte array length mismatch");
+      }
+      memcpy(buffer + static_cast<int64_t>(i) * type_length, decode_byte_array[i].ptr,
+             type_length);
+    }
+    return decoded_values_size;
+  }
 };
 
 // ----------------------------------------------------------------------
@@ -2370,9 +2436,22 @@ class ByteStreamSplitDecoder<FLBAType> : public ByteStreamSplitDecoderBase<FLBAT
     }
     return num_decoded;
   }
+
+  // DecodeRaw already unsplits the byte streams into a contiguous buffer, so
+  // decode straight into the caller's buffer with no intermediate scratch.
+  int Decode(uint8_t* buffer, int max_values) override {
+    return this->DecodeRaw(buffer, max_values);
+  }
 };
 
 }  // namespace
+
+// Default for the dense (densely packed) FLBA decode. Encodings override this;
+// the base throws so an unimplemented encoding fails with a clear message.
+int FLBADecoder::Decode(uint8_t* /*buffer*/, int /*max_values*/) {
+  throw ParquetException(
+      "Dense FIXED_LEN_BYTE_ARRAY decoding is not implemented for this encoding");
+}
 
 // ----------------------------------------------------------------------
 // Factory functions
@@ -2475,7 +2554,7 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
     case Type::BYTE_ARRAY:
       return std::make_unique<DictByteArrayDecoderImpl>(descr, pool);
     case Type::FIXED_LEN_BYTE_ARRAY:
-      return std::make_unique<DictDecoderImpl<FLBAType>>(descr, pool);
+      return std::make_unique<DictFLBADecoder>(descr, pool);
     default:
       break;
   }

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -1779,12 +1779,19 @@ class DeltaLengthByteArrayDecoder : public TypedDecoderImpl<ByteArrayType> {
     DecodeLengths();
   }
 
-  int Decode(ByteArray* buffer, int max_values) override {
-    // Decode up to `max_values` strings into an internal buffer
-    // and reference them into `buffer`.
+  // Advance over up to `max_values` values and expose them as a view: the
+  // per-value lengths, and a pointer to the start of their (contiguous) data.
+  // Returns the number of values available.
+  //
+  // The lengths are already fully decoded by `DecodeLengths`, and the values are
+  // stored contiguously in the page, so callers that only need the bytes can walk
+  // this view directly instead of materializing a `ByteArray` per value.
+  int GetBatchView(int max_values, const int32_t** lengths, const uint8_t** data) {
     max_values = std::min(max_values, num_valid_values_);
     DCHECK_GE(max_values, 0);
     if (max_values == 0) {
+      *lengths = nullptr;
+      *data = nullptr;
       return 0;
     }
 
@@ -1796,7 +1803,6 @@ class DeltaLengthByteArrayDecoder : public TypedDecoderImpl<ByteArrayType> {
       if (ARROW_PREDICT_FALSE(len < 0)) {
         throw ParquetException("negative string delta length");
       }
-      buffer[i].len = len;
       if (AddWithOverflow(data_size, len, &data_size)) {
         throw ParquetException("excess expansion in DELTA_(LENGTH_)BYTE_ARRAY");
       }
@@ -1805,13 +1811,24 @@ class DeltaLengthByteArrayDecoder : public TypedDecoderImpl<ByteArrayType> {
     if (ARROW_PREDICT_FALSE(!decoder_->Advance(8 * static_cast<int64_t>(data_size)))) {
       ParquetException::EofException();
     }
-    const uint8_t* data_ptr = data_ + bytes_offset;
+    *lengths = length_ptr;
+    *data = data_ + bytes_offset;
+    this->num_values_ -= max_values;
+    num_valid_values_ -= max_values;
+    return max_values;
+  }
+
+  int Decode(ByteArray* buffer, int max_values) override {
+    // Decode up to `max_values` strings into an internal buffer
+    // and reference them into `buffer`.
+    const int32_t* lengths = nullptr;
+    const uint8_t* data_ptr = nullptr;
+    max_values = GetBatchView(max_values, &lengths, &data_ptr);
     for (int i = 0; i < max_values; ++i) {
+      buffer[i].len = static_cast<uint32_t>(lengths[i]);
       buffer[i].ptr = data_ptr;
       data_ptr += buffer[i].len;
     }
-    this->num_values_ -= max_values;
-    num_valid_values_ -= max_values;
     return max_values;
   }
 
@@ -2032,7 +2049,8 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
         suffix_decoder_(nullptr, pool),
         last_value_in_previous_page_(""),
         buffered_prefix_length_(AllocateBuffer(pool, 0)),
-        buffered_data_(AllocateBuffer(pool, 0)) {}
+        buffered_data_(AllocateBuffer(pool, 0)),
+        buffered_suffix_(AllocateBuffer(pool, 0)) {}
 
   void SetData(int num_values, const uint8_t* data, int len) override {
     this->num_values_ = num_values;
@@ -2082,93 +2100,171 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
   }
 
  protected:
-  template <bool is_first_run>
-  static void BuildBufferInternal(const int32_t* prefix_len_ptr, int i, ByteArray* buffer,
-                                  std::string_view* prefix, uint8_t** data_ptr) {
-    if (ARROW_PREDICT_FALSE(static_cast<size_t>(prefix_len_ptr[i]) > prefix->length())) {
-      throw ParquetException("prefix length too large in DELTA_BYTE_ARRAY");
+  // Storage-agnostic reconstruction of DELTA_BYTE_ARRAY values.
+  //
+  // Each value is a `prefix` (a prefix of the previous value) followed by a
+  // `suffix` produced by `suffix_decoder_`. `GetInternalImpl` drives the shared
+  // decoding and delegates the actual materialization to an `Output` policy, so
+  // callers can either reference values as `ByteArray`s (backed by
+  // `buffered_data_`) or write fixed-length values contiguously into a
+  // caller-provided buffer without allocating per-value pointers.
+
+  // Output that reconstructs values into `ByteArray`s backed by `buffered_data_`,
+  // reproducing the original DELTA_BYTE_ARRAY behavior including the zero-copy
+  // optimizations for empty prefixes/suffixes.
+  struct ByteArrayOutput {
+    // `buffer` is used both as the suffix decode target and as the output.
+    ByteArray* buffer;
+    ResizableBuffer* buffered_data;
+    int type_length;
+    uint8_t* data_begin = nullptr;
+    uint8_t* data_ptr = nullptr;
+    int64_t data_size = 0;
+
+    int FetchSuffixes(DeltaLengthByteArrayDecoder* suffix_decoder, int max_values) {
+      // Decode the suffixes in place; `Emit` reads each one before overwriting it
+      // with the reconstructed value.
+      return suffix_decoder->Decode(buffer, max_values);
     }
-    // For now, `buffer` points to string suffixes, and the suffix decoder
-    // ensures that the suffix data has sufficient lifetime.
-    if (prefix_len_ptr[i] == 0) {
-      // prefix is empty: buffer[i] already points to the suffix.
-      *prefix = std::string_view{buffer[i]};
-      return;
+
+    void Prepare(const int32_t* prefix_len_ptr, int max_values) {
+      data_size = 0;
+      for (int i = 0; i < max_values; ++i) {
+        if (prefix_len_ptr[i] == 0) {
+          // We don't need to copy the suffix if the prefix length is 0.
+          continue;
+        }
+        if (ARROW_PREDICT_FALSE(prefix_len_ptr[i] < 0)) {
+          throw ParquetException("negative prefix length in DELTA_BYTE_ARRAY");
+        }
+        if (buffer[i].len == 0 && i != 0) {
+          // We don't need to copy the prefix if the suffix length is 0
+          // and this is not the first run (that is, the prefix doesn't point
+          // to the mutable `last_value_`).
+          continue;
+        }
+        if (ARROW_PREDICT_FALSE(
+                AddWithOverflow(data_size, prefix_len_ptr[i], &data_size) ||
+                AddWithOverflow(data_size, buffer[i].len, &data_size))) {
+          throw ParquetException("excess expansion in DELTA_BYTE_ARRAY");
+        }
+      }
+      PARQUET_THROW_NOT_OK(buffered_data->Resize(data_size));
+      data_begin = buffered_data->mutable_data();
+      data_ptr = data_begin;
     }
-    DCHECK_EQ(is_first_run, i == 0);
-    if constexpr (!is_first_run) {
-      if (buffer[i].len == 0) {
+
+    std::string_view Emit(int i, int32_t prefix_len, std::string_view prefix) {
+      // Read the suffix before `buffer[i]` is overwritten with the output.
+      const ByteArray suffix = buffer[i];
+      if (ARROW_PREDICT_FALSE(static_cast<size_t>(prefix_len) > prefix.length())) {
+        throw ParquetException("prefix length too large in DELTA_BYTE_ARRAY");
+      }
+      if (prefix_len == 0) {
+        // prefix is empty: buffer[i] already points to the suffix.
+        return std::string_view{buffer[i]};
+      }
+      if (i != 0 && suffix.len == 0) {
         // suffix is empty: buffer[i] can simply point to the prefix.
         // This is not possible for the first run since the prefix
         // would point to the mutable `last_value_`.
-        *prefix = prefix->substr(0, prefix_len_ptr[i]);
-        buffer[i] = ByteArray(*prefix);
-        return;
+        prefix = prefix.substr(0, prefix_len);
+        buffer[i] = ByteArray(prefix);
+        return prefix;
+      }
+      // Both prefix and suffix are non-empty, so decode the string into
+      // `data_ptr`.
+      memcpy(data_ptr, prefix.data(), prefix_len);
+      memcpy(data_ptr + prefix_len, suffix.ptr, suffix.len);
+      const uint32_t full_len = suffix.len + static_cast<uint32_t>(prefix_len);
+      buffer[i].ptr = data_ptr;
+      buffer[i].len = full_len;
+      data_ptr += full_len;
+      return std::string_view{buffer[i]};
+    }
+
+    void Finish(int max_values) {
+      DCHECK_EQ(data_ptr - data_begin, data_size);
+      if constexpr (std::is_same_v<DType, FLBAType>) {
+        // Checks all values
+        for (int i = 0; i < max_values; ++i) {
+          if (buffer[i].len != static_cast<uint32_t>(type_length)) {
+            throw ParquetException("FLBA type requires fixed-length ", type_length,
+                                   " but got ", buffer[i].len);
+          }
+        }
       }
     }
-    // Both prefix and suffix are non-empty, so we need to decode the string
-    // into `data_ptr`.
-    // 1. Copy the prefix
-    memcpy(*data_ptr, prefix->data(), prefix_len_ptr[i]);
-    // 2. Copy the suffix.
-    memcpy(*data_ptr + prefix_len_ptr[i], buffer[i].ptr, buffer[i].len);
-    // 3. Point buffer[i] to the decoded string.
-    buffer[i].ptr = *data_ptr;
-    buffer[i].len += prefix_len_ptr[i];
-    *data_ptr += buffer[i].len;
-    *prefix = std::string_view{buffer[i]};
-  }
+  };
 
-  int GetInternal(ByteArray* buffer, int max_values) {
-    // Decode up to `max_values` strings into an internal buffer
-    // and reference them into `buffer`.
+  // Output that writes fixed-length values contiguously into a caller-provided
+  // buffer. Used by the FLBA dense decode path; avoids `buffered_data_` and any
+  // temporary per-value `ByteArray` storage.
+  struct DenseOutput {
+    uint8_t* out;
+    int type_length;
+    // View of the suffixes still to be consumed: their lengths, and a cursor into
+    // their contiguous data. No per-value pointer is ever materialized.
+    const int32_t* suffix_lengths = nullptr;
+    const uint8_t* suffix_data = nullptr;
+
+    int FetchSuffixes(DeltaLengthByteArrayDecoder* suffix_decoder, int max_values) {
+      return suffix_decoder->GetBatchView(max_values, &suffix_lengths, &suffix_data);
+    }
+
+    void Prepare(const int32_t* prefix_len_ptr, int max_values) {}
+
+    std::string_view Emit(int i, int32_t prefix_len, std::string_view prefix) {
+      const int32_t suffix_len = suffix_lengths[i];
+      const uint8_t* suffix_ptr = suffix_data;
+      suffix_data += suffix_len;
+
+      if (ARROW_PREDICT_FALSE(static_cast<size_t>(prefix_len) > prefix.length())) {
+        throw ParquetException("prefix length too large in DELTA_BYTE_ARRAY");
+      }
+      // Each reconstructed FLBA value must be exactly `type_length` bytes.
+      if (ARROW_PREDICT_FALSE(static_cast<int64_t>(prefix_len) + suffix_len !=
+                              type_length)) {
+        throw ParquetException("Fixed length byte array length mismatch");
+      }
+      // Copy the prefix and the suffix straight into the caller's buffer.
+      uint8_t* dst = out + static_cast<int64_t>(i) * type_length;
+      memcpy(dst, prefix.data(), prefix_len);
+      memcpy(dst + prefix_len, suffix_ptr, suffix_len);
+      // The next value's prefix references this value, which now lives in the
+      // caller's buffer.
+      return std::string_view{reinterpret_cast<const char*>(dst),
+                              static_cast<size_t>(type_length)};
+    }
+
+    void Finish(int max_values) {}
+  };
+
+  template <typename Output>
+  int GetInternalImpl(Output&& output, int max_values) {
+    // Decode up to `max_values` values, delegating materialization to `output`.
     max_values = std::min(max_values, num_valid_values_);
     if (max_values == 0) {
       return max_values;
     }
 
-    int suffix_read = suffix_decoder_.Decode(buffer, max_values);
+    const int suffix_read = output.FetchSuffixes(&suffix_decoder_, max_values);
     if (ARROW_PREDICT_FALSE(suffix_read != max_values)) {
       ParquetException::EofException("Read " + std::to_string(suffix_read) +
                                      ", expecting " + std::to_string(max_values) +
                                      " from suffix decoder");
     }
 
-    int64_t data_size = 0;
     const int32_t* prefix_len_ptr =
         buffered_prefix_length_->data_as<int32_t>() + prefix_len_offset_;
-    for (int i = 0; i < max_values; ++i) {
-      if (prefix_len_ptr[i] == 0) {
-        // We don't need to copy the suffix if the prefix length is 0.
-        continue;
-      }
-      if (ARROW_PREDICT_FALSE(prefix_len_ptr[i] < 0)) {
-        throw ParquetException("negative prefix length in DELTA_BYTE_ARRAY");
-      }
-      if (buffer[i].len == 0 && i != 0) {
-        // We don't need to copy the prefix if the suffix length is 0
-        // and this is not the first run (that is, the prefix doesn't point
-        // to the mutable `last_value_`).
-        continue;
-      }
-      if (ARROW_PREDICT_FALSE(AddWithOverflow(data_size, prefix_len_ptr[i], &data_size) ||
-                              AddWithOverflow(data_size, buffer[i].len, &data_size))) {
-        throw ParquetException("excess expansion in DELTA_BYTE_ARRAY");
-      }
-    }
-    PARQUET_THROW_NOT_OK(buffered_data_->Resize(data_size));
+
+    output.Prepare(prefix_len_ptr, max_values);
 
     std::string_view prefix{last_value_};
-    uint8_t* data_ptr = buffered_data_->mutable_data();
-    if (max_values > 0) {
-      BuildBufferInternal</*is_first_run=*/true>(prefix_len_ptr, 0, buffer, &prefix,
-                                                 &data_ptr);
+    for (int i = 0; i < max_values; ++i) {
+      prefix = output.Emit(i, prefix_len_ptr[i], prefix);
     }
-    for (int i = 1; i < max_values; ++i) {
-      BuildBufferInternal</*is_first_run=*/false>(prefix_len_ptr, i, buffer, &prefix,
-                                                  &data_ptr);
-    }
-    DCHECK_EQ(data_ptr - buffered_data_->mutable_data(), data_size);
+
     prefix_len_offset_ += max_values;
     this->num_values_ -= max_values;
     num_valid_values_ -= max_values;
@@ -2178,17 +2274,28 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
       last_value_in_previous_page_ = last_value_;
     }
 
-    if constexpr (std::is_same_v<DType, FLBAType>) {
-      // Checks all values
-      for (int i = 0; i < max_values; i++) {
-        if (buffer[i].len != static_cast<uint32_t>(this->type_length_)) {
-          throw ParquetException("FLBA type requires fixed-length ", this->type_length_,
-                                 " but got ", buffer[i].len);
-        }
-      }
-    }
-
+    output.Finish(max_values);
     return max_values;
+  }
+
+  // Resize the ByteArray scratch buffer and return its data. Used to decode
+  // suffixes and to expose reconstructed value pointers without a per-call
+  // heap allocation.
+  ByteArray* ResizeSuffixScratch(int max_values) {
+    PARQUET_THROW_NOT_OK(buffered_suffix_->Resize(sizeof(ByteArray) * max_values));
+    return buffered_suffix_->mutable_data_as<ByteArray>();
+  }
+
+  int GetInternal(ByteArray* buffer, int max_values) {
+    ByteArrayOutput output{buffer, buffered_data_.get(), this->type_length_};
+    return GetInternalImpl(output, max_values);
+  }
+
+  // Decode fixed-length values contiguously into `out` without materializing
+  // per-value pointers. Only meaningful for `FLBAType`.
+  int DecodeDense(uint8_t* out, int max_values) {
+    DenseOutput output{out, this->type_length_};
+    return GetInternalImpl(output, max_values);
   }
 
   Status DecodeArrowDense(int num_values, int null_count, const uint8_t* valid_bits,
@@ -2248,6 +2355,9 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
   // buffer for decoded strings, which guarantees the lifetime of the decoded strings
   // until the next call of Decode.
   std::shared_ptr<ResizableBuffer> buffered_data_;
+  // Scratch buffer of ByteArray used to decode suffixes / expose value pointers
+  // without a per-call heap allocation.
+  std::shared_ptr<ResizableBuffer> buffered_suffix_;
 };
 
 class DeltaByteArrayDecoder : public DeltaByteArrayDecoderImpl<ByteArrayType> {
@@ -2268,35 +2378,21 @@ class DeltaByteArrayFLBADecoder : public DeltaByteArrayDecoderImpl<FLBAType>,
   using Base::pool_;
 
   int Decode(FixedLenByteArray* buffer, int max_values) override {
-    // GetInternal currently only support ByteArray.
-    std::vector<ByteArray> decode_byte_array(max_values);
-    const int decoded_values_size = GetInternal(decode_byte_array.data(), max_values);
-    const uint32_t type_length = static_cast<uint32_t>(this->type_length_);
-
-    for (int i = 0; i < decoded_values_size; i++) {
-      if (ARROW_PREDICT_FALSE(decode_byte_array[i].len != type_length)) {
-        throw ParquetException("Fixed length byte array length mismatch");
-      }
-      buffer[i].ptr = decode_byte_array[i].ptr;
+    // Reconstruct values as ByteArrays backed by `buffered_data_`, then expose
+    // their pointers; the fixed length is implied by the column descriptor and
+    // validated by `GetInternal`.
+    ByteArray* values = this->ResizeSuffixScratch(max_values);
+    const int decoded_values_size = this->GetInternal(values, max_values);
+    for (int i = 0; i < decoded_values_size; ++i) {
+      buffer[i].ptr = values[i].ptr;
     }
     return decoded_values_size;
   }
 
-  // Same internal decode as above, but copy the bytes contiguously into the
-  // caller's buffer instead of materializing per-value pointers.
+  // Decode the bytes contiguously into the caller's buffer without
+  // materializing per-value pointers.
   int Decode(uint8_t* buffer, int max_values) override {
-    std::vector<ByteArray> decode_byte_array(max_values);
-    const int decoded_values_size = GetInternal(decode_byte_array.data(), max_values);
-    const uint32_t type_length = static_cast<uint32_t>(this->type_length_);
-
-    for (int i = 0; i < decoded_values_size; i++) {
-      if (ARROW_PREDICT_FALSE(decode_byte_array[i].len != type_length)) {
-        throw ParquetException("Fixed length byte array length mismatch");
-      }
-      memcpy(buffer + static_cast<int64_t>(i) * type_length, decode_byte_array[i].ptr,
-             type_length);
-    }
-    return decoded_values_size;
+    return this->DecodeDense(buffer, max_values);
   }
 };
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -410,12 +410,23 @@ class BooleanDecoder : virtual public TypedDecoder<BooleanType> {
 
 class FLBADecoder : virtual public TypedDecoder<FLBAType> {
  public:
+  using TypedDecoder<FLBAType>::Decode;
   using TypedDecoder<FLBAType>::DecodeSpaced;
 
-  // TODO(wesm): As possible follow-up to PARQUET-1508, we should examine if
-  // there is value in adding specialized read methods for
-  // FIXED_LEN_BYTE_ARRAY. If only Decimal data can occur with this data type
-  // then perhaps not
+  /// \brief Decode values into a densely packed buffer
+  ///
+  /// Unlike Decode(FixedLenByteArray*, int), which writes one pointer per
+  /// value, this writes the raw fixed-width values back to back, with no
+  /// per-value pointers and no gaps.
+  ///
+  /// \param[in] buffer destination for decoded values; caller owns it and
+  /// must size it to at least max_values * descr->type_length() bytes.
+  /// \param[in] max_values max values to decode.
+  /// \return The number of values decoded. Should be identical to max_values
+  /// except at the end of the current data page.
+  ///
+  /// \note API EXPERIMENTAL
+  virtual int Decode(uint8_t* buffer, int max_values);  
 };
 
 PARQUET_EXPORT

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -426,7 +426,7 @@ class FLBADecoder : virtual public TypedDecoder<FLBAType> {
   /// except at the end of the current data page.
   ///
   /// \note API EXPERIMENTAL
-  virtual int Decode(uint8_t* buffer, int max_values);
+  virtual int Decode(uint8_t* buffer, int max_values) = 0;
 };
 
 PARQUET_EXPORT

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -426,7 +426,7 @@ class FLBADecoder : virtual public TypedDecoder<FLBAType> {
   /// except at the end of the current data page.
   ///
   /// \note API EXPERIMENTAL
-  virtual int Decode(uint8_t* buffer, int max_values);  
+  virtual int Decode(uint8_t* buffer, int max_values);
 };
 
 PARQUET_EXPORT

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2660,4 +2660,98 @@ TEST(DeltaByteArrayEncodingAdHoc, ArrowDirectPut) {
   }
 }
 
+// ----------------------------------------------------------------------
+// Dense FIXED_LEN_BYTE_ARRAY decode tests
+//
+// FLBADecoder::Decode(uint8_t*, int) writes decoded values back to back into a
+// densely packed buffer, with no per-value FixedLenByteArray pointers. Verify
+// it for every encoding that overrides it: PLAIN, RLE_DICTIONARY,
+// DELTA_BYTE_ARRAY and BYTE_STREAM_SPLIT.
+
+class TestFLBADenseDecode : public ::testing::Test {
+ public:
+  void SetUp() override {
+    descr_ = ExampleDescr<FLBAType>();
+    type_length_ = descr_->type_length();
+    draws_.resize(kNumValues);
+    GenerateData<FLBA>(kNumValues, draws_.data(), &data_buffer_);
+  }
+
+  // Decode densely and compare each value against the original draw.
+  void CheckDenseDecode(FLBADecoder* decoder) {
+    ASSERT_NE(nullptr, decoder);
+    std::vector<uint8_t> dense(static_cast<size_t>(type_length_) * kNumValues);
+    int values_decoded = decoder->Decode(dense.data(), kNumValues);
+    ASSERT_EQ(kNumValues, values_decoded);
+    for (int i = 0; i < kNumValues; ++i) {
+      ASSERT_EQ(0, memcmp(dense.data() + static_cast<int64_t>(i) * type_length_,
+                          draws_[i].ptr, type_length_))
+          << "mismatch at value " << i;
+    }
+  }
+
+ protected:
+  static constexpr int kNumValues = 1000;
+  int type_length_;
+  std::vector<FLBA> draws_;
+  std::vector<uint8_t> data_buffer_;
+  std::shared_ptr<ColumnDescriptor> descr_;
+};
+
+TEST_F(TestFLBADenseDecode, Plain) {
+  auto encoder =
+      MakeTypedEncoder<FLBAType>(Encoding::PLAIN, /*use_dictionary=*/false, descr_.get());
+  encoder->Put(draws_.data(), kNumValues);
+  auto buffer = encoder->FlushValues();
+
+  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::PLAIN, descr_.get());
+  decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
+  ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+}
+
+TEST_F(TestFLBADenseDecode, Dictionary) {
+  auto base_encoder = MakeEncoder(::parquet::Type::FIXED_LEN_BYTE_ARRAY, Encoding::PLAIN,
+                                  /*use_dictionary=*/true, descr_.get());
+  auto encoder = dynamic_cast<TypedEncoder<FLBAType>*>(base_encoder.get());
+  auto dict_traits = dynamic_cast<DictEncoder<FLBAType>*>(base_encoder.get());
+
+  encoder->Put(draws_.data(), kNumValues);
+  auto dict_buffer =
+      AllocateBuffer(default_memory_pool(), dict_traits->dict_encoded_size());
+  dict_traits->WriteDict(dict_buffer->mutable_data());
+  auto indices = encoder->FlushValues();
+
+  auto dict_decoder = MakeTypedDecoder<FLBAType>(Encoding::PLAIN, descr_.get());
+  dict_decoder->SetData(dict_traits->num_entries(), dict_buffer->data(),
+                        static_cast<int>(dict_buffer->size()));
+
+  auto decoder = MakeDictDecoder<FLBAType>(descr_.get());
+  decoder->SetDict(dict_decoder.get());
+  decoder->SetData(kNumValues, indices->data(), static_cast<int>(indices->size()));
+  // dict_decoder must outlive the decode: the decoded bytes are owned by it.
+  ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+}
+
+TEST_F(TestFLBADenseDecode, DeltaByteArray) {
+  auto encoder = MakeTypedEncoder<FLBAType>(Encoding::DELTA_BYTE_ARRAY,
+                                            /*use_dictionary=*/false, descr_.get());
+  encoder->Put(draws_.data(), kNumValues);
+  auto buffer = encoder->FlushValues();
+
+  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::DELTA_BYTE_ARRAY, descr_.get());
+  decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
+  ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+}
+
+TEST_F(TestFLBADenseDecode, ByteStreamSplit) {
+  auto encoder = MakeTypedEncoder<FLBAType>(Encoding::BYTE_STREAM_SPLIT,
+                                            /*use_dictionary=*/false, descr_.get());
+  encoder->Put(draws_.data(), kNumValues);
+  auto buffer = encoder->FlushValues();
+
+  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::BYTE_STREAM_SPLIT, descr_.get());
+  decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
+  ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+}
+
 }  // namespace parquet::test

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2678,16 +2678,33 @@ class TestFLBADenseDecode : public ::testing::Test {
   }
 
   // Decode densely and compare each value against the original draw.
-  void CheckDenseDecode(FLBADecoder* decoder) {
+  void CheckDenseDecode(FLBADecoder* decoder, const std::vector<int>& decode_sizes) {
     ASSERT_NE(nullptr, decoder);
     std::vector<uint8_t> dense(static_cast<size_t>(type_length_) * kNumValues);
-    int values_decoded = decoder->Decode(dense.data(), kNumValues);
+
+    int values_decoded = 0;
+    for (int decode_size : decode_sizes) {
+      const int expected_decoded = std::min(decode_size, kNumValues - values_decoded);
+      ASSERT_EQ(expected_decoded,
+                decoder->Decode(
+                    dense.data() + static_cast<int64_t>(values_decoded) * type_length_,
+                    decode_size));
+      values_decoded += expected_decoded;
+      ASSERT_EQ(kNumValues - values_decoded, decoder->values_left());
+    }
     ASSERT_EQ(kNumValues, values_decoded);
+    ASSERT_EQ(0, decoder->Decode(dense.data(), /*max_values=*/1));
+    ASSERT_EQ(0, decoder->values_left());
+
     for (int i = 0; i < kNumValues; ++i) {
       ASSERT_EQ(0, memcmp(dense.data() + static_cast<int64_t>(i) * type_length_,
                           draws_[i].ptr, type_length_))
           << "mismatch at value " << i;
     }
+  }
+
+  void CheckDenseDecode(FLBADecoder* decoder) {
+    CheckDenseDecode(decoder, {1, 17, kNumValues / 2, kNumValues});
   }
 
  protected:
@@ -2752,6 +2769,51 @@ TEST_F(TestFLBADenseDecode, ByteStreamSplit) {
   auto decoder = MakeTypedDecoder<FLBAType>(Encoding::BYTE_STREAM_SPLIT, descr_.get());
   decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
   ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+}
+
+TEST_F(TestFLBADenseDecode, PlainRejectsTruncatedDenseBuffer) {
+  auto encoder =
+      MakeTypedEncoder<FLBAType>(Encoding::PLAIN, /*use_dictionary=*/false, descr_.get());
+  encoder->Put(draws_.data(), kNumValues);
+  auto buffer = encoder->FlushValues();
+
+  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::PLAIN, descr_.get());
+  decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size() - 1));
+
+  std::vector<uint8_t> dense(static_cast<size_t>(type_length_) * kNumValues);
+  ASSERT_THROW(decoder->Decode(dense.data(), kNumValues), ParquetException);
+}
+
+TEST_F(TestFLBADenseDecode, DictionaryRejectsOutOfBoundsDenseIndex) {
+  auto dict_decoder = MakeTypedDecoder<FLBAType>(Encoding::PLAIN, descr_.get());
+  dict_decoder->SetData(/*num_values=*/1, draws_[0].ptr, type_length_);
+
+  auto decoder = MakeDictDecoder<FLBAType>(descr_.get());
+  decoder->SetDict(dict_decoder.get());
+
+  // RLE_DICTIONARY data: bit width 1, followed by an RLE run of one index value
+  // 1. The dictionary has only one entry, so the index is out of bounds.
+  const std::vector<uint8_t> indices = {1, 2, 1};
+  decoder->SetData(/*num_values=*/1, indices.data(), static_cast<int>(indices.size()));
+
+  auto flba_decoder = dynamic_cast<FLBADecoder*>(decoder.get());
+  ASSERT_NE(nullptr, flba_decoder);
+  std::vector<uint8_t> dense(static_cast<size_t>(type_length_));
+  ASSERT_THROW(flba_decoder->Decode(dense.data(), /*max_values=*/1), ParquetException);
+}
+
+TEST_F(TestFLBADenseDecode, DeltaByteArrayRejectsWrongFLBALengthDense) {
+  std::string suffix(static_cast<size_t>(type_length_ - 1), 'x');
+  auto buffer =
+      ::arrow::ConcatenateBuffers({DeltaEncode({0}), DeltaEncode({type_length_ - 1}),
+                                   std::make_shared<Buffer>(suffix)})
+          .ValueOrDie();
+
+  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::DELTA_BYTE_ARRAY, descr_.get());
+  decoder->SetData(/*num_values=*/1, buffer->data(), static_cast<int>(buffer->size()));
+
+  std::vector<uint8_t> dense(static_cast<size_t>(type_length_));
+  ASSERT_THROW(decoder->Decode(dense.data(), /*max_values=*/1), ParquetException);
 }
 
 }  // namespace parquet::test

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2715,15 +2715,23 @@ class TestFLBADenseDecode : public ::testing::Test {
   std::shared_ptr<ColumnDescriptor> descr_;
 };
 
-TEST_F(TestFLBADenseDecode, Plain) {
-  auto encoder =
-      MakeTypedEncoder<FLBAType>(Encoding::PLAIN, /*use_dictionary=*/false, descr_.get());
-  encoder->Put(draws_.data(), kNumValues);
-  auto buffer = encoder->FlushValues();
+// These encodings are all built the same way, so exercise them with a single
+// body. RLE_DICTIONARY needs a dictionary and is tested separately below.
+TEST_F(TestFLBADenseDecode, NonDictionaryEncodings) {
+  for (auto encoding : {Encoding::PLAIN, Encoding::DELTA_BYTE_ARRAY,
+                        Encoding::BYTE_STREAM_SPLIT}) {
+    SCOPED_TRACE(EncodingToString(encoding));
 
-  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::PLAIN, descr_.get());
-  decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
-  ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+    auto encoder =
+        MakeTypedEncoder<FLBAType>(encoding, /*use_dictionary=*/false, descr_.get());
+    encoder->Put(draws_.data(), kNumValues);
+    auto buffer = encoder->FlushValues();
+
+    auto decoder = MakeTypedDecoder<FLBAType>(encoding, descr_.get());
+    decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
+    // EXPECT rather than ASSERT so one failing encoding doesn't hide the others.
+    EXPECT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+  }
 }
 
 TEST_F(TestFLBADenseDecode, Dictionary) {
@@ -2746,28 +2754,6 @@ TEST_F(TestFLBADenseDecode, Dictionary) {
   decoder->SetDict(dict_decoder.get());
   decoder->SetData(kNumValues, indices->data(), static_cast<int>(indices->size()));
   // dict_decoder must outlive the decode: the decoded bytes are owned by it.
-  ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
-}
-
-TEST_F(TestFLBADenseDecode, DeltaByteArray) {
-  auto encoder = MakeTypedEncoder<FLBAType>(Encoding::DELTA_BYTE_ARRAY,
-                                            /*use_dictionary=*/false, descr_.get());
-  encoder->Put(draws_.data(), kNumValues);
-  auto buffer = encoder->FlushValues();
-
-  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::DELTA_BYTE_ARRAY, descr_.get());
-  decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
-  ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
-}
-
-TEST_F(TestFLBADenseDecode, ByteStreamSplit) {
-  auto encoder = MakeTypedEncoder<FLBAType>(Encoding::BYTE_STREAM_SPLIT,
-                                            /*use_dictionary=*/false, descr_.get());
-  encoder->Put(draws_.data(), kNumValues);
-  auto buffer = encoder->FlushValues();
-
-  auto decoder = MakeTypedDecoder<FLBAType>(Encoding::BYTE_STREAM_SPLIT, descr_.get());
-  decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
   ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
 }
 

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2718,8 +2718,8 @@ class TestFLBADenseDecode : public ::testing::Test {
 // These encodings are all built the same way, so exercise them with a single
 // body. RLE_DICTIONARY needs a dictionary and is tested separately below.
 TEST_F(TestFLBADenseDecode, NonDictionaryEncodings) {
-  for (auto encoding : {Encoding::PLAIN, Encoding::DELTA_BYTE_ARRAY,
-                        Encoding::BYTE_STREAM_SPLIT}) {
+  for (auto encoding :
+       {Encoding::PLAIN, Encoding::DELTA_BYTE_ARRAY, Encoding::BYTE_STREAM_SPLIT}) {
     SCOPED_TRACE(EncodingToString(encoding));
 
     auto encoder =
@@ -2755,6 +2755,27 @@ TEST_F(TestFLBADenseDecode, Dictionary) {
   decoder->SetData(kNumValues, indices->data(), static_cast<int>(indices->size()));
   // dict_decoder must outlive the decode: the decoded bytes are owned by it.
   ASSERT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+}
+
+// DELTA_BYTE_ARRAY stores each value as a prefix shared with its predecessor plus
+// a suffix, so the dense decode path has to reconstruct the two halves. The
+// random draws used above hardly ever share a prefix, which leaves that
+// reconstruction untested; use prefixed data here instead.
+TEST_F(TestFLBADenseDecode, DeltaByteArrayPrefixedData) {
+  for (double prefixed_probability : {0.5, 1.0}) {
+    SCOPED_TRACE("prefixed_probability=" + std::to_string(prefixed_probability));
+    GeneratePrefixedData<FLBA>(kNumValues, draws_.data(), &data_buffer_,
+                               prefixed_probability);
+
+    auto encoder = MakeTypedEncoder<FLBAType>(Encoding::DELTA_BYTE_ARRAY,
+                                              /*use_dictionary=*/false, descr_.get());
+    encoder->Put(draws_.data(), kNumValues);
+    auto buffer = encoder->FlushValues();
+
+    auto decoder = MakeTypedDecoder<FLBAType>(Encoding::DELTA_BYTE_ARRAY, descr_.get());
+    decoder->SetData(kNumValues, buffer->data(), static_cast<int>(buffer->size()));
+    EXPECT_NO_FATAL_FAILURE(CheckDenseDecode(dynamic_cast<FLBADecoder*>(decoder.get())));
+  }
 }
 
 TEST_F(TestFLBADenseDecode, PlainRejectsTruncatedDenseBuffer) {


### PR DESCRIPTION
### Rationale for this change
Follow-up to #50335. 

> `DeltaByteArrayFLBADecoder::Decode(uint8_t*, int)` decodes into a
temporary `std::vector<ByteArray>` and then copies the bytes into the caller's buffer,
because `DeltaByteArrayDecoderImpl::GetInternal` only supports `ByteArray` output. The
vector is a per-call allocation, and the pointer it holds for every value is discarded
immediately after the copy.

### What changes are included in this PR?
Adds two output policy structs, `ByteArrayOutput` and `DenseOutput` for DeltaByteArrayFLBADecoder:
  - `ByteArrayOutput` reproduces the previous behavior: it decodes values into a `ByteArray*` buffer
  - `DenseOutput` writes each reconstructed fixed-length value directly into a caller-provided `uint8_t*` buffer
  
Adds benchmarks to test the `DeltaByteArrayFLBADecoder` performance.


- Before the change
```
Running /workspace/arrow/cpp/build/release/parquet-encoding-benchmark
Run on (20 X 2112 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 25600 KiB (x1)
Load Average: 2.22, 3.84, 3.64
---------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------------------------------------
BM_DeltaDecodingFLBA/type-length:2/batch-size:512/prefixed-percent:10              3217 ns         3215 ns       221856 bytes_per_second=303.706Mi/s compression_ratio=0.760208 items_per_second=159.229M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:512/prefixed-percent:90              3923 ns         3921 ns       185631 bytes_per_second=249.056Mi/s compression_ratio=1.38753 items_per_second=130.577M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:512/prefixed-percent:99              3929 ns         3927 ns       182369 bytes_per_second=248.649Mi/s compression_ratio=1.79649 items_per_second=130.363M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:2048/prefixed-percent:10            11335 ns        11329 ns        62995 bytes_per_second=344.803Mi/s compression_ratio=0.76148 items_per_second=180.776M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:2048/prefixed-percent:90            15514 ns        15506 ns        43892 bytes_per_second=251.918Mi/s compression_ratio=1.40466 items_per_second=132.078M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:2048/prefixed-percent:99            16525 ns        16517 ns        42482 bytes_per_second=236.502Mi/s compression_ratio=1.7747 items_per_second=123.995M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:512/prefixed-percent:10             2796 ns         2794 ns       249283 bytes_per_second=2.73034Gi/s compression_ratio=0.966836 items_per_second=183.23M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:512/prefixed-percent:90             4512 ns         4510 ns       151783 bytes_per_second=1.69171Gi/s compression_ratio=1.70489 items_per_second=113.529M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:512/prefixed-percent:99             4729 ns         4727 ns       139167 bytes_per_second=1.61411Gi/s compression_ratio=1.78203 items_per_second=108.321M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:2048/prefixed-percent:10           11151 ns        11144 ns        62274 bytes_per_second=2.73856Gi/s compression_ratio=0.966836 items_per_second=183.781M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:2048/prefixed-percent:90           17927 ns        17918 ns        39408 bytes_per_second=1.70318Gi/s compression_ratio=1.6732 items_per_second=114.298M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:2048/prefixed-percent:99           19689 ns        19678 ns        34933 bytes_per_second=1.55083Gi/s compression_ratio=1.79168 items_per_second=104.075M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:512/prefixed-percent:10         3309 ns         3308 ns       211062 bytes_per_second=295.22Mi/s compression_ratio=0.760208 items_per_second=154.78M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:512/prefixed-percent:90         4273 ns         4271 ns       162512 bytes_per_second=228.642Mi/s compression_ratio=1.38753 items_per_second=119.874M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:512/prefixed-percent:99         4404 ns         4402 ns       157929 bytes_per_second=221.87Mi/s compression_ratio=1.79649 items_per_second=116.324M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:2048/prefixed-percent:10       12811 ns        12804 ns        54299 bytes_per_second=305.071Mi/s compression_ratio=0.76148 items_per_second=159.945M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:2048/prefixed-percent:90       17186 ns        17178 ns        39521 bytes_per_second=227.399Mi/s compression_ratio=1.40466 items_per_second=119.223M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:2048/prefixed-percent:99       18260 ns        18250 ns        38287 bytes_per_second=214.042Mi/s compression_ratio=1.7747 items_per_second=112.219M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:512/prefixed-percent:10        3218 ns         3217 ns       214108 bytes_per_second=2.37183Gi/s compression_ratio=0.966836 items_per_second=159.171M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:512/prefixed-percent:90        4807 ns         4805 ns       126853 bytes_per_second=1.58781Gi/s compression_ratio=1.70489 items_per_second=106.556M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:512/prefixed-percent:99        4941 ns         4939 ns       137130 bytes_per_second=1.54488Gi/s compression_ratio=1.78203 items_per_second=103.675M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:2048/prefixed-percent:10      12255 ns        12249 ns        55533 bytes_per_second=2.4915Gi/s compression_ratio=0.966836 items_per_second=167.202M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:2048/prefixed-percent:90      19460 ns        19338 ns        35959 bytes_per_second=1.57813Gi/s compression_ratio=1.6732 items_per_second=105.906M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:2048/prefixed-percent:99      21114 ns        21103 ns        32878 bytes_per_second=1.4461Gi/s compression_ratio=1.79168 items_per_second=97.0458M/s
```

- After the change
```
Running /workspace/arrow/cpp/build/release/parquet-encoding-benchmark
Run on (20 X 2112 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 25600 KiB (x1)
Load Average: 1.24, 6.66, 4.25
---------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------------------------------------
BM_DeltaDecodingFLBA/type-length:2/batch-size:512/prefixed-percent:10              3419 ns         3418 ns       188811 bytes_per_second=285.752Mi/s compression_ratio=0.760208 items_per_second=149.816M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:512/prefixed-percent:90              3843 ns         3841 ns       174937 bytes_per_second=254.249Mi/s compression_ratio=1.38753 items_per_second=133.3M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:512/prefixed-percent:99              3730 ns         3728 ns       186091 bytes_per_second=261.966Mi/s compression_ratio=1.79649 items_per_second=137.345M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:2048/prefixed-percent:10            13447 ns        13439 ns        51135 bytes_per_second=290.661Mi/s compression_ratio=0.76148 items_per_second=152.39M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:2048/prefixed-percent:90            17300 ns        17292 ns        39339 bytes_per_second=225.901Mi/s compression_ratio=1.40466 items_per_second=118.437M/s
BM_DeltaDecodingFLBA/type-length:2/batch-size:2048/prefixed-percent:99            16789 ns        16781 ns        40393 bytes_per_second=232.784Mi/s compression_ratio=1.7747 items_per_second=122.046M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:512/prefixed-percent:10             3138 ns         3137 ns       226716 bytes_per_second=2.43218Gi/s compression_ratio=0.966836 items_per_second=163.221M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:512/prefixed-percent:90             3569 ns         3568 ns       192341 bytes_per_second=2.13857Gi/s compression_ratio=1.70489 items_per_second=143.517M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:512/prefixed-percent:99             3437 ns         3435 ns       198130 bytes_per_second=2.22082Gi/s compression_ratio=1.78203 items_per_second=149.036M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:2048/prefixed-percent:10           12079 ns        12072 ns        56551 bytes_per_second=2.52788Gi/s compression_ratio=0.966836 items_per_second=169.643M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:2048/prefixed-percent:90           14949 ns        14941 ns        43250 bytes_per_second=2.04249Gi/s compression_ratio=1.6732 items_per_second=137.069M/s
BM_DeltaDecodingFLBA/type-length:16/batch-size:2048/prefixed-percent:99           15358 ns        15350 ns        45877 bytes_per_second=1.98814Gi/s compression_ratio=1.79168 items_per_second=133.422M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:512/prefixed-percent:10         3262 ns         3261 ns       212131 bytes_per_second=299.505Mi/s compression_ratio=0.760208 items_per_second=157.027M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:512/prefixed-percent:90         3518 ns         3516 ns       196251 bytes_per_second=277.715Mi/s compression_ratio=1.38753 items_per_second=145.603M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:512/prefixed-percent:99         3536 ns         3534 ns       199117 bytes_per_second=276.305Mi/s compression_ratio=1.79649 items_per_second=144.863M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:2048/prefixed-percent:10       12662 ns        12656 ns        55254 bytes_per_second=308.658Mi/s compression_ratio=0.76148 items_per_second=161.826M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:2048/prefixed-percent:90       16081 ns        16073 ns        40982 bytes_per_second=243.035Mi/s compression_ratio=1.40466 items_per_second=127.421M/s
BM_DeltaDecodingDenseFLBA/type-length:2/batch-size:2048/prefixed-percent:99       16415 ns        16407 ns        42847 bytes_per_second=238.086Mi/s compression_ratio=1.7747 items_per_second=124.825M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:512/prefixed-percent:10        2969 ns         2968 ns       238205 bytes_per_second=2.57067Gi/s compression_ratio=0.966836 items_per_second=172.515M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:512/prefixed-percent:90        3462 ns         3460 ns       203926 bytes_per_second=2.20507Gi/s compression_ratio=1.70489 items_per_second=147.98M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:512/prefixed-percent:99        3392 ns         3390 ns       200885 bytes_per_second=2.25044Gi/s compression_ratio=1.78203 items_per_second=151.025M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:2048/prefixed-percent:10      11560 ns        11554 ns        60264 bytes_per_second=2.64135Gi/s compression_ratio=0.966836 items_per_second=177.258M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:2048/prefixed-percent:90      14602 ns        14512 ns        49410 bytes_per_second=2.10297Gi/s compression_ratio=1.6732 items_per_second=141.128M/s
BM_DeltaDecodingDenseFLBA/type-length:16/batch-size:2048/prefixed-percent:99      14782 ns        14775 ns        47312 bytes_per_second=2.06547Gi/s compression_ratio=1.79168 items_per_second=138.612M/s
```
 
### Are these changes tested?
Yes
### Are there any user-facing changes?
No

* GitHub Issue: #50822