### PR TITLE
GH-46646: [dev][R] Replace linr with jarl for R linting / pre-commit check

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -56,7 +56,6 @@ jobs:
           sudo apt update
           sudo apt install -y -V \
             pre-commit \
-            r-base \
             ruby-dev \
             libuv1-dev
       - name: Cache pre-commit
@@ -64,7 +63,6 @@ jobs:
         with:
           path: |
             ~/.cache/pre-commit
-            ~/.local/share/renv/cache
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -193,9 +193,7 @@ repos:
     hooks:
       - id: jarl-check
         alias: r
-        name: R Lint
-        files: >-
-          ^r/.*\.(R|Rmd)$
+        name: R Lint (jarl)
   - repo: https://github.com/posit-dev/air-pre-commit
     rev: 0.8.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,19 +188,12 @@ repos:
           ?^python/pyarrow/util\.py$|
           ?^python/pyarrow/vendored/|
           )
-  - repo: local
+  - repo: https://github.com/etiennebacher/jarl-pre-commit
+    rev: "0.5.0"
     hooks:
-      - id: lintr
+      - id: jarl-check
         alias: r
         name: R Lint
-        language: r
-        additional_dependencies:
-          - cyclocomp
-          - lintr
-          - testthat
-        entry: |
-          Rscript -e "Sys.setenv(NOT_CRAN = 'TRUE'); lintr::expect_lint_free('r')"
-        pass_filenames: false
         files: >-
           ^r/.*\.(R|Rmd)$
   - repo: https://github.com/posit-dev/air-pre-commit

--- a/docs/source/developers/guide/step_by_step/styling.rst
+++ b/docs/source/developers/guide/step_by_step/styling.rst
@@ -38,12 +38,11 @@ linters and styling of the code.
       For the R package you can use
       `air <https://posit-dev.github.io/air/>`_ to format the code,
       and
-
-      ``{lintr}``
+      `jarl <https://etiennebacher.github.io/jarl/>`_
       to check if the code follows the
       `tidyverse style <https://style.tidyverse.org/>`_.
 
-      The instructions on how to use `air` and ``{lintr}``
+      The instructions on how to use `air` and `jarl`
       can be found in the
       `Styling and Linting section of the Common developer workflow tasks <https://arrow.apache.org/docs/r/articles/developers/workflow.html#styling-and-linting>`_.
 

--- a/r/jarl.toml
+++ b/r/jarl.toml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[lint]
+# exclude below files as all are generated or used for generating other files
+exclude = ["R/arrowExports.R", "R/dplyr-funcs-doc.R", "data-raw/codegen.R"]

--- a/r/jarl.toml
+++ b/r/jarl.toml
@@ -18,3 +18,23 @@
 [lint]
 # exclude below files as all are generated or used for generating other files
 exclude = ["R/arrowExports.R", "R/dplyr-funcs-doc.R", "data-raw/codegen.R"]
+
+# TODO: these rules currently fire on existing code; re-enable incrementally
+# after triaging/fixing the findings (see GH-46646).
+ignore = [
+  "any_is_na",
+  "comparison_negation",
+  "download_file",
+  "duplicated_arguments",
+  "equals_null",
+  "implicit_assignment",
+  "internal_function",
+  "numeric_leading_zero",
+  "outer_negation",
+  "redundant_equals",
+  "redundant_ifelse",
+  "repeat",
+  "seq",
+  "sprintf",
+  "unused_function",
+]

--- a/r/vignettes/developers/workflow.Rmd
+++ b/r/vignettes/developers/workflow.Rmd
@@ -13,17 +13,18 @@ knitr::opts_chunk$set(error = TRUE, eval = FALSE)
 The Arrow R package uses several additional development tools:
 
 * [`air`](https://posit-dev.github.io/air/) for code styling
-* [`lintr`](https://github.com/r-lib/lintr) for code analysis
+* [`jarl`](https://etiennebacher.github.io/jarl/) for code analysis
 * [`pkgdown`](https://pkgdown.r-lib.org) for building the website
 * [`roxygen2`](https://roxygen2.r-lib.org) for documenting the package
   - the R documentation uses the [`@examplesIf`](https://roxygen2.r-lib.org/articles/rd.html#functions) tag introduced in `roxygen2` version 7.1.2
 
-Instructions for installing `air` can be found at <https://posit-dev.github.io/air/cli.html>.
+Instructions for installing `air` can be found at <https://posit-dev.github.io/air/cli.html>,
+and instructions for installing `jarl` can be found at <https://etiennebacher.github.io/jarl/#installation>.
 
 You can install all the other additional dependencies by running:
 
 ```r
-install.packages(c("lintr", "pkgdown", "roxygen2"))
+install.packages(c("pkgdown", "roxygen2"))
 ```
 
 
@@ -68,7 +69,7 @@ The R code in the package follows [the tidyverse style](https://style.tidyverse.
 
 You can automatically change the formatting of the code in the package using the [air](https://posit-dev.github.io/air/cli.html) formatter.
 
-The `air` formatter will fix many styling errors, thought not all lintr errors are automatically fixable with `air`. The list of files we intentionally do not style is in the `exclude` field in `r/air.toml`.
+The `air` formatter will fix many styling errors, though not all `jarl` errors are automatically fixable with `air`. The list of files we intentionally do not style is in the `exclude` field in `r/air.toml`.
 
 Linting and styling with [pre-commit](https://pre-commit.com/) as described above is the best way to ensure your changes are being checked properly but you can also run the tools individually if you prefer, from the `arrow/r` directory of the repository.
 
@@ -78,13 +79,13 @@ From the command line, run `air`:
 air format
 ```
 
-In R, run `lintr`: 
+From the command line, run `jarl`:
 
-```r
-lintr::lint_package()
+```
+jarl check .
 ```
 
-Note: To run lintr, we require the `cyclocomp` package to be installed first.
+Some `jarl` findings can be fixed automatically with `jarl check --fix .`.
 
 ### C++ code
 


### PR DESCRIPTION
### Rationale for this change

Fix #46646 by replacing the `lintr` pre-commit hook (which requires system R/Rscript to bootstrap, causing hard failures when R isn't installed, end even if installed still gives errors when using conda (https://github.com/apache/arrow/issues/47997)) with jarl (https://jarl.etiennebacher.com/, a Rust-native R linter distributed as a standalone binary or as a python package).

### What changes are included in this PR?

- `.pre-commit-config.yaml`: swapped the local `lintr` hook for `etiennebacher/jarl-pre-commit` (jarl-check, rev 0.5.0)
- `r/jarl.toml`: new config file, excludes the same generated files that `r/.lintr` and `r/air.toml` already exclude
  - NOTE: for now I did not remove `r/.lintr` in case people would use that locally or through their IDE, so it might be useful to keep. But for our CI it could be removed.
- `.github/workflows/dev.yml`: dropped r-base from the CI apt install and the now-unused `~/.local/share/renv/cache` from the pre-commit cache path, since no pre-commit hook needs R anymore
- `r/vignettes/developers/workflow.Rmd` and `docs/source/developers/guide/step_by_step/styling.rst`: updated references from lintr to jarl

At the moment, running `jarl check` gives 42 pre-existing errors (13 auto-fixable), so CI will be failing at the moment. 
Those should be fixed (or temporarily suppressed) in a next commit. EDIT: for now I added those to the configuration as ignored rules, so CI would be green. Those can be fixed as a follow-up issue.

Also note the differences between lintr and jarl listed at https://github.com/apache/arrow/issues/46646#issuecomment-5253845795. Especially no cyclocomp (complexity) or object_length equivalent exists in jarl, so we have to see if we are fine with dropping those checks.

Code changes are largely generated by Claude, I did review everything, but I am no R developer ..

### Are these changes tested?

pre-commit runs on CI

### Are there any user-facing changes?

No

* GitHub Issue: #47937
* GitHub Issue: #46646