### PR TITLE
GH-31464: [C++][Python] Fix string filters with empty value sets

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -222,6 +222,8 @@ struct InitStateVisitor {
             ty1, " and ", ty2);
       }
     } else if ((arg_type.id() == Type::STRING || arg_type.id() == Type::LARGE_STRING) &&
+               !(options.value_set.type()->id() == Type::NA &&
+                 options.value_set.length() == 0) &&
                !is_base_binary_like(options.value_set.type()->id())) {
       // This is a bit of a hack, but don't implicitly cast from a non-binary
       // type to string, since most types support casting to string and that

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -203,6 +203,12 @@ TEST_F(TestIsInKernel, ImplicitlyCastValueSet) {
             ArrayFromJSON(utf8(), R"(["aaa", "bbb"])"),
             "[true, true, false, false, true]");
 
+  // An empty null value set can be safely cast to the input string type.
+  CheckIsIn(ArrayFromJSON(utf8(), R"(["aaa", "bbb"])"), ArrayFromJSON(null(), "[]"),
+            "[false, false]");
+  CheckIsIn(ArrayFromJSON(large_utf8(), R"(["aaa", "bbb"])"), ArrayFromJSON(null(), "[]"),
+            "[false, false]");
+
   // But explicitly deny implicit casts from non-binary to utf8 to
   // avoid surprises
   ASSERT_RAISES(TypeError,
@@ -1455,6 +1461,13 @@ TEST_F(TestIndexInKernel, ImplicitlyCastValueSet) {
                ArrayFromJSON(large_utf8(), R"(["aaa", "bbb"])"), "[0, 1, null, null, 1]");
   CheckIndexIn(ArrayFromJSON(large_utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
                ArrayFromJSON(utf8(), R"(["aaa", "bbb"])"), "[0, 1, null, null, 1]");
+
+  // An empty null value set can be safely cast to the input string type.
+  CheckIndexIn(ArrayFromJSON(utf8(), R"(["aaa", "bbb"])"), ArrayFromJSON(null(), "[]"),
+               "[null, null]");
+  CheckIndexIn(ArrayFromJSON(large_utf8(), R"(["aaa", "bbb"])"),
+               ArrayFromJSON(null(), "[]"), "[null, null]");
+
   // But explicitly deny implicit casts from non-binary to utf8 to
   // avoid surprises
   ASSERT_RAISES(TypeError,

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1730,6 +1730,17 @@ def test_filter_table():
         assert result.equals(expected_null)
 
 
+@pytest.mark.parametrize("dictionary_encode", [False, True],
+                         ids=["string", "dictionary-string"])
+def test_filter_table_expression_empty_set(dictionary_encode):
+    values = pa.array(["a", "b"])
+    if dictionary_encode:
+        values = values.dictionary_encode()
+
+    table = pa.table({"a": values})
+    assert table.filter(pc.field("a").isin([])).equals(table.slice(0, 0))
+
+
 def test_filter_errors():
     arr = pa.chunked_array([["a", None], ["c", "d", "e"]])
     batch = pa.record_batch(


### PR DESCRIPTION
### Rationale for this change

`field.isin([])` creates an empty null-typed value set. String inputs currently fail the string-specific type check before that empty set can be safely cast, so filtering string and dictionary-encoded string columns raises `ArrowTypeError` instead of returning no rows.

### What changes are included in this PR?

Allow only zero-length null-typed value sets through the string type check so the existing safe-cast path can handle them. The existing rejection of non-empty non-binary value sets is preserved.

Add C++ coverage for `is_in` and `index_in` with `string` and `large_string`, and Python coverage for string and dictionary-encoded string table filters.

### Are these changes tested?

Yes:

- Reproduced on `pyarrow 26.0.0.dev131`: string and dictionary-string filters raised the reported type error.
- Full `arrow-compute-scalar-utility-test`: 95 passed.
- Focused PyArrow compute tests: 4 passed.
- C++ format/lint and Python format/lint hooks for the changed files: passed.
- `git diff --check`: passed.

### Are there any user-facing changes?

Yes. Filtering string or dictionary-encoded string data with an empty set now returns an empty result instead of raising `ArrowTypeError`. There is no public API change.

### AI usage

OpenAI Codex assisted with reproducing the issue, tracing the type check, and drafting the patch, tests, and PR description. This draft remains pending my line-by-line review; I will only mark it ready after I understand and verify every change.

* GitHub Issue: #31464