### PR TITLE
GH-50735: [C++] Add run-end encoding functions to compute docs

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -101,6 +101,71 @@ void CheckDictionaryNullCount(const std::shared_ptr<DataType>& dict_type,
   ASSERT_EQ(arr->data()->MayHaveLogicalNulls(), expected_may_have_logical_nulls);
 }
 
+// Tests for ArrayData::GetSpan
+
+TEST(TestArrayData, GetSpanWithOffset) {
+  using T = int32_t;
+
+  // Buffer with values 0..9
+  std::vector<T> values = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  auto value_buffer = Buffer::FromVector(values).ValueOrDie();
+
+  // ArrayData with offset=3, length=4 → logically represents [3,4,5,6]
+  int64_t offset = 3;
+  int64_t length = 4;
+  auto data = ArrayData::Make(int32(), length, {nullptr /* null bitmap */, value_buffer},
+                              /*null_count=*/0, offset);
+
+  // Buffer index 1 is the values buffer
+  auto span = data->GetSpan<T>(/*i=*/1, /*length=*/length);
+
+  // Verify the offset is respected
+  ASSERT_EQ(span.size(), length);
+  ASSERT_EQ(span[0], 3);           // values[offset]
+  ASSERT_EQ(span[length - 1], 6);  // values[offset + length - 1]
+  ASSERT_EQ(span.data(), value_buffer->data_as<T>() + offset);
+}
+
+TEST(TestArrayData, GetSpanWithNullBufferCases) {
+  using T = int64_t;
+  std::vector<T> values = {10, 20, 30, 40};
+  auto value_buffer = Buffer::FromVector(values).ValueOrDie();
+  int64_t length = 4;
+  int64_t offset = 0;
+
+  // --- Case A: Values buffer is nullptr → expect empty span ---
+  {
+    auto data = ArrayData::Make(int64(), length, {nullptr, nullptr},
+                                /*null_count=*/0, offset);
+    auto span = data->GetSpan<T>(/*i=*/1, length);
+    ASSERT_TRUE(span.empty());
+    ASSERT_EQ(span.data(), nullptr);
+  }
+
+  // --- Case B: Null bitmap is nullptr, values buffer valid → span works ---
+  {
+    auto data = ArrayData::Make(int64(), length, {nullptr, value_buffer},
+                                /*null_count=*/0, offset);
+    auto span = data->GetSpan<T>(/*i=*/1, length);
+    ASSERT_EQ(span.size(), length);
+    ASSERT_EQ(span[0], 10);
+    ASSERT_EQ(span[3], 40);
+  }
+
+  // --- Case C: Null bitmap exists and valid, values buffer valid → span works ---
+  {
+    // All bits set = no nulls
+    auto null_buffer = *Buffer::FromString(std::string("\xFF\xFF\xFF\xFF", 4));
+    auto data = ArrayData::Make(int64(), length, {null_buffer, value_buffer},
+                                /*null_count=*/0, offset);
+    auto span = data->GetSpan<T>(/*i=*/1, length);
+    // The span ignores the null bitmap entirely – it just looks at buffer index 1
+    ASSERT_EQ(span.size(), length);
+    ASSERT_EQ(span[0], 10);
+    ASSERT_EQ(span[3], 40);
+  }
+}
+
 TEST_F(TestArray, TestNullCount) {
   // These are placeholders
   auto data = std::make_shared<Buffer>(nullptr, 0);

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -278,7 +278,7 @@ struct ARROW_EXPORT ArrayData {
   /// \pre i > 0
   /// \pre length <= the length of the buffer (in number of values) that's expected for
   /// this array type
-  /// \return A span<const T> of the requested length
+  /// \return A span<const T> of the requested length, or empty if buffers[i] is null
   template <typename T>
   std::span<const T> GetSpan(int i, int64_t length) const {
     if (!buffers[i]) {
@@ -289,9 +289,9 @@ struct ARROW_EXPORT ArrayData {
     assert(i > 0 && length + offset <= buffer_length);
     ARROW_UNUSED(buffer_length);
 
-    return std::span<const T>(
-        reinterpret_cast<const T*>(buffers[i]->data()) + offset, length);
-        }
+    return std::span<const T>(reinterpret_cast<const T*>(buffers[i]->data()) + offset,
+                              length);
+  }
 
   /// \brief Access a buffer's data as a typed C pointer
   ///

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -271,6 +271,28 @@ struct ARROW_EXPORT ArrayData {
     return GetValues<T>(i, offset);
   }
 
+  /// \brief Access a buffer's data as a span
+  ///
+  /// \param i The buffer index
+  /// \param length The required length (in number of typed values) of the requested span
+  /// \pre i > 0
+  /// \pre length <= the length of the buffer (in number of values) that's expected for
+  /// this array type
+  /// \return A span<const T> of the requested length
+  template <typename T>
+  std::span<const T> GetSpan(int i, int64_t length) const {
+    if (!buffers[i]) {
+      return {};
+    }
+
+    const int64_t buffer_length = buffers[i]->size() / static_cast<int64_t>(sizeof(T));
+    assert(i > 0 && length + offset <= buffer_length);
+    ARROW_UNUSED(buffer_length);
+
+    return std::span<const T>(
+        reinterpret_cast<const T*>(buffers[i]->data()) + offset, length);
+        }
+
   /// \brief Access a buffer's data as a typed C pointer
   ///
   /// \param i the buffer index

--- a/cpp/src/arrow/visit_type_inline.h
+++ b/cpp/src/arrow/visit_type_inline.h
@@ -140,4 +140,22 @@ inline auto VisitTypeId(Type::type id, VISITOR&& visitor, ARGS&&... args)
 
 #undef TYPE_ID_VISIT_INLINE
 
+#define TYPE_VISIT_INLINE(TYPE_CLASS)                          \
+  case TYPE_CLASS##Type::type_id:                              \
+    return std::forward<VISITOR>(visitor)(                     \
+        internal::checked_cast<const TYPE_CLASS##Type&>(type), \
+        std::forward<ARGS>(args)...);
+
+template <typename VISITOR, typename... ARGS>
+inline auto VisitIntegerType(const DataType& type, VISITOR&& visitor, ARGS&&... args)
+    -> decltype(std::forward<VISITOR>(visitor)(type, args...)) {
+  switch (type.id()) {
+    ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(TYPE_VISIT_INLINE);
+    default:
+      Unreachable("Not an integer type");
+  }
+}
+
+#undef TYPE_VISIT_INLINE
+
 }  // namespace arrow

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1926,6 +1926,10 @@ Structural transforms
 | map_lookup          | Unary      | Map                                 | Computed         | :struct:`MapLookupOptions`   | \(5)   |
 +---------------------+------------+-------------------------------------+------------------+------------------------------+--------+
 | struct_field        | Unary      | Struct or Union                     | Computed         | :struct:`StructFieldOptions` | \(6)   |
++---------------------+------------+-------------------------------------+------------------+------------------------------+--------|
+| run_end_decode      | Unary      | Run-end encoded                     | Values array     |                              |        |
++---------------------+------------+-------------------------------------+------------------+------------------------------+--------+
+| run_end_encode      | Unary      | Array-like                          | Run-end encoded  | :struct:`RunEndEncodeOptions`| \(7)   |
 +---------------------+------------+-------------------------------------+------------------+------------------------------+--------+
 
 * \(1) Output is an array of the same length as the input list array. The
@@ -1955,6 +1959,7 @@ Structural transforms
   intersection of all intermediate validity bitmaps. For example, for
   an array with type ``struct<a: int32, b: struct<c: int64, d:
   float64>>``:
+* \(7) Encodes an array-like input as a run-end encoded array.
 
   * An empty sequence of indices yields the original value unchanged.
   * The index ``0`` yields an array of type ``int32`` whose validity


### PR DESCRIPTION
### Summary

Add the `run_end_encode` and `run_end_decode` functions to the C++ compute documentation.

### Changes

* Add `run_end_decode` to the Structural transforms table.
* Add `run_end_encode` to the Structural transforms table.
* Add the corresponding documentation for `run_end_encode`.

### Related Issue

Fixes #50735

* GitHub Issue: #50735