### PR TITLE
GH-50828: [C++][FlightRPC][ODBC] Add SQLGetInfo remote tests

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -31,7 +31,7 @@ class ConnectionInfoTest : public T {};
 
 class ConnectionInfoMockTest : public FlightSQLODBCMockTestBase {};
 class ConnectionInfoRemoteTest : public FlightSQLODBCRemoteTestBase {};
-using TestTypes = ::testing::Types<ConnectionInfoMockTest, FlightSQLODBCRemoteTestBase>;
+using TestTypes = ::testing::Types<ConnectionInfoMockTest, ConnectionInfoRemoteTest>;
 TYPED_TEST_SUITE(ConnectionInfoTest, TestTypes);
 
 template <typename T>
@@ -709,6 +709,20 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCreateTable) {
   GetInfo(this->conn, SQL_CREATE_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(1), value);
+}
+
+TEST_F(ConnectionInfoRemoteTest, TestSQLGetInfoCreateSchema) {
+  SQLUINTEGER value;
+  GetInfo(this->conn, SQL_CREATE_SCHEMA, &value);
+
+  EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
+}
+
+TEST_F(ConnectionInfoRemoteTest, TestSQLGetInfoCreateTable) {
+  SQLUINTEGER value;
+  GetInfo(this->conn, SQL_CREATE_TABLE, &value);
+
+  EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateTranslation) {


### PR DESCRIPTION
### Rationale for this change

The SQLGetInfo tests for `SQL_CREATE_SCHEMA` and `SQL_CREATE_TABLE` only covered the mock server. The remote fixture can report different DDL capabilities, so the missing remote coverage allowed regressions to go unnoticed.

### What changes are included in this PR?

- Add a named remote connection-info fixture.
- Add remote tests for `SQL_CREATE_SCHEMA` and `SQL_CREATE_TABLE`.
- Keep the mock expectations (`1`) and assert the remote fixture's unsupported DDL values (`0`) separately.

Fixes #50828.

### Are these changes tested?

The changed C++ test source passes `git diff --check` and was reviewed for fixture-specific expectations. A local runtime ODBC test could not be run because this checkout has no compiled ODBC test binary or configured remote server.

### Are there any user-facing changes?

No.

* GitHub Issue: #50828
