### PR TITLE
GH-50819: [Release] Increase YUM verification timeout

### DIFF
--- a/.github/workflows/verify_rc.yml
+++ b/.github/workflows/verify_rc.yml
@@ -251,7 +251,7 @@ jobs:
     name: Yum
     needs: target
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Rationale for this change

The arm64 YUM release-verification job can exceed its 30-minute limit when the EPEL mirror is slow. Issue #50819 reports repeated timeouts during the 25.0.1 verification, including a package download taking about 15 minutes at roughly 23 kB/s. Increasing the shared matrix job timeout gives the verification enough time to complete under this documented slow-mirror condition.

### What changes are included in this PR?

- Increase `yum` in `.github/workflows/verify_rc.yml` from `timeout-minutes: 30` to `timeout-minutes: 60`.
- The job is a shared matrix for `ubuntu-latest` and `ubuntu-24.04-arm`, so the timeout change applies to both architectures while keeping the workflow structure unchanged.

### Are these changes tested?

The workflow remains valid YAML, and `git diff --check` passes. This is a CI configuration-only change; no runtime test is applicable.

### Are there any user-facing changes?

No direct user-facing API changes. Release verification is less likely to fail due to transient slow package mirrors.

* GitHub Issue: #50819