### PR TITLE
GH-50897: [Python] Fix typo LZ0 -> LZO in ORC writer docstring

### DIFF
--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -200,7 +200,7 @@ stripe_size : int, default 64 * 1024 * 1024
 compression : string, default 'uncompressed'
     The compression codec.
     Valid values: {'UNCOMPRESSED', 'SNAPPY', 'ZLIB', 'LZ4', 'ZSTD'}
-    Note that LZ0 is currently not supported.
+    Note that LZO is currently not supported.
 compression_block_size : int, default 64 * 1024
     Size of each compression block in bytes.
 compression_strategy : string, default 'speed'


### PR DESCRIPTION
### Rationale for this change

Fix a typo in the ORC writer `compression` docstring where `LZ0` was incorrectly written instead of `LZO`.

### What changes are included in this PR?

Change `LZ0` to `LZO` in the `python/pyarrow/orc.py` documentation.

### Are these changes tested?

Documentation-only change; no code behavior is affected.

### Are there any user-facing changes?

No

* GitHub Issue: #50897