### PR TITLE
GH-39660: [R] Document partition value types

### DIFF
--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -57,6 +57,21 @@
 #' you could provide a Schema to specify that "month" should be `int8()`
 #' instead of the `int32()` it will be parsed as by default.
 #'
+#' If a partition value contains meaningful leading zeros, specify its type
+#' explicitly. Otherwise, type inference may interpret a value such as `001`
+#' as the integer `1`. For example, use a string field when opening a
+#' Hive-partitioned dataset whose `product_id` values include leading zeros:
+#'
+#' ```r
+#' ds <- open_dataset(
+#'   "products",
+#'   partitioning = hive_partition(product_id = string())
+#' )
+#' ```
+#'
+#' With this schema, a path such as `product_id=001/part-0.parquet` keeps
+#' `product_id` as the string `"001"` instead of converting it to `1`.
+#'
 #' If your file paths do not appear to be Hive-style, or if you pass
 #' `hive_style = FALSE`, the `partitioning` argument will be used to create
 #' Directory partitioning. A character vector of names is required to create

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -59,18 +59,8 @@
 #'
 #' If a partition value contains meaningful leading zeros, specify its type
 #' explicitly. Otherwise, type inference may interpret a value such as `001`
-#' as the integer `1`. For example, use a string field when opening a
-#' Hive-partitioned dataset whose `product_id` values include leading zeros:
-#'
-#' ```r
-#' ds <- open_dataset(
-#'   "products",
-#'   partitioning = hive_partition(product_id = string())
-#' )
-#' ```
-#'
-#' With this schema, a path such as `product_id=001/part-0.parquet` keeps
-#' `product_id` as the string `"001"` instead of converting it to `1`.
+#' as the integer `1`. See the examples below for a runnable Hive-partitioned
+#' dataset whose `product_id` values include leading zeros.
 #'
 #' If your file paths do not appear to be Hive-style, or if you pass
 #' `hive_style = FALSE`, the `partitioning` argument will be used to create
@@ -186,6 +176,16 @@
 #'
 #' # If you want to specify the data types for your fields, you can pass in a Schema
 #' open_dataset(tf3, partitioning = schema(Month = int8(), Day = int8()))
+#'
+#' # If a partition value contains meaningful leading zeros, specify its type
+#' # explicitly so values such as "001" remain strings instead of becoming 1.
+#' products <- data.frame(x = 1:3, product_id = c("001", "002", "010"))
+#' tf4 <- tempfile()
+#' write_dataset(products, tf4, partitioning = "product_id")
+#' ds <- open_dataset(
+#'   tf4,
+#'   partitioning = hive_partition(product_id = string())
+#' )
 open_dataset <- function(
   sources,
   schema = NULL,

--- a/r/man/open_dataset.Rd
+++ b/r/man/open_dataset.Rd
@@ -153,6 +153,11 @@ it will use the types defined by the Schema. In the example file path above,
 you could provide a Schema to specify that "month" should be \code{int8()}
 instead of the \code{int32()} it will be parsed as by default.
 
+If a partition value contains meaningful leading zeros, specify its type
+explicitly. Otherwise, type inference may interpret a value such as \code{001}
+as the integer \code{1}. See the examples below for a runnable Hive-partitioned
+dataset whose \code{product_id} values include leading zeros.
+
 If your file paths do not appear to be Hive-style, or if you pass
 \code{hive_style = FALSE}, the \code{partitioning} argument will be used to create
 Directory partitioning. A character vector of names is required to create
@@ -206,6 +211,16 @@ open_dataset(tf3, partitioning = c("Month", "Day"))
 
 # If you want to specify the data types for your fields, you can pass in a Schema
 open_dataset(tf3, partitioning = schema(Month = int8(), Day = int8()))
+
+# If a partition value contains meaningful leading zeros, specify its type
+# explicitly so values such as "001" remain strings instead of becoming 1.
+products <- data.frame(x = 1:3, product_id = c("001", "002", "010"))
+tf4 <- tempfile()
+write_dataset(products, tf4, partitioning = "product_id")
+ds <- open_dataset(
+  tf4,
+  partitioning = hive_partition(product_id = string())
+)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -104,6 +104,17 @@ ds <- open_dataset("nyc-taxi", partitioning = c("year", "month"))
 
 Either way, when you look at the Dataset, you can see that in addition to the columns present in every file, there are also columns `year` and `month`. These columns are not present in the files themselves: they are inferred from the partitioning structure.
 
+If a partition value contains meaningful leading zeros, specify its type explicitly. Otherwise, type inference may interpret a value such as `001` as the integer `1`. For example, use a string field when opening a Hive-partitioned dataset whose `product_id` values include leading zeros:
+
+```r
+ds <- open_dataset(
+  "products",
+  partitioning = hive_partition(product_id = string())
+)
+```
+
+With this schema, a path such as `product_id=001/part-0.parquet` keeps `product_id` as the string `"001"` instead of converting it to `1`.
+
 ```{r, eval = file.exists("nyc-taxi")}
 ds
 ```

--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -104,17 +104,6 @@ ds <- open_dataset("nyc-taxi", partitioning = c("year", "month"))
 
 Either way, when you look at the Dataset, you can see that in addition to the columns present in every file, there are also columns `year` and `month`. These columns are not present in the files themselves: they are inferred from the partitioning structure.
 
-If a partition value contains meaningful leading zeros, specify its type explicitly. Otherwise, type inference may interpret a value such as `001` as the integer `1`. For example, use a string field when opening a Hive-partitioned dataset whose `product_id` values include leading zeros:
-
-```r
-ds <- open_dataset(
-  "products",
-  partitioning = hive_partition(product_id = string())
-)
-```
-
-With this schema, a path such as `product_id=001/part-0.parquet` keeps `product_id` as the string `"001"` instead of converting it to `1`.
-
 ```{r, eval = file.exists("nyc-taxi")}
 ds
 ```


### PR DESCRIPTION
## Rationale for this change

Partition values such as `001` can be inferred as integers and lose meaningful leading zeros. The guidance belongs with the `open_dataset()` API documentation, where users look for partitioning and schema controls, rather than in the NYC taxi vignette where the example introduces a separate hypothetical dataset.

## What changes are included in this PR?

- Add the leading-zero partition example to the `open_dataset()` Partitioning documentation.
- Show `hive_partition(product_id = string())` as the explicit schema declaration.
- Remove the duplicated example from the dataset vignette so the vignette stays focused on its existing flow.

## Are these changes tested?

- R parsing of `r/R/dataset.R` passes.
- `git diff --check` passes.
- The change keeps the example in roxygen documentation and does not alter runtime code. A full R package documentation render was not run in this checkout.

## Are there any user-facing changes?

Yes. `?open_dataset` will explain how to preserve leading zeros in Hive partition values, in the API documentation for the argument that controls this behavior.

Closes #39660
* GitHub Issue: #39660