### PR TITLE
GH-46918: [Python] Respect explicit Field type in add_column/set_column

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2896,6 +2896,8 @@ cdef class RecordBatch(_Tabular):
 
         if isinstance(field_, Field):
             c_field = field_
+            if c_arr.type == null() and c_field.type != null():
+                c_arr = c_arr.cast(c_field.type)
         else:
             c_field = field(field_, c_arr.type)
 
@@ -2994,6 +2996,8 @@ cdef class RecordBatch(_Tabular):
 
         if isinstance(field_, Field):
             c_field = field_
+            if c_arr.type == null() and c_field.type != null():
+                c_arr = c_arr.cast(c_field.type)
         else:
             c_field = field(field_, c_arr.type)
 
@@ -5430,6 +5434,8 @@ cdef class Table(_Tabular):
 
         if isinstance(field_, Field):
             c_field = field_
+            if c_arr.type == null() and c_field.type != null():
+                c_arr = c_arr.cast(c_field.type)
         else:
             c_field = field(field_, c_arr.type)
 
@@ -5519,6 +5525,8 @@ cdef class Table(_Tabular):
 
         if isinstance(field_, Field):
             c_field = field_
+            if c_arr.type == null() and c_field.type != null():
+                c_arr = c_arr.cast(c_field.type)
         else:
             c_field = field(field_, c_arr.type)
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1687,6 +1687,57 @@ def test_table_add_column(cls):
         (pa.RecordBatch)
     ]
 )
+@pytest.mark.parametrize('method', ['add_column', 'set_column'])
+def test_table_add_column_all_null_data_typed_field(cls, method):
+    # GH-46918: an explicitly typed field must win over the null type
+    # inferred from all-null column data
+    table = cls.from_arrays([pa.array([1.0, 2.0])], names=('a',))
+    column = [[None, None]] if cls is pa.Table else [None, None]
+
+    new_field = pa.field('b', pa.float64(), nullable=True)
+    result = getattr(table, method)(0, new_field, column)
+
+    assert result.schema.field('b').type == pa.float64()
+    assert result.column('b').to_pylist() == [None, None]
+
+    # a null field with null data stays null
+    null_field = pa.field('b', pa.null())
+    result = getattr(table, method)(0, null_field, column)
+    assert result.schema.field('b').type == pa.null()
+
+    # non-null data that does not match the field type is still rejected
+    values = [[1.5, 2.5]] if cls is pa.Table else [1.5, 2.5]
+    with pytest.raises(pa.ArrowInvalid if cls is pa.Table
+                       else pa.ArrowTypeError):
+        getattr(table, method)(0, pa.field('b', pa.int64()), values)
+
+
+@pytest.mark.parametrize(
+    ('cls'),
+    [
+        (pa.Table),
+        (pa.RecordBatch)
+    ]
+)
+def test_table_append_column_all_null_data_typed_field(cls):
+    # GH-46918
+    table = cls.from_arrays([pa.array([1.0, 2.0])], names=('a',))
+    column = [[None, None]] if cls is pa.Table else [None, None]
+
+    result = table.append_column(
+        pa.field('b', pa.float64(), nullable=True), column)
+
+    assert result.schema.field('b').type == pa.float64()
+    assert result.column('b').to_pylist() == [None, None]
+
+
+@pytest.mark.parametrize(
+    ('cls'),
+    [
+        (pa.Table),
+        (pa.RecordBatch)
+    ]
+)
 def test_table_set_column(cls):
     data = [
         pa.array(range(5)),


### PR DESCRIPTION
### Rationale for this change

Closes #46918

`add_column` / `set_column` on both `Table` and `RecordBatch` convert the column
data before they look at `field_`. Column data that is entirely null is therefore
inferred as the null type, and `AddColumn` / `SetColumn` then reject it against an
explicitly typed `Field`:

```python
>>> t = pa.table({"A": [1.0, 2.0]})
>>> t.append_column(pa.field("B", pa.float64(), nullable=True), [[None, None]])
ArrowInvalid: Field type did not match data type
```

The type the user asked for was available in `field_` the whole time, it just was
not used for the conversion.

### What changes are included in this PR?

When `field_` is a `Field` and the converted column came out as null type while the
field type is not null, the column is cast to the field type. Four call sites, same
two lines each:

- `Table.add_column`
- `Table.set_column`
- `RecordBatch.add_column`
- `RecordBatch.set_column`

`append_column` on both classes forwards to `add_column`, so it is covered too.

The issue only reports `append_column`, but `set_column` has the identical defect,
so it is fixed here as well. Happy to split it out if reviewers prefer.

Data that is not all-null keeps its inferred type, so a genuine mismatch is still
reported rather than silently cast:

```python
>>> t.append_column(pa.field("B", pa.int64()), [[1.5, 2.5]])
ArrowInvalid: Field type did not match data type   # unchanged
```

This narrow scope is deliberate. Always converting with the field type would be more
uniform with `pa.array(data, type=...)`, but that API truncates silently
(`pa.array([1.5, 2.5], type=pa.int64())` gives `[1, 2]`), so the broad version would
turn today's loud error into a silent data change. Happy to switch to the broad
behaviour if that is preferred.

### Are these changes tested?

Yes. `test_table_add_column_all_null_data_typed_field` (parametrized over
`Table`/`RecordBatch` x `add_column`/`set_column`) and
`test_table_append_column_all_null_data_typed_field`. They cover the typed field
case, a null field with null data staying null, and a non-null mismatch still
raising.

### Are there any user-facing changes?

Yes, a bug fix. Calls that raised `ArrowInvalid` / `ArrowTypeError` now succeed and
produce a column of the requested type. No previously working call changes behaviour.

### Note

One pre-existing inconsistency noticed while writing the tests, left alone here:
for the same type mismatch `Table` raises `ArrowInvalid` while `RecordBatch` raises
`ArrowTypeError`. Can file a separate issue if that is worth aligning.

### AI usage disclosure

This change was written with the assistance of an AI coding agent (Claude Code).
The agent located the four call sites, wrote the patch and the tests, and ran the
test suite. I reviewed the diff, chose the narrow-vs-broad scope, and verified the
results before submitting.

* GitHub Issue: #46918