### PR TITLE
GH-50906: [Python] Reshape 1D tensors to 2D in SparseCSR/CSC matrix conversion

### DIFF
--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -840,6 +840,9 @@ shape: {self.shape}"""
         if not isinstance(obj, (scipy.sparse.csr_array, scipy.sparse.csr_matrix)):
             raise TypeError(
                 f"Expected scipy.sparse.csr_array or scipy.sparse.csr_matrix, got {type(obj)}")
+        if obj.ndim != 2:
+            raise ValueError("Expected 2-dimensional sparse input for "
+                             "SparseCSRMatrix")
 
         cdef shared_ptr[CSparseCSRMatrix] csparse_tensor
         cdef vector[int64_t] c_shape
@@ -1111,6 +1114,9 @@ shape: {self.shape}"""
         if not isinstance(obj, (scipy.sparse.csc_array, scipy.sparse.csc_matrix)):
             raise TypeError(
                 f"Expected scipy.sparse.csc_array or scipy.sparse.csc_matrix, got {type(obj)}")
+        if obj.ndim != 2:
+            raise ValueError("Expected 2-dimensional sparse input for "
+                             "SparseCSCMatrix")
 
         cdef shared_ptr[CSparseCSCMatrix] csparse_tensor
         cdef vector[int64_t] c_shape

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -26,10 +26,13 @@ except ImportError:
 import pyarrow as pa
 
 try:
-    from scipy.sparse import csr_array, coo_array, csr_matrix, coo_matrix
+    from scipy.sparse import (
+        csr_array, coo_array, csr_matrix, csc_matrix, coo_matrix
+    )
 except ImportError:
     coo_matrix = None
     csr_matrix = None
+    csc_matrix = None
     csr_array = None
     coo_array = None
 
@@ -252,6 +255,24 @@ def test_sparse_csr_matrix_from_dense(dtype_str, arrow_type):
     assert np.array_equal(data, result_data)
     assert np.array_equal(indptr, result_indptr)
     assert np.array_equal(indices, result_indices)
+
+
+@pytest.mark.skipif(not csr_matrix, reason="requires scipy")
+@pytest.mark.parametrize('pa_class,sc_class', [
+    pytest.param(pa.SparseCSRMatrix, csr_matrix, id='CSR'),
+    pytest.param(pa.SparseCSCMatrix, csc_matrix, id='CSC'),
+])
+def test_sparse_csx_matrix_from_1d(pa_class, sc_class):
+    array = np.array([1, 0, 2, 0, 0, 3, 0, 4], dtype=np.int64)
+
+    # csr_matrix/csc_matrix normalize 1D input to (1, n)
+    scipy_matrix = sc_class(array)
+
+    # Test from 1D scipy matrix
+    sparse_tensor = pa_class.from_scipy(scipy_matrix)
+    assert np.array_equal(
+        sparse_tensor.to_tensor().to_numpy(), scipy_matrix.toarray()
+    )
 
 
 @pytest.mark.parametrize('dtype_str,arrow_type', tensor_type_pairs)


### PR DESCRIPTION
### Rationale for this change

`SparseCSRMatrix` and `SparseCSCMatrix` represent 2-dimensional sparse matrices. In the current codebase, passing a 1D SciPy sparse array (such as `scipy.sparse.csr_array([1, 0, 2])` with `ndim == 1`) to `SparseCSRMatrix.from_scipy` or `SparseCSCMatrix.from_scipy` silently creates a 1D `SparseCSRMatrix` with shape `(n,)` without dimension validation.

This PR adds explicit 2D dimension checks to `from_scipy` in `SparseCSRMatrix` and `SparseCSCMatrix` to raise a `ValueError` for non-2D sparse objects, while ensuring legacy `csr_matrix` / `csc_matrix` objects (which normalize 1D input to `(1, n)`) continue to work and are tested.

### What changes are included in this PR?

- **`python/pyarrow/tensor.pxi`**: Added `if obj.ndim != 2:` validation in `SparseCSRMatrix.from_scipy` and `SparseCSCMatrix.from_scipy` to raise `ValueError("Expected 2-dimensional sparse input for ...")`.
- **`python/pyarrow/tests/test_sparse_tensor.py`**: Added a parametric unit test `test_sparse_csx_matrix_from_1d` verifying that 1D vector input passed via `csr_matrix` / `csc_matrix` produces the expected `(1, n)` 2D sparse matrix via `from_scipy`.

### Are these changes tested?

Yes, tested by the new parametric unit test `test_sparse_csx_matrix_from_1d` in `python/pyarrow/tests/test_sparse_tensor.py`.

### Are there any user-facing changes?

Yes. `SparseCSRMatrix.from_scipy` and `SparseCSCMatrix.from_scipy` now explicitly raise `ValueError` if passed a 1D sparse array instead of silently creating an invalid 1D sparse matrix.

* GitHub Issue: #50906