### PR TITLE
GH-50865: [Release][CI] Install conda-gcc-specs for Linux Conda builds

### DIFF
--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -34,6 +34,7 @@ RUN mamba install -q -y \
         --file arrow/ci/conda_env_cpp.txt \
         --file arrow/ci/conda_env_gandiva.txt \
         compilers \
+        conda-gcc-specs \
         doxygen \
         libnuma \
         mold \

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -37,6 +37,7 @@ RUN mamba install -q -y \
         "python < 3.12" \
         numpy \
         compilers \
+        conda-gcc-specs \
         go \
         maven=${maven} \
         nodejs=${node} \

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -443,12 +443,6 @@ maybe_setup_virtualenv() {
 test_and_install_cpp() {
   show_header "Build, install and test C++ libraries"
 
-  # Ensure GCC uses libraries and headers from the Conda env
-  local conda_gcc_specs=()
-  if [ "$(uname)" = "Linux" ]; then
-    conda_gcc_specs=(conda-gcc-specs)
-  fi
-
   # Build and test C++
   maybe_setup_virtualenv numpy
   maybe_setup_conda \
@@ -458,8 +452,7 @@ test_and_install_cpp() {
     ncurses \
     numpy \
     sqlite \
-    compilers \
-    "${conda_gcc_specs[@]}"
+    compilers
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     DEFAULT_DEPENDENCY_SOURCE="CONDA"

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -443,6 +443,12 @@ maybe_setup_virtualenv() {
 test_and_install_cpp() {
   show_header "Build, install and test C++ libraries"
 
+  # Ensure GCC uses libraries and headers from the Conda env
+  local conda_gcc_specs=()
+  if [ "$(uname)" = "Linux" ]; then
+    conda_gcc_specs=(conda-gcc-specs)
+  fi
+
   # Build and test C++
   maybe_setup_virtualenv numpy
   maybe_setup_conda \
@@ -452,7 +458,8 @@ test_and_install_cpp() {
     ncurses \
     numpy \
     sqlite \
-    compilers
+    compilers \
+    "${conda_gcc_specs[@]}"
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     DEFAULT_DEPENDENCY_SOURCE="CONDA"


### PR DESCRIPTION
### Rationale for this change
Fix #50865
With conda-forge `compilers 2.0` builds started failing at linking various C++ executables in Linux release verification (jobs `verify-rc-source-{cpp/integration/python/ruby}-linux-conda-latest-amd64`) and Conda C++ CI (jobs `test-conda-cpp`, `test-conda-python-3.11-hdfs-{2.9.2/3.2.1}`).

From Aug 14 - Aug 19 `conda-forge` dependencies resolved as:
`compilers 2.0` -> `cxx-compiler 2.0 hdab9b82_0` -> `gxx 15.3.0 hd47ba16_1`
-> `gcc 15.3.0 hb7a6aa6_1` -> depends only on `gcc_impl_linux-64`, so missing `conda-gcc-specs`.
`gxx` build pinned no-specs GCC variant, and even though specs GCC variant existed didn't get selected.
This specs vs. no-specs got [fixed upstream in ctng-compilers-feedstock #224](https://github.com/conda-forge/ctng-compilers-feedstock/pull/224)

### What changes are included in this PR?
Instead of indirect dependency, explicitly install `conda-gcc-specs` for Linux 
in `verify-release-candidate.sh`,
in `conda-cpp.dockerfile`, in `conda-integration.dockerfile`.

### Are these changes tested?
Yes, locally, and affected CI jobs also build successfully now.

### Are there any user-facing changes?
No.

* GitHub Issue: #50865