### PR TITLE
GH-50849: [Python] Return correct ParquetLogicalType.type for geometry/geography

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1464,6 +1464,8 @@ cdef logical_type_name_from_enum(ParquetLogicalTypeId type_):
         ParquetLogicalType_JSON: 'JSON',
         ParquetLogicalType_BSON: 'BSON',
         ParquetLogicalType_UUID: 'UUID',
+        ParquetLogicalType_GEOMETRY: 'GEOMETRY'
+        ParquetLogicalType_GEOGRAPHY: 'GEOGRAPHY',
         ParquetLogicalType_NONE: 'NONE',
     }.get(type_, 'UNKNOWN')
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1464,7 +1464,7 @@ cdef logical_type_name_from_enum(ParquetLogicalTypeId type_):
         ParquetLogicalType_JSON: 'JSON',
         ParquetLogicalType_BSON: 'BSON',
         ParquetLogicalType_UUID: 'UUID',
-        ParquetLogicalType_GEOMETRY: 'GEOMETRY'
+        ParquetLogicalType_GEOMETRY: 'GEOMETRY',
         ParquetLogicalType_GEOGRAPHY: 'GEOGRAPHY',
         ParquetLogicalType_NONE: 'NONE',
     }.get(type_, 'UNKNOWN')

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -871,3 +871,25 @@ def test_read_schema_uuid_extension_type(tmp_path):
 
     schema_disabled = pq.read_schema(file_path_str, arrow_extensions_enabled=False)
     assert schema_disabled.field("ext").type == pa.binary(16)
+
+
+def test_geospatial_types(parquet_test_datadir):
+    metadata = pq.read_metadata(
+        parquet_test_datadir / "geospatial" / "crs-default.parquet"
+    )
+    column_schema = metadata.schema.column(1)
+    assert column_schema.name == "geometry"
+    assert column_schema.logical_type.type == "GEOMETRY"
+
+    col_chunk = metadata.row_group(0).column(1)
+    assert col_chunk.is_geo_stats_set
+    assert isinstance(col_chunk.geo_statistics, pa._parquet.GeoStatistics)
+    assert isinstance(col_chunk.geo_statistics.geospatial_types, list)
+    assert isinstance(col_chunk.geo_statistics.xmin, float)
+
+    metadata = pq.read_metadata(
+        parquet_test_datadir / "geospatial" / "crs-geography.parquet"
+    )
+    column_schema = metadata.schema.column(1)
+    assert column_schema.name == "geography"
+    assert column_schema.logical_type.type == "GEOGRAPHY"


### PR DESCRIPTION
### Rationale for this change

Fix the return value of `ParquetLogicalType.type` for geometry/geography types

### Are these changes tested?

Yes

### Are there any user-facing changes?

Not apart from the bug fix

* GitHub Issue: #50849