### PR TITLE
GH-50665: [Python] Assert s3fs selector result count

### DIFF
--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -803,7 +803,7 @@ def test_get_file_info_with_selector(fs, pathfn):
         infos = fs.get_file_info(selector)
         if fs.type_name == "py::fsspec+('s3', 's3a')":
             # s3fs only lists directories if they are not empty
-            len(infos) == 4
+            assert len(infos) == 4
         else:
             assert len(infos) == 5
 


### PR DESCRIPTION
### Rationale for this change

The recursive selector branch for the fsspec S3 backend evaluated `len(infos) == 4` without asserting the result. As a result, an incorrect number of returned entries could pass the test unnoticed.

### What changes are included in this PR?

- Assert that the recursive s3fs selector returns four entries.

Fixes #50665.

### Are these changes tested?

Yes. The modified test file passes Python syntax compilation, and `git diff --check` passes. The focused runtime test could not run locally because this checkout does not have the pyarrow test dependencies installed.

### Are there any user-facing changes?

No. This change only strengthens an existing Python filesystem test.

* GitHub Issue: #50665
