### PR TITLE
GH-50623: [C++][Python] Fix IPC serialization for extension storage layouts

### DIFF
--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -410,6 +410,40 @@ class ExtensionTypesMixin {
   ExtensionTypeGuard ext_guard_;
 };
 
+class IpcStorageExtensionType : public ExtensionType {
+ public:
+  IpcStorageExtensionType(std::shared_ptr<DataType> storage_type,
+                          std::string extension_name)
+      : ExtensionType(std::move(storage_type)),
+        extension_name_(std::move(extension_name)) {}
+
+  std::string extension_name() const override { return extension_name_; }
+
+  bool ExtensionEquals(const ExtensionType& other) const override {
+    return extension_name_ == other.extension_name() &&
+           storage_type()->Equals(*other.storage_type());
+  }
+
+  std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override {
+    return std::make_shared<ExtensionArray>(std::move(data));
+  }
+
+  Result<std::shared_ptr<DataType>> Deserialize(
+      std::shared_ptr<DataType> storage_type,
+      const std::string& serialized_data) const override {
+    if (serialized_data != extension_name_) {
+      return Status::Invalid("Unexpected extension metadata: ", serialized_data);
+    }
+    return std::make_shared<IpcStorageExtensionType>(std::move(storage_type),
+                                                     extension_name_);
+  }
+
+  std::string Serialize() const override { return extension_name_; }
+
+ private:
+  std::string extension_name_;
+};
+
 class IpcTestFixture : public io::MemoryMapFixture, public ExtensionTypesMixin {
  public:
   void SetUp() {
@@ -693,6 +727,39 @@ TEST_P(TestIpcRoundTrip, ZeroLengthArrays) {
 
   CheckRoundtrip(bin_array);
   CheckRoundtrip(bin_array2);
+}
+
+TEST_F(TestIpcRoundTrip, ExtensionWithUnionStorage) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeUnion(&batch));
+
+  for (int i = 0; i < batch->num_columns(); ++i) {
+    auto extension_type = std::make_shared<IpcStorageExtensionType>(
+        batch->column(i)->type(), "ipc.union." + std::to_string(i));
+    ExtensionTypeGuard extension_guard(extension_type);
+    for (const auto version : kMetadataVersions) {
+      options_.metadata_version = version;
+      CheckRoundtrip(ExtensionType::WrapArray(extension_type, batch->column(i)),
+                     options_);
+    }
+  }
+}
+
+TEST_F(TestIpcRoundTrip, ExtensionWithNullStorage) {
+  auto extension_type = std::make_shared<IpcStorageExtensionType>(null(), "ipc.null");
+  ExtensionTypeGuard extension_guard(extension_type);
+
+  auto extension =
+      ExtensionType::WrapArray(extension_type, std::make_shared<NullArray>(3));
+  auto values = ArrayFromJSON(int64(), "[1, 2, 3]");
+  auto batch = RecordBatch::Make(
+      schema({field("extension", extension_type), field("values", int64())}), 3,
+      {extension, values});
+
+  for (const auto version : kMetadataVersions) {
+    options_.metadata_version = version;
+    CheckRoundtrip(*batch, options_);
+  }
 }
 
 TEST_F(TestIpcRoundTrip, SparseUnionOfStructsWithReusedBuffers) {

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -164,7 +164,9 @@ class RecordBatchSerializer {
 
     // In V4, null types have no validity bitmap
     // In V5 and later, null and union types have no validity bitmap
-    if (internal::HasValidityBitmap(arr.type_id(), options_.metadata_version)) {
+    // Extension arrays use the physical layout of their storage type.
+    if (internal::HasValidityBitmap(arr.type()->storage_id(),
+                                    options_.metadata_version)) {
       if (arr.null_count() > 0) {
         std::shared_ptr<Buffer> bitmap;
         RETURN_NOT_OK(GetTruncatedBitmap(arr.offset(), arr.length(), arr.null_bitmap(),


### PR DESCRIPTION
### Rationale for this change

The IPC writer selected the top-level validity-buffer layout from the logical extension type. Extension arrays backed by null or union storage therefore received an extra validity-buffer entry, while the reader reconstructed the physical storage layout without that entry. The resulting buffer shift produced invalid data and could lead to a crash when values were accessed.

Fixes #50623.
Fixes #15068.

### What changes are included in this PR?

- Select the IPC validity-buffer layout from `DataType::storage_id()`, which is unchanged for ordinary Arrow types and resolves to the physical type for extensions.
- Add roundtrip regressions for extension arrays backed by dense union, sparse union, and null storage.
- Exercise both IPC metadata versions V4 and V5. The null-storage test includes an adjacent `int64` column so a shifted buffer is detected directly.

### Are these changes tested?

- On unpatched current `main`, both new regressions failed with `Buffer #1 too small` validation errors.
- Focused patched regressions: 2/2 passed.
- Full `arrow-ipc-read-write-test`: 412/412 passed with the official `arrow-testing` data.
- `clang-format` 20.1.8 dry run and `git diff --check`: passed.

### Are there any user-facing changes?

Yes. IPC file and stream roundtrips for extension types with null or union storage now preserve valid buffer layouts. There is no public API or ABI change.

**This PR contains a Critical Fix.** It prevents the IPC writer from producing invalid data for valid extension arrays and addresses the crash path described in #50623.

### AI-assisted contribution disclosure

OpenAI Codex generated the patch and regression tests under the account owner authorization. Codex reproduced the issue on current `main`, reviewed the complete diff, audited visible ownership and overlap, and ran the validation listed above. This PR remains a Draft pending the account owner personal review before it is marked ready.
* GitHub Issue: #50623