### PR TITLE
GH-50831: [Python] Avoid aborting on read-only output buffers

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -2934,7 +2934,10 @@ def output_stream(source, compression='detect', buffer_size=None):
     elif source_path is not None:
         stream = OSFile(source_path, 'w')
     elif isinstance(source, (Buffer, memoryview)):
-        stream = FixedSizeBufferWriter(as_buffer(source))
+        source = as_buffer(source)
+        if not source.is_mutable:
+            raise ValueError("pa.output_stream() requires a mutable buffer")
+        stream = FixedSizeBufferWriter(source)
     elif (hasattr(source, 'write') and
           hasattr(source, 'close') and
           hasattr(source, 'closed')):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1336,6 +1336,8 @@ cdef class FixedSizeBufferWriter(NativeFile):
     """
 
     def __cinit__(self, Buffer buffer):
+        if not buffer.is_mutable:
+            raise ValueError("pa.FixedSizeBufferWriter() requires a mutable buffer")
         self.output_stream.reset(new CFixedSizeBufferWriter(buffer.buffer))
         self.is_writable = True
 
@@ -2934,10 +2936,7 @@ def output_stream(source, compression='detect', buffer_size=None):
     elif source_path is not None:
         stream = OSFile(source_path, 'w')
     elif isinstance(source, (Buffer, memoryview)):
-        source = as_buffer(source)
-        if not source.is_mutable:
-            raise ValueError("pa.output_stream() requires a mutable buffer")
-        stream = FixedSizeBufferWriter(source)
+        stream = FixedSizeBufferWriter(as_buffer(source))
     elif (hasattr(source, 'write') and
           hasattr(source, 'close') and
           hasattr(source, 'closed')):

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -2230,6 +2230,10 @@ def test_output_stream_errors(tmpdir):
         with pytest.raises(ValueError, match="requires a mutable buffer"):
             pa.output_stream(arg)
 
+    for arg in [pa.py_buffer(b"x"), pa.py_buffer(b"")]:
+        with pytest.raises(ValueError, match="requires a mutable buffer"):
+            pa.FixedSizeBufferWriter(arg)
+
     for arg in [memoryview(bytearray(1)), pa.py_buffer(bytearray(1))]:
         with pa.output_stream(arg) as stream:
             stream.write(b"x")

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -2225,6 +2225,15 @@ def test_output_stream_errors(tmpdir):
     with pytest.raises(ValueError):
         pa.output_stream(buf, compression="foo")
 
+    for arg in [memoryview(b"x"), pa.py_buffer(b"x"),
+                memoryview(b""), pa.py_buffer(b"")]:
+        with pytest.raises(ValueError, match="requires a mutable buffer"):
+            pa.output_stream(arg)
+
+    for arg in [memoryview(bytearray(1)), pa.py_buffer(bytearray(1))]:
+        with pa.output_stream(arg) as stream:
+            stream.write(b"x")
+
     for arg in [bytearray(), StringIO()]:
         with pytest.raises(TypeError):
             pa.output_stream(arg)


### PR DESCRIPTION
### Rationale for this change

`pa.output_stream()` currently aborts the Python process when passed a read-only buffer such as `pa.py_buffer(b'x')` or a `memoryview`, because the C++ fixed-size buffer writer checks `buffer->is_mutable()`. A Python API misuse should raise a Python exception instead of terminating the interpreter.

### What changes are included in this PR?

- `python/pyarrow/io.pxi`: validate that a buffer passed to `FixedSizeBufferWriter` is mutable and raise a Python `ValueError` before constructing the C++ writer.
- `python/pyarrow/tests/test_io.py`: add regression coverage for read-only buffers and preserve successful writes to mutable buffers.

Fixes #50831.

### Are these changes tested?

Yes. Focused `pyarrow` IO regression tests were added for the read-only buffer path and the valid mutable-buffer path. The local Arrow checkout also passes `git diff --check`; the available Arrow CI checks are passing.

### Are there any user-facing changes?

Yes. Passing a read-only buffer to `pa.output_stream()` now raises a Python exception instead of aborting the process. Valid mutable-buffer behavior is unchanged.

**This PR contains a "Critical Fix".** This fixes a bug that causes a crash when the API contract is upheld by passing a buffer object that is accepted by the Python API but is read-only.
* GitHub Issue: #50831

No public API signatures are changed.