### PR TITLE
GH-50911: [C++][FlightSQL][ODBC] Replace RapidJSON with JsonWriter

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/CMakeLists.txt
@@ -134,7 +134,10 @@ if(WIN32)
   find_package(ODBC REQUIRED)
   target_include_directories(arrow_odbc_spi_impl PUBLIC ${ODBC_INCLUDE_DIR})
   target_link_libraries(arrow_odbc_spi_impl
-                        PUBLIC arrow_flight_sql_shared arrow_compute_shared Boost::locale
+                        PUBLIC arrow_flight_sql_shared
+                               arrow_compute_shared
+                               Boost::locale
+                               arrow::simdjson
                                ${ODBCINST})
 else()
   # Unix
@@ -144,7 +147,7 @@ else()
                                arrow_compute_static
                                Boost::locale
                                Boost::headers
-                               RapidJSON)
+                               arrow::simdjson)
 
   if(NOT APPLE)
     # Explicitly link to unix-odbc on Linux

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/json_converter.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/json_converter.cc
@@ -17,11 +17,10 @@
 
 #include "arrow/flight/sql/odbc/odbc_impl/json_converter.h"
 
-#include <rapidjson/rapidjson.h>
-#include <rapidjson/writer.h>
 #include <boost/beast/core/detail/base64.hpp>
 #include "arrow/builder.h"
 #include "arrow/flight/sql/odbc/odbc_impl/util.h"
+#include "arrow/json/json_writer_internal.h"
 #include "arrow/scalar.h"
 #include "arrow/visitor.h"
 
@@ -31,32 +30,31 @@ namespace base64 = boost::beast::detail::base64;
 
 namespace arrow::flight::sql::odbc {
 
+using ::arrow::json::JsonWriter;
 using util::ThrowIfNotOK;
 
 namespace {
 template <typename ScalarT>
-Status ConvertScalarToStringAndWrite(const ScalarT& scalar,
-                                     rapidjson::Writer<rapidjson::StringBuffer>& writer) {
+Status ConvertScalarToStringAndWrite(const ScalarT& scalar, JsonWriter& writer) {
   ARROW_ASSIGN_OR_RAISE(auto string_scalar, scalar.CastTo(arrow::utf8()))
   const auto& view = reinterpret_cast<StringScalar*>(string_scalar.get())->view();
-  writer.String(view.data(), static_cast<rapidjson::SizeType>(view.length()), true);
+  writer.String(view);
   return Status::OK();
 }
 
 template <typename BinaryScalarT>
-Status ConvertBinaryToBase64StringAndWrite(
-    const BinaryScalarT& scalar, rapidjson::Writer<rapidjson::StringBuffer>& writer) {
+Status ConvertBinaryToBase64StringAndWrite(const BinaryScalarT& scalar,
+                                           JsonWriter& writer) {
   const auto& view = scalar.view();
   size_t encoded_size = base64::encoded_size(view.length());
   std::vector<char> encoded(std::max(encoded_size, static_cast<size_t>(1)));
   base64::encode(&encoded[0], view.data(), view.length());
-  writer.String(&encoded[0], static_cast<rapidjson::SizeType>(encoded_size), true);
+  writer.String(std::string_view(encoded.data(), encoded_size));
   return Status::OK();
 }
 
 template <typename ListScalarT>
-Status WriteListScalar(const ListScalarT& scalar,
-                       rapidjson::Writer<rapidjson::StringBuffer>& writer,
+Status WriteListScalar(const ListScalarT& scalar, JsonWriter& writer,
                        ScalarVisitor* visitor) {
   writer.StartArray();
   for (int64_t i = 0; i < scalar.value->length(); ++i) {
@@ -75,16 +73,16 @@ Status WriteListScalar(const ListScalarT& scalar,
 
 class ScalarToJson : public ScalarVisitor {
  private:
-  rapidjson::StringBuffer string_buffer_;
-  rapidjson::Writer<rapidjson::StringBuffer> writer_{string_buffer_};
+  JsonWriter writer_;
 
  public:
-  void Reset() {
-    string_buffer_.Clear();
-    writer_.Reset(string_buffer_);
-  }
+  void Reset() { writer_.Clear(); }
 
-  std::string ToString() { return string_buffer_.GetString(); }
+  std::string ToString() {
+    auto result = writer_.GetString();
+    ThrowIfNotOK(result.status());
+    return std::string(*result);
+  }
 
   Status Visit(const NullScalar& scalar) override {
     writer_.Null();
@@ -164,7 +162,7 @@ class ScalarToJson : public ScalarVisitor {
 
   Status Visit(const StringScalar& scalar) override {
     const auto& view = scalar.view();
-    writer_.String(view.data(), static_cast<rapidjson::SizeType>(view.length()));
+    writer_.String(view);
 
     return Status::OK();
   }
@@ -175,7 +173,7 @@ class ScalarToJson : public ScalarVisitor {
 
   Status Visit(const LargeStringScalar& scalar) override {
     const auto& view = scalar.view();
-    writer_.String(view.data(), static_cast<rapidjson::SizeType>(view.length()));
+    writer_.String(view);
 
     return Status::OK();
   }
@@ -227,16 +225,14 @@ class ScalarToJson : public ScalarVisitor {
 
   Status Visit(const Decimal128Scalar& scalar) override {
     const auto& view = scalar.ToString();
-    writer_.RawValue(view.data(), static_cast<rapidjson::SizeType>(view.length()),
-                     rapidjson::kNumberType);
+    writer_.RawValue(view);
 
     return Status::OK();
   }
 
   Status Visit(const Decimal256Scalar& scalar) override {
     const auto& view = scalar.ToString();
-    writer_.RawValue(view.data(), static_cast<rapidjson::SizeType>(view.length()),
-                     rapidjson::kNumberType);
+    writer_.RawValue(view);
 
     return Status::OK();
   }


### PR DESCRIPTION
### Rationale for this change

This PR continues the simdjson migration by replacing the remaining RapidJSON usage in the FlightSQL ODBC JSON converter with Arrow's existing `JsonWriter`.

### Changes

- Replace `rapidjson::Writer` and `rapidjson::StringBuffer` with `arrow::json::JsonWriter`.
- Replace RapidJSON-specific `SizeType` usage with the `JsonWriter` interface.
- Replace RapidJSON `RawValue` usage with `JsonWriter::RawValue`.
- Remove the unused RapidJSON dependency from the ODBC implementation target.
- Preserve the existing `ConvertToJson` behavior and test coverage.

* GitHub Issue: #50911