### PR TITLE
GH-50855: [R] Fix shellcheck errors in the r/inst/build_arrow_static.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -322,6 +322,7 @@ repos:
           ?^dev/release/utils-generate-checksum\.sh$|
           ?^dev/release/utils-watch-gh-workflow\.sh$|
           ?^r/tools/download_dependencies_R\.sh$|
+          ?^r/inst/build_arrow_static\.sh$|
           ?^swift/gen-protobuffers\.sh$|
           )
   - repo: https://github.com/scop/pre-commit-shfmt

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -62,12 +62,17 @@ case "$CXX" in
     ;;
 esac
 
+
+CMAKE_COMMAND=("${CMAKE}")
+
 # Used for Emscripten
-: "${CMAKE_WRAPPER:=}"
+if [[ -n "${CMAKE_WRAPPER:-}" ]]; then
+  CMAKE_COMMAND=("${CMAKE_WRAPPER}" "${CMAKE}")
+fi
 
 mkdir -p "${BUILD_DIR}"
 pushd "${BUILD_DIR}"
-"${CMAKE_WRAPPER}" "${CMAKE}" -DARROW_BOOST_USE_SHARED=OFF \
+"${CMAKE_COMMAND[@]}" -DARROW_BOOST_USE_SHARED=OFF \
     -DARROW_SNAPPY_USE_SHARED=OFF \
     -DARROW_BUILD_TESTS=OFF \
     -DARROW_BUILD_SHARED=OFF \

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -67,7 +67,7 @@ CMAKE_COMMAND=("${CMAKE}")
 
 # Used for Emscripten
 if [[ -n "${CMAKE_WRAPPER:-}" ]]; then
-  CMAKE_COMMAND=("${CMAKE_WRAPPER}" "${CMAKE}")
+  CMAKE_COMMAND=("${CMAKE_WRAPPER}" "${CMAKE_COMMAND[@]}")
 fi
 
 mkdir -p "${BUILD_DIR}"

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -26,18 +26,18 @@ set -x
 # By default, this script assumes it's in the top-level dir of the apache/arrow
 # git repository. Set any of the following env vars to customize where to read
 # and write from
-: ${ARROW_HOME:="$(pwd)"}                       # Only used in default SOURCE/BUILD dirs
-: ${SOURCE_DIR:="${ARROW_HOME}/cpp"}            # Where the C++ source is
-: ${BUILD_DIR:="${ARROW_HOME}/r/libarrow/dist"} # Where cmake should build
-: ${DEST_DIR:="$BUILD_DIR"}                     # Where the resulting /lib and /include should be
-: ${CMAKE:="$(which cmake)"}
+: "${ARROW_HOME:=$(pwd)}"                       # Only used in default SOURCE/BUILD dirs
+: "${SOURCE_DIR:=${ARROW_HOME}/cpp}"            # Where the C++ source is
+: "${BUILD_DIR:=${ARROW_HOME}/r/libarrow/dist}" # Where cmake should build
+: "${DEST_DIR:=$BUILD_DIR}"                     # Where the resulting /lib and /include should be
+: "${CMAKE:=$(which cmake)}"
 
 # Make sure SOURCE and DEST dirs are absolute and exist
 SOURCE_DIR="$(cd "${SOURCE_DIR}" && pwd)"
 DEST_DIR="$(mkdir -p "${DEST_DIR}" && cd "${DEST_DIR}" && pwd)"
 
 if [ "$N_JOBS" = "" ]; then
-  if [ "`uname -s`" = "Darwin" ]; then
+  if [ "$(uname -s)" = "Darwin" ]; then
     N_JOBS="$(sysctl -n hw.logicalcpu)"
   else
     N_JOBS="$(nproc)"
@@ -46,7 +46,7 @@ fi
 
 # Make some env vars case-insensitive
 if [ "$LIBARROW_MINIMAL" != "" ]; then
-  LIBARROW_MINIMAL=`echo $LIBARROW_MINIMAL | tr '[:upper:]' '[:lower:]'`
+  LIBARROW_MINIMAL=$(echo "$LIBARROW_MINIMAL" | tr '[:upper:]' '[:lower:]')
 fi
 
 if [ "$LIBARROW_MINIMAL" = "false" ]; then
@@ -63,60 +63,60 @@ case "$CXX" in
 esac
 
 # Used for Emscripten
-: ${CMAKE_WRAPPER:=""}
+: "${CMAKE_WRAPPER:=}"
 
 mkdir -p "${BUILD_DIR}"
 pushd "${BUILD_DIR}"
-${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
+"${CMAKE_WRAPPER}" "${CMAKE}" -DARROW_BOOST_USE_SHARED=OFF \
     -DARROW_SNAPPY_USE_SHARED=OFF \
     -DARROW_BUILD_TESTS=OFF \
     -DARROW_BUILD_SHARED=OFF \
     -DARROW_BUILD_STATIC=ON \
-    -DARROW_ACERO=${ARROW_ACERO:-ON} \
+    -DARROW_ACERO="${ARROW_ACERO:-ON}" \
     -DARROW_COMPUTE=ON \
     -DARROW_CSV=ON \
-    -DARROW_DATASET=${ARROW_DATASET:-ON} \
-    -DARROW_DEPENDENCY_SOURCE=${ARROW_DEPENDENCY_SOURCE:-AUTO} \
-    -DARROW_DEPENDENCY_USE_SHARED=${ARROW_DEPENDENCY_USE_SHARED:-ON} \
-    -DARROW_ENABLE_THREADING=${ARROW_ENABLE_THREADING:-ON} \
-    -DAWSSDK_SOURCE=${AWSSDK_SOURCE:-} \
-    -DBoost_SOURCE=${Boost_SOURCE:-} \
-    -Dlz4_SOURCE=${lz4_SOURCE:-} \
+    -DARROW_DATASET="${ARROW_DATASET:-ON}" \
+    -DARROW_DEPENDENCY_SOURCE="${ARROW_DEPENDENCY_SOURCE:-AUTO}" \
+    -DARROW_DEPENDENCY_USE_SHARED="${ARROW_DEPENDENCY_USE_SHARED:-ON}" \
+    -DARROW_ENABLE_THREADING="${ARROW_ENABLE_THREADING:-ON}" \
+    -DAWSSDK_SOURCE="${AWSSDK_SOURCE:-}" \
+    -DBoost_SOURCE="${Boost_SOURCE:-}" \
+    -Dlz4_SOURCE="${lz4_SOURCE:-}" \
     -DARROW_FILESYSTEM=ON \
-    -DARROW_GCS=${ARROW_GCS:-OFF} \
-    -DARROW_AZURE=${ARROW_AZURE:-$ARROW_DEFAULT_PARAM} \
-    -DARROW_JEMALLOC=${ARROW_JEMALLOC:-$ARROW_DEFAULT_PARAM} \
-    -DARROW_MIMALLOC=${ARROW_MIMALLOC:-ON} \
-    -DARROW_JSON=${ARROW_JSON:-ON} \
-    -DARROW_PARQUET=${ARROW_PARQUET:-ON} \
-    -DARROW_S3=${ARROW_S3:-$ARROW_DEFAULT_PARAM} \
-    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI:-$ARROW_DEFAULT_PARAM} \
-    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2:-$ARROW_DEFAULT_PARAM} \
-    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4:-ON} \
-    -DARROW_WITH_RE2=${ARROW_WITH_RE2:-ON} \
-    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY:-ON} \
-    -DARROW_WITH_UTF8PROC=${ARROW_WITH_UTF8PROC:-ON} \
-    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB:-$ARROW_DEFAULT_PARAM} \
-    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD:-$ARROW_DEFAULT_PARAM} \
-    -DARROW_VERBOSE_THIRDPARTY_BUILD=${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF} \
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} \
-    -DCMAKE_FIND_DEBUG_MODE=${CMAKE_FIND_DEBUG_MODE:-OFF} \
+    -DARROW_GCS="${ARROW_GCS:-OFF}" \
+    -DARROW_AZURE="${ARROW_AZURE:-$ARROW_DEFAULT_PARAM}" \
+    -DARROW_JEMALLOC="${ARROW_JEMALLOC:-$ARROW_DEFAULT_PARAM}" \
+    -DARROW_MIMALLOC="${ARROW_MIMALLOC:-ON}" \
+    -DARROW_JSON="${ARROW_JSON:-ON}" \
+    -DARROW_PARQUET="${ARROW_PARQUET:-ON}" \
+    -DARROW_S3="${ARROW_S3:-$ARROW_DEFAULT_PARAM}" \
+    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI:-$ARROW_DEFAULT_PARAM}" \
+    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2:-$ARROW_DEFAULT_PARAM}" \
+    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4:-ON}" \
+    -DARROW_WITH_RE2="${ARROW_WITH_RE2:-ON}" \
+    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY:-ON}" \
+    -DARROW_WITH_UTF8PROC="${ARROW_WITH_UTF8PROC:-ON}" \
+    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB:-$ARROW_DEFAULT_PARAM}" \
+    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD:-$ARROW_DEFAULT_PARAM}" \
+    -DARROW_VERBOSE_THIRDPARTY_BUILD="${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF}" \
+    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" \
+    -DCMAKE_FIND_DEBUG_MODE="${CMAKE_FIND_DEBUG_MODE:-OFF}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
-    -DCMAKE_INSTALL_PREFIX=${DEST_DIR} \
+    -DCMAKE_INSTALL_PREFIX="${DEST_DIR}" \
     -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON \
     -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
-    -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR} \
-    -Dabsl_SOURCE=${absl_SOURCE:-BUNDLED} \
-    -Dre2_SOURCE=${re2_SOURCE:-BUNDLED} \
-    -Dsimdjson_SOURCE=${simdjson_SOURCE:-BUNDLED} \
-    -Dxsimd_SOURCE=${xsimd_SOURCE:-} \
-    -Dzstd_SOURCE=${zstd_SOURCE:-} \
-    ${EXTRA_CMAKE_FLAGS} \
+    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \
+    -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR}" \
+    -Dabsl_SOURCE="${absl_SOURCE:-BUNDLED}" \
+    -Dre2_SOURCE="${re2_SOURCE:-BUNDLED}" \
+    -Dsimdjson_SOURCE="${simdjson_SOURCE:-BUNDLED}" \
+    -Dxsimd_SOURCE="${xsimd_SOURCE:-}" \
+    -Dzstd_SOURCE="${zstd_SOURCE:-}" \
+    "${EXTRA_CMAKE_FLAGS}" \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
-    ${SOURCE_DIR}
+    "${SOURCE_DIR}"
 
-${CMAKE} --build . --target install -- -j $N_JOBS
+"${CMAKE}" --build . --target install -- -j "$N_JOBS"
 
 if command -v sccache &> /dev/null; then
   echo "=== sccache stats after the build ==="

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -70,6 +70,10 @@ if [[ -n "${CMAKE_WRAPPER:-}" ]]; then
   CMAKE_COMMAND=("${CMAKE_WRAPPER}" "${CMAKE_COMMAND[@]}")
 fi
 
+# Convert the space-separated options into a Bash array.
+# This avoids ShellCheck SC2086 and preserves argument boundaries.
+read -r -a ARROW_EXTRA_CMAKE_FLAGS <<< "${EXTRA_CMAKE_FLAGS}"
+
 mkdir -p "${BUILD_DIR}"
 pushd "${BUILD_DIR}"
 "${CMAKE_COMMAND[@]}" -DARROW_BOOST_USE_SHARED=OFF \
@@ -117,7 +121,7 @@ pushd "${BUILD_DIR}"
     -Dsimdjson_SOURCE="${simdjson_SOURCE:-BUNDLED}" \
     -Dxsimd_SOURCE="${xsimd_SOURCE:-}" \
     -Dzstd_SOURCE="${zstd_SOURCE:-}" \
-    "${EXTRA_CMAKE_FLAGS}" \
+    "${ARROW_EXTRA_CMAKE_FLAGS[@]}" \
     -G "${CMAKE_GENERATOR:-Unix Makefiles}" \
     "${SOURCE_DIR}"
 


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2086: Double quote to prevent globbing and word splitting.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.
* SC2006: Use $(...) notation instead of legacy backticked `...`.


```
shellcheck r/inst/build_arrow_static.sh

In r/inst/build_arrow_static.sh line 29:
: ${ARROW_HOME:="$(pwd)"}                       # Only used in default SOURCE/BUILD dirs
  ^---------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In r/inst/build_arrow_static.sh line 30:
: ${SOURCE_DIR:="${ARROW_HOME}/cpp"}            # Where the C++ source is
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In r/inst/build_arrow_static.sh line 31:
: ${BUILD_DIR:="${ARROW_HOME}/r/libarrow/dist"} # Where cmake should build
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In r/inst/build_arrow_static.sh line 32:
: ${DEST_DIR:="$BUILD_DIR"}                     # Where the resulting /lib and /include should be
  ^-----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In r/inst/build_arrow_static.sh line 33:
: ${CMAKE:="$(which cmake)"}
  ^------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In r/inst/build_arrow_static.sh line 40:
  if [ "`uname -s`" = "Darwin" ]; then
        ^--------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
  if [ "$(uname -s)" = "Darwin" ]; then


In r/inst/build_arrow_static.sh line 49:
  LIBARROW_MINIMAL=`echo $LIBARROW_MINIMAL | tr '[:upper:]' '[:lower:]'`
                   ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                         ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  LIBARROW_MINIMAL=$(echo "$LIBARROW_MINIMAL" | tr '[:upper:]' '[:lower:]')


In r/inst/build_arrow_static.sh line 66:
: ${CMAKE_WRAPPER:=""}
  ^------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In r/inst/build_arrow_static.sh line 70:
${CMAKE_WRAPPER} ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
                 ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${CMAKE_WRAPPER} "${CMAKE}" -DARROW_BOOST_USE_SHARED=OFF \


In r/inst/build_arrow_static.sh line 75:
    -DARROW_ACERO=${ARROW_ACERO:-ON} \
                  ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_ACERO="${ARROW_ACERO:-ON}" \


In r/inst/build_arrow_static.sh line 78:
    -DARROW_DATASET=${ARROW_DATASET:-ON} \
                    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_DATASET="${ARROW_DATASET:-ON}" \


In r/inst/build_arrow_static.sh line 79:
    -DARROW_DEPENDENCY_SOURCE=${ARROW_DEPENDENCY_SOURCE:-AUTO} \
                              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_DEPENDENCY_SOURCE="${ARROW_DEPENDENCY_SOURCE:-AUTO}" \


In r/inst/build_arrow_static.sh line 80:
    -DARROW_DEPENDENCY_USE_SHARED=${ARROW_DEPENDENCY_USE_SHARED:-ON} \
                                  ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_DEPENDENCY_USE_SHARED="${ARROW_DEPENDENCY_USE_SHARED:-ON}" \


In r/inst/build_arrow_static.sh line 81:
    -DARROW_ENABLE_THREADING=${ARROW_ENABLE_THREADING:-ON} \
                             ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_ENABLE_THREADING="${ARROW_ENABLE_THREADING:-ON}" \


In r/inst/build_arrow_static.sh line 82:
    -DAWSSDK_SOURCE=${AWSSDK_SOURCE:-} \
                    ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DAWSSDK_SOURCE="${AWSSDK_SOURCE:-}" \


In r/inst/build_arrow_static.sh line 83:
    -DBoost_SOURCE=${Boost_SOURCE:-} \
                   ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DBoost_SOURCE="${Boost_SOURCE:-}" \


In r/inst/build_arrow_static.sh line 84:
    -Dlz4_SOURCE=${lz4_SOURCE:-} \
                 ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -Dlz4_SOURCE="${lz4_SOURCE:-}" \


In r/inst/build_arrow_static.sh line 86:
    -DARROW_GCS=${ARROW_GCS:-OFF} \
                ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_GCS="${ARROW_GCS:-OFF}" \


In r/inst/build_arrow_static.sh line 87:
    -DARROW_AZURE=${ARROW_AZURE:-$ARROW_DEFAULT_PARAM} \
                  ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_AZURE="${ARROW_AZURE:-$ARROW_DEFAULT_PARAM}" \


In r/inst/build_arrow_static.sh line 88:
    -DARROW_JEMALLOC=${ARROW_JEMALLOC:-$ARROW_DEFAULT_PARAM} \
                     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_JEMALLOC="${ARROW_JEMALLOC:-$ARROW_DEFAULT_PARAM}" \


In r/inst/build_arrow_static.sh line 89:
    -DARROW_MIMALLOC=${ARROW_MIMALLOC:-ON} \
                     ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_MIMALLOC="${ARROW_MIMALLOC:-ON}" \


In r/inst/build_arrow_static.sh line 90:
    -DARROW_JSON=${ARROW_JSON:-ON} \
                 ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_JSON="${ARROW_JSON:-ON}" \


In r/inst/build_arrow_static.sh line 91:
    -DARROW_PARQUET=${ARROW_PARQUET:-ON} \
                    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_PARQUET="${ARROW_PARQUET:-ON}" \


In r/inst/build_arrow_static.sh line 92:
    -DARROW_S3=${ARROW_S3:-$ARROW_DEFAULT_PARAM} \
               ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_S3="${ARROW_S3:-$ARROW_DEFAULT_PARAM}" \


In r/inst/build_arrow_static.sh line 93:
    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI:-$ARROW_DEFAULT_PARAM} \
                        ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI:-$ARROW_DEFAULT_PARAM}" \


In r/inst/build_arrow_static.sh line 94:
    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2:-$ARROW_DEFAULT_PARAM} \
                     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2:-$ARROW_DEFAULT_PARAM}" \


In r/inst/build_arrow_static.sh line 95:
    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4:-ON} \
                     ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4:-ON}" \


In r/inst/build_arrow_static.sh line 96:
    -DARROW_WITH_RE2=${ARROW_WITH_RE2:-ON} \
                     ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_RE2="${ARROW_WITH_RE2:-ON}" \


In r/inst/build_arrow_static.sh line 97:
    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY:-ON} \
                        ^----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY:-ON}" \


In r/inst/build_arrow_static.sh line 98:
    -DARROW_WITH_UTF8PROC=${ARROW_WITH_UTF8PROC:-ON} \
                          ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_UTF8PROC="${ARROW_WITH_UTF8PROC:-ON}" \


In r/inst/build_arrow_static.sh line 99:
    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB:-$ARROW_DEFAULT_PARAM} \
                      ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB:-$ARROW_DEFAULT_PARAM}" \


In r/inst/build_arrow_static.sh line 100:
    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD:-$ARROW_DEFAULT_PARAM} \
                      ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD:-$ARROW_DEFAULT_PARAM}" \


In r/inst/build_arrow_static.sh line 101:
    -DARROW_VERBOSE_THIRDPARTY_BUILD=${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF} \
                                     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DARROW_VERBOSE_THIRDPARTY_BUILD="${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF}" \


In r/inst/build_arrow_static.sh line 102:
    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} \
                       ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" \


In r/inst/build_arrow_static.sh line 103:
    -DCMAKE_FIND_DEBUG_MODE=${CMAKE_FIND_DEBUG_MODE:-OFF} \
                            ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_FIND_DEBUG_MODE="${CMAKE_FIND_DEBUG_MODE:-OFF}" \


In r/inst/build_arrow_static.sh line 105:
    -DCMAKE_INSTALL_PREFIX=${DEST_DIR} \
                           ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_INSTALL_PREFIX="${DEST_DIR}" \


In r/inst/build_arrow_static.sh line 108:
    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
                        ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \


In r/inst/build_arrow_static.sh line 109:
    -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR} \
                       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR}" \


In r/inst/build_arrow_static.sh line 110:
    -Dabsl_SOURCE=${absl_SOURCE:-BUNDLED} \
                  ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -Dabsl_SOURCE="${absl_SOURCE:-BUNDLED}" \


In r/inst/build_arrow_static.sh line 111:
    -Dre2_SOURCE=${re2_SOURCE:-BUNDLED} \
                 ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -Dre2_SOURCE="${re2_SOURCE:-BUNDLED}" \


In r/inst/build_arrow_static.sh line 112:
    -Dsimdjson_SOURCE=${simdjson_SOURCE:-BUNDLED} \
                      ^-------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -Dsimdjson_SOURCE="${simdjson_SOURCE:-BUNDLED}" \


In r/inst/build_arrow_static.sh line 113:
    -Dxsimd_SOURCE=${xsimd_SOURCE:-} \
                   ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -Dxsimd_SOURCE="${xsimd_SOURCE:-}" \


In r/inst/build_arrow_static.sh line 114:
    -Dzstd_SOURCE=${zstd_SOURCE:-} \
                  ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    -Dzstd_SOURCE="${zstd_SOURCE:-}" \


In r/inst/build_arrow_static.sh line 115:
    ${EXTRA_CMAKE_FLAGS} \
    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${EXTRA_CMAKE_FLAGS}" \


In r/inst/build_arrow_static.sh line 117:
    ${SOURCE_DIR}
    ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${SOURCE_DIR}"


In r/inst/build_arrow_static.sh line 119:
${CMAKE} --build . --target install -- -j $N_JOBS
                                          ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${CMAKE} --build . --target install -- -j "$N_JOBS"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```

### What changes are included in this PR?

* SC2086: Quote variable expansions to prevent globbing and word splitting.
* SC2223: Quote parameter expansion in default assignments to prevent globbing.
* SC2006: Use $(...) notation instead of legacy backticked `...`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50855