### PR TITLE
GH-50859: [C++] Build JsonWriter when Parquet is enabled without JSON

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -1070,6 +1070,18 @@ else()
   set(ARROW_IPC_TARGET_STATIC)
 endif()
 
+# Parquet (LogicalType::ToJSON, encryption, geospatial) calls JsonWriter
+# even when ARROW_JSON=OFF. Keep the writer in its own object library.
+if(ARROW_JSON OR ARROW_PARQUET)
+  arrow_add_object_library(ARROW_JSON_WRITER json/json_writer_internal.cc)
+  foreach(ARROW_JSON_WRITER_TARGET ${ARROW_JSON_WRITER_TARGETS})
+    target_link_libraries(${ARROW_JSON_WRITER_TARGET} PRIVATE arrow::simdjson)
+  endforeach()
+else()
+  set(ARROW_JSON_WRITER_TARGET_SHARED)
+  set(ARROW_JSON_WRITER_TARGET_STATIC)
+endif()
+
 if(ARROW_JSON)
   arrow_add_object_library(ARROW_JSON
                            extension/fixed_shape_tensor.cc
@@ -1081,7 +1093,6 @@ if(ARROW_JSON)
                            json/chunker.cc
                            json/converter.cc
                            json/from_string.cc
-                           json/json_writer_internal.cc
                            json/object_parser.cc
                            json/parser.cc
                            json/reader.cc)
@@ -1195,6 +1206,7 @@ add_arrow_lib(arrow
               ${ARROW_IO_TARGET_SHARED}
               ${ARROW_IPC_TARGET_SHARED}
               ${ARROW_JSON_TARGET_SHARED}
+              ${ARROW_JSON_WRITER_TARGET_SHARED}
               ${ARROW_MEMORY_POOL_TARGET_SHARED}
               ${ARROW_ORC_TARGET_SHARED}
               ${ARROW_TELEMETRY_TARGET_SHARED}
@@ -1211,6 +1223,7 @@ add_arrow_lib(arrow
               ${ARROW_IO_TARGET_STATIC}
               ${ARROW_IPC_TARGET_STATIC}
               ${ARROW_JSON_TARGET_STATIC}
+              ${ARROW_JSON_WRITER_TARGET_STATIC}
               ${ARROW_MEMORY_POOL_TARGET_STATIC}
               ${ARROW_ORC_TARGET_STATIC}
               ${ARROW_TELEMETRY_TARGET_STATIC}


### PR DESCRIPTION
### Rationale for this change

#50859: with `ARROW_JSON=OFF`, parquet tools fail to link:

`undefined reference to arrow::json::JsonWriter::GetString() const`

`json_writer_internal.cc` was only compiled into the `ARROW_JSON` object library. Parquet still calls `JsonWriter` from `types.cc`, encryption, and geospatial helpers. `ARROW_PARQUET` already pulls in simdjson, so the writer can live outside the JSON feature flag.

### What changes are included in this PR?

Move `json/json_writer_internal.cc` into a small `ARROW_JSON_WRITER` object library, built when `ARROW_JSON` or `ARROW_PARQUET` is on, and link it into libarrow.

### Are these changes tested?

I did not run a full `ARROW_JSON=OFF` + Parquet extra build on this machine. The failure is a missing object in libarrow; Arrow CI (including jobs that set `ARROW_JSON=OFF`) is the check I am relying on.

### Are there any user-facing changes?

No.

* GitHub Issue: #50859