### PR TITLE
MINOR: [C++][Documentation] Update tutorial docs to include parquet linking gotcha

### DIFF
--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -55,6 +55,38 @@ file into an executable linked with the Arrow C++ shared library:
    add_executable(my_example my_example.cc)
    target_link_libraries(my_example PRIVATE Arrow::arrow_shared)
 
+.. _cpp-build-system-linking-parquet:
+
+Linking Parquet
+---------------
+
+The Parquet reader and writer used in the :doc:`tutorials/io_tutorial` and the
+:doc:`tutorials/datasets_tutorial` (the ``parquet::arrow`` namespace, declared in
+``parquet/arrow/reader.h`` and ``parquet/arrow/writer.h``) live in a separate
+library, so linking ``Arrow::arrow_shared`` alone is not enough. Look up the
+Parquet package as well and link its target:
+
+.. code-block:: cmake
+
+   cmake_minimum_required(VERSION 3.25)
+
+   project(MyExample)
+
+   find_package(Arrow REQUIRED)
+   find_package(Parquet REQUIRED)
+
+   add_executable(my_example my_example.cc)
+   target_link_libraries(my_example PRIVATE Arrow::arrow_shared
+                                            Parquet::parquet_shared)
+
+Use ``Parquet::parquet_static`` instead if you are linking the static libraries.
+
+The same applies to other Arrow components: each one is a separate package with
+its own target, as described in `Other available packages`_ below. For example,
+the dataset API used in the :doc:`tutorials/datasets_tutorial` requires
+``find_package(ArrowDataset REQUIRED)`` and
+``ArrowDataset::arrow_dataset_shared``.
+
 Available variables and targets
 -------------------------------
 

--- a/docs/source/cpp/tutorials/datasets_tutorial.rst
+++ b/docs/source/cpp/tutorials/datasets_tutorial.rst
@@ -66,6 +66,15 @@ compute functionality for each file type we'll work with in this article:
   :start-after: (Doc section: Includes)
   :end-before: (Doc section: Includes)
 
+.. note::
+   The dataset and Parquet headers come from libraries separate from ``arrow``,
+   so linking ``Arrow::arrow_shared`` alone is not enough to build this example.
+   Your ``CMakeLists.txt`` needs ``find_package(ArrowDataset REQUIRED)`` and
+   ``find_package(Parquet REQUIRED)``, linking both the
+   ``ArrowDataset::arrow_dataset_shared`` and ``Parquet::parquet_shared``
+   targets. See :ref:`cpp-build-system-linking-parquet` for a complete
+   ``CMakeLists.txt``.
+
 Main()
 ^^^^^^
 

--- a/docs/source/cpp/tutorials/datasets_tutorial.rst
+++ b/docs/source/cpp/tutorials/datasets_tutorial.rst
@@ -69,11 +69,11 @@ compute functionality for each file type we'll work with in this article:
 .. note::
    The dataset and Parquet headers come from libraries separate from ``arrow``,
    so linking ``Arrow::arrow_shared`` alone is not enough to build this example.
-   Your ``CMakeLists.txt`` needs ``find_package(ArrowDataset REQUIRED)`` and
-   ``find_package(Parquet REQUIRED)``, linking both the
-   ``ArrowDataset::arrow_dataset_shared`` and ``Parquet::parquet_shared``
-   targets. See :ref:`cpp-build-system-linking-parquet` for a complete
-   ``CMakeLists.txt``.
+   Your ``CMakeLists.txt`` needs ``find_package(Arrow REQUIRED)``,
+   ``find_package(ArrowDataset REQUIRED)``, and ``find_package(Parquet REQUIRED)``,
+   linking ``Arrow::arrow_shared`` plus ``ArrowDataset::arrow_dataset_shared`` and
+   ``Parquet::parquet_shared``. See :ref:`cpp-build-system-linking-parquet` for a
+   complete ``CMakeLists.txt``.
 
 Main()
 ^^^^^^

--- a/docs/source/cpp/tutorials/io_tutorial.rst
+++ b/docs/source/cpp/tutorials/io_tutorial.rst
@@ -66,6 +66,13 @@ I/O functionality for each file type we'll work with in this article:
   :start-after: (Doc section: Includes)
   :end-before: (Doc section: Includes)
 
+.. note::
+   The Parquet headers come from a library separate from ``arrow``, so linking
+   ``Arrow::arrow_shared`` alone is not enough to build this example. Your
+   ``CMakeLists.txt`` needs ``find_package(Parquet REQUIRED)`` and the
+   ``Parquet::parquet_shared`` target as well. See
+   :ref:`cpp-build-system-linking-parquet` for a complete ``CMakeLists.txt``.
+
 Main()
 ^^^^^^
 


### PR DESCRIPTION
I was running in to an issue that ended up being solved by: https://github.com/apache/arrow/issues/42730

That being said, it would probably be good for novices to parquet and arrow C++ such as myself to have some explicit documentation as part of the tutorial.
