### PR TITLE
GH-50917: [C++] Fix shellcheck errors in cpp/build-support/*-flatbuffers.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -296,7 +296,9 @@ repos:
           ?^cpp/build-support/build-lz4-lib\.sh$|
           ?^cpp/build-support/build-zstd-lib\.sh$|
           ?^cpp/build-support/get-upstream-commit\.sh$|
+          ?^cpp/build-support/update-flatbuffers\.sh$|
           ?^cpp/build-support/update-thrift\.sh$|
+          ?^cpp/build-support/vendor-flatbuffers\.sh$|
           ?^cpp/examples/minimal_build/run\.sh$|
           ?^cpp/examples/tutorial_examples/run\.sh$|
           ?^cpp/src/arrow/flight/sql/odbc/install/mac/postinstall$|

--- a/cpp/build-support/update-flatbuffers.sh
+++ b/cpp/build-support/update-flatbuffers.sh
@@ -24,9 +24,7 @@ set -euo pipefail
 
 CWD="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 SOURCE_DIR="$CWD/../src"
-#PYTHON_SOURCE_DIR="$CWD/../../python" # Unused ShellCheck (SC2034)
 FORMAT_DIR="$CWD/../../format"
-#TOP="$FORMAT_DIR/.." # Unused ShellCheck (SC2034)
 FLATC="flatc --cpp --cpp-std c++11 --scoped-enums"
 
 OUT_DIR="$SOURCE_DIR/generated"

--- a/cpp/build-support/update-flatbuffers.sh
+++ b/cpp/build-support/update-flatbuffers.sh
@@ -24,13 +24,18 @@ set -euo pipefail
 
 CWD="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 SOURCE_DIR="$CWD/../src"
-PYTHON_SOURCE_DIR="$CWD/../../python"
+#PYTHON_SOURCE_DIR="$CWD/../../python" # Unused ShellCheck (SC2034)
 FORMAT_DIR="$CWD/../../format"
-TOP="$FORMAT_DIR/.."
+#TOP="$FORMAT_DIR/.." # Unused ShellCheck (SC2034)
 FLATC="flatc --cpp --cpp-std c++11 --scoped-enums"
 
 OUT_DIR="$SOURCE_DIR/generated"
-FILES=($(find $FORMAT_DIR -name '*.fbs'))
+# Avoid word splitting (SC2207) while maintaining Bash 3 compatibility.
+# See: https://www.shellcheck.net/wiki/SC2207
+FILES=()
+while IFS= read -r file; do
+  FILES+=("$file")
+done < <(find "$FORMAT_DIR" -name '*.fbs')
 FILES+=("$SOURCE_DIR/arrow/ipc/feather.fbs")
 
 $FLATC -o "$OUT_DIR" "${FILES[@]}"

--- a/cpp/build-support/vendor-flatbuffers.sh
+++ b/cpp/build-support/vendor-flatbuffers.sh
@@ -25,7 +25,7 @@ set -eu
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
 VENDOR_LOCATION=$SOURCE_DIR/../thirdparty/flatbuffers/include/flatbuffers
-mkdir -p $VENDOR_LOCATION
-cp -f $FLATBUFFERS_HOME/include/flatbuffers/base.h $VENDOR_LOCATION
-cp -f $FLATBUFFERS_HOME/include/flatbuffers/flatbuffers.h $VENDOR_LOCATION
-cp -f $FLATBUFFERS_HOME/include/flatbuffers/stl_emulation.h $VENDOR_LOCATION
+mkdir -p "$VENDOR_LOCATION"
+cp -f "$FLATBUFFERS_HOME/include/flatbuffers/base.h" "$VENDOR_LOCATION"
+cp -f "$FLATBUFFERS_HOME/include/flatbuffers/flatbuffers.h" "$VENDOR_LOCATION"
+cp -f "$FLATBUFFERS_HOME/include/flatbuffers/stl_emulation.h" "$VENDOR_LOCATION"


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2034: foo appears unused. Verify it or export it.
* SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
* SC2086: Double quote to prevent globbing and word splitting.

```
shellcheck cpp/build-support/*flatbuffer*.sh

In cpp/build-support/update-flatbuffers.sh line 27:
PYTHON_SOURCE_DIR="$CWD/../../python"
^---------------^ SC2034 (warning): PYTHON_SOURCE_DIR appears unused. Verify use (or export if used externally).


In cpp/build-support/update-flatbuffers.sh line 29:
TOP="$FORMAT_DIR/.."
^-^ SC2034 (warning): TOP appears unused. Verify use (or export if used externally).


In cpp/build-support/update-flatbuffers.sh line 33:
FILES=($(find $FORMAT_DIR -name '*.fbs'))
       ^-- SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).
              ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
FILES=($(find "$FORMAT_DIR" -name '*.fbs'))


In cpp/build-support/vendor-flatbuffers.sh line 28:
mkdir -p $VENDOR_LOCATION
         ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "$VENDOR_LOCATION"


In cpp/build-support/vendor-flatbuffers.sh line 29:
cp -f $FLATBUFFERS_HOME/include/flatbuffers/base.h $VENDOR_LOCATION
      ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                   ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp -f "$FLATBUFFERS_HOME"/include/flatbuffers/base.h "$VENDOR_LOCATION"


In cpp/build-support/vendor-flatbuffers.sh line 30:
cp -f $FLATBUFFERS_HOME/include/flatbuffers/flatbuffers.h $VENDOR_LOCATION
      ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                          ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp -f "$FLATBUFFERS_HOME"/include/flatbuffers/flatbuffers.h "$VENDOR_LOCATION"


In cpp/build-support/vendor-flatbuffers.sh line 31:
cp -f $FLATBUFFERS_HOME/include/flatbuffers/stl_emulation.h $VENDOR_LOCATION
      ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                            ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp -f "$FLATBUFFERS_HOME"/include/flatbuffers/stl_emulation.h "$VENDOR_LOCATION"

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- PYTHON_SOURCE_DIR appears unused....
  https://www.shellcheck.net/wiki/SC2207 -- Prefer mapfile or read -a to spli...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC2034: Comment out unused variables
* SC2207: Populate arrays without command substitution
* SC2086: Quote variables


### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50917