### PR TITLE
GH-50824: [R] Fix shellcheck errors in the r/tools/download_dependencies_R.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -321,6 +321,7 @@ repos:
           ?^dev/release/setup-rhel-rebuilds\.sh$|
           ?^dev/release/utils-generate-checksum\.sh$|
           ?^dev/release/utils-watch-gh-workflow\.sh$|
+          ?^r/tools/download_dependencies_R\.sh$|
           ?^swift/gen-protobuffers\.sh$|
           )
   - repo: https://github.com/scop/pre-commit-shfmt

--- a/r/tools/download_dependencies_R.sh
+++ b/r/tools/download_dependencies_R.sh
@@ -45,7 +45,7 @@ download_dependency() {
   local url=$1
   local out=$2
 
-  echo 'download.file("'${url}'", "'${out}'", quiet = TRUE)'
+  echo "download.file(\"${url}\", \"${out}\", quiet = TRUE)"
 }
 
 print_tar_name() {
@@ -56,7 +56,7 @@ print_tar_name() {
 
 main() {
   # Load `DEPENDENCIES` variable.
-  source ${SOURCE_DIR}/cpp/thirdparty/versions.txt
+  source "${SOURCE_DIR}/cpp/thirdparty/versions.txt"
 
   for ((i = 0; i < ${#DEPENDENCIES[@]}; i++)); do
     local dep_packed=${DEPENDENCIES[$i]}
@@ -65,7 +65,7 @@ main() {
     IFS=" " read -r dep_url_var dep_tar_name dep_url <<< "${dep_packed}"
 
     if [[ "$run_mode" == "download_dependency" ]]; then
-      local out=${DESTDIR}/${dep_tar_name}
+      local out="${DESTDIR}/${dep_tar_name}"
       download_dependency "${dep_url}" "${out}"
     elif [[ "$run_mode" == "print_tar_name" ]]; then
       print_tar_name "${dep_url_var}" "${dep_tar_name}"


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2086: Double quote to prevent globbing and word splitting.

```
shellcheck r/tools/download_dependencies_R.sh

In r/tools/download_dependencies_R.sh line 48:
  echo 'download.file("'${url}'", "'${out}'", quiet = TRUE)'
                        ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                    ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  echo 'download.file("'"${url}"'", "'"${out}"'", quiet = TRUE)'


In r/tools/download_dependencies_R.sh line 59:
  source ${SOURCE_DIR}/cpp/thirdparty/versions.txt
         ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  source "${SOURCE_DIR}"/cpp/thirdparty/versions.txt

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC2086: Quote variable

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50824