### PR TITLE
GH-50904: [C++] Replace RapidJSON with simdjson in OpaqueType

### DIFF
--- a/cpp/src/arrow/extension/opaque.cc
+++ b/cpp/src/arrow/extension/opaque.cc
@@ -66,18 +66,14 @@ Result<std::shared_ptr<DataType>> OpaqueType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized_data) const {
   simdjson::padded_string padded_json(serialized_data);
   simdjson::ondemand::parser parser;
-  simdjson::ondemand::document document;
 
-  if (auto error = parser.iterate(padded_json).get(document);
-      error != simdjson::SUCCESS) {
-    return Status::Invalid("Invalid serialized JSON data for OpaqueType: ",
-                           serialized_data);
-  }
+  ARROW_ASSIGN_OR_RAISE(auto document,
+                        internal::ResolveSimdjsonResult(parser.iterate(padded_json),
+                                                        "Failed to parse JSON"));
 
-  simdjson::ondemand::object object;
-  if (auto error = document.get_object().get(object); error != simdjson::SUCCESS) {
-    return Status::Invalid("Invalid serialized JSON data for OpaqueType: not an object");
-  }
+  ARROW_ASSIGN_OR_RAISE(auto object,
+                        internal::ResolveSimdjsonResult(document.get_object(),
+                                                        "Failed to get JSON object"));
 
   std::string type_name;
   std::string vendor_name;

--- a/cpp/src/arrow/extension/opaque.cc
+++ b/cpp/src/arrow/extension/opaque.cc
@@ -20,11 +20,10 @@
 #include <sstream>
 
 #include "arrow/json/json_writer_internal.h"
-#include "arrow/json/rapidjson_defs.h"  // IWYU pragma: keep
 #include "arrow/util/logging_internal.h"
+#include "arrow/util/simdjson_internal.h"
 
-#include <rapidjson/document.h>
-#include <rapidjson/error/en.h>
+#include <simdjson.h>
 
 using ::arrow::json::JsonWriter;
 
@@ -65,34 +64,83 @@ std::string OpaqueType::Serialize() const {
 
 Result<std::shared_ptr<DataType>> OpaqueType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized_data) const {
-  rapidjson::Document document;
-  const auto& parsed = document.Parse(serialized_data.data(), serialized_data.length());
-  if (parsed.HasParseError()) {
+  simdjson::padded_string padded_json(serialized_data);
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document document;
+
+  if (auto error = parser.iterate(padded_json).get(document);
+      error != simdjson::SUCCESS) {
     return Status::Invalid("Invalid serialized JSON data for OpaqueType: ",
-                           rapidjson::GetParseError_En(parsed.GetParseError()), ": ",
                            serialized_data);
-  } else if (!document.IsObject()) {
+  }
+
+  simdjson::ondemand::object object;
+  if (auto error = document.get_object().get(object); error != simdjson::SUCCESS) {
     return Status::Invalid("Invalid serialized JSON data for OpaqueType: not an object");
   }
-  if (!document.HasMember("type_name")) {
+
+  std::string type_name;
+  std::string vendor_name;
+  bool has_type_name = false;
+  bool has_vendor_name = false;
+
+  for (auto field_result : object) {
+    ARROW_ASSIGN_OR_RAISE(auto field, internal::ResolveSimdjsonResult(
+                                          field_result, "Failed to iterate JSON object"));
+
+    ARROW_ASSIGN_OR_RAISE(
+        auto key, internal::ResolveSimdjsonResult(field.unescaped_key(),
+                                                  "Failed to get JSON object key"));
+
+    auto value = field.value();
+
+    if (key == "type_name") {
+      has_type_name = true;
+
+      ARROW_ASSIGN_OR_RAISE(auto type,
+                            internal::ResolveSimdjsonResult(
+                                value.type(), "Failed to determine type_name JSON type"));
+
+      if (type != simdjson::ondemand::json_type::string) {
+        return Status::Invalid(
+            "Invalid serialized JSON data for OpaqueType: type_name is not a string");
+      }
+
+      ARROW_ASSIGN_OR_RAISE(
+          auto name,
+          internal::ResolveSimdjsonResult(value.get_string(), "Failed to get type_name"));
+      type_name = std::string(name);
+
+    } else if (key == "vendor_name") {
+      has_vendor_name = true;
+
+      ARROW_ASSIGN_OR_RAISE(
+          auto type, internal::ResolveSimdjsonResult(
+                         value.type(), "Failed to determine vendor_name JSON type"));
+
+      if (type != simdjson::ondemand::json_type::string) {
+        return Status::Invalid(
+            "Invalid serialized JSON data for OpaqueType: vendor_name is not a string");
+      }
+
+      ARROW_ASSIGN_OR_RAISE(auto name,
+                            internal::ResolveSimdjsonResult(value.get_string(),
+                                                            "Failed to get vendor_name"));
+      vendor_name = std::string(name);
+    }
+  }
+
+  if (!has_type_name) {
     return Status::Invalid(
         "Invalid serialized JSON data for OpaqueType: missing type_name");
-  } else if (!document.HasMember("vendor_name")) {
+  }
+
+  if (!has_vendor_name) {
     return Status::Invalid(
         "Invalid serialized JSON data for OpaqueType: missing vendor_name");
   }
 
-  const auto& type_name = document["type_name"];
-  const auto& vendor_name = document["vendor_name"];
-  if (!type_name.IsString()) {
-    return Status::Invalid(
-        "Invalid serialized JSON data for OpaqueType: type_name is not a string");
-  } else if (!vendor_name.IsString()) {
-    return Status::Invalid(
-        "Invalid serialized JSON data for OpaqueType: vendor_name is not a string");
-  }
-
-  return opaque(std::move(storage_type), type_name.GetString(), vendor_name.GetString());
+  return opaque(std::move(storage_type), std::move(type_name), std::move(vendor_name));
 }
 
 std::shared_ptr<Array> OpaqueType::MakeArray(std::shared_ptr<ArrayData> data) const {

--- a/cpp/src/arrow/extension/opaque_test.cc
+++ b/cpp/src/arrow/extension/opaque_test.cc
@@ -127,11 +127,12 @@ TEST(OpaqueType, Deserialize) {
 
   auto type = internal::checked_pointer_cast<extension::OpaqueType>(
       extension::opaque(null(), "type", "vendor"));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("The document is empty"),
-                                  type->Deserialize(null(), R"()"));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
-                                  testing::HasSubstr("Missing a name for object member"),
-                                  type->Deserialize(null(), R"({)"));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("Invalid serialized JSON data for OpaqueType"),
+      type->Deserialize(null(), R"()"));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, testing::HasSubstr("Invalid serialized JSON data for OpaqueType"),
+      type->Deserialize(null(), R"({)"));
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("not an object"),
                                   type->Deserialize(null(), R"([])"));
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("missing type_name"),

--- a/cpp/src/arrow/extension/opaque_test.cc
+++ b/cpp/src/arrow/extension/opaque_test.cc
@@ -127,13 +127,13 @@ TEST(OpaqueType, Deserialize) {
 
   auto type = internal::checked_pointer_cast<extension::OpaqueType>(
       extension::opaque(null(), "type", "vendor"));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, testing::HasSubstr("Invalid serialized JSON data for OpaqueType"),
-      type->Deserialize(null(), R"()"));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, testing::HasSubstr("Invalid serialized JSON data for OpaqueType"),
-      type->Deserialize(null(), R"({)"));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("not an object"),
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("Failed to parse JSON"),
+                                  type->Deserialize(null(), R"()"));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                  testing::HasSubstr("Failed to get JSON object"),
+                                  type->Deserialize(null(), R"({)"));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                  testing::HasSubstr("Failed to get JSON object"),
                                   type->Deserialize(null(), R"([])"));
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("missing type_name"),
                                   type->Deserialize(null(), R"({})"));


### PR DESCRIPTION
### Rationale for this change

This PR continues the simdjson migration by replacing the remaining RapidJSON usage in `OpaqueType` under `cpp/src/arrow/extension` with the existing simdjson helpers and On-Demand API.

The existing deserialization validation and behavior are preserved, with tests updated for parser-specific error messages.

### Changes

- Replace RapidJSON parsing in `OpaqueType::Deserialize()` with simdjson.
- Use the existing `ResolveSimdjsonResult()` helper.
- Remove the RapidJSON dependency from `opaque.cc`.
- Update OpaqueType deserialization tests for simdjson parsing errors.

* GitHub Issue: #50904