### PR TITLE
GH-38868: [C++][Python] Add Array::ToTensor and fixed size list support

### DIFF
--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -325,7 +325,7 @@ Result<std::shared_ptr<Array>> Array::ViewOrCopyTo(
 
 Result<std::shared_ptr<Tensor>> Array::ToTensor(bool allow_nulls) const {
   if (!allow_nulls && null_count() > 0) {
-    return Status::NotImplemented(
+    return Status::Invalid(
         "Array contains nulls, explicitly pass `allow_nulls=true` to leave them "
         "undefined.");
   }
@@ -334,8 +334,7 @@ Result<std::shared_ptr<Tensor>> Array::ToTensor(bool allow_nulls) const {
 }
 
 Result<std::shared_ptr<Tensor>> Array::ToTensorWithNulls() const {
-  return Status::NotImplemented("ToTensor is not implemented for Array type ",
-                                type()->name());
+  return Status::TypeError("ToTensor is not implemented for Array type ", type()->name());
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -323,6 +323,11 @@ Result<std::shared_ptr<Array>> Array::ViewOrCopyTo(
   return MakeArray(new_data);
 }
 
+Result<std::shared_ptr<Tensor>> Array::ToTensor() const {
+  return Status::NotImplemented("ToTensor is not implemented for Array type ",
+                                type()->name());
+}
+
 // ----------------------------------------------------------------------
 // NullArray
 

--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -323,7 +323,17 @@ Result<std::shared_ptr<Array>> Array::ViewOrCopyTo(
   return MakeArray(new_data);
 }
 
-Result<std::shared_ptr<Tensor>> Array::ToTensor() const {
+Result<std::shared_ptr<Tensor>> Array::ToTensor(bool allow_nulls) const {
+  if (!allow_nulls && null_count() > 0) {
+    return Status::NotImplemented(
+        "Array contains nulls, explicitly pass `allow_nulls=true` to leave them "
+        "undefined.");
+  }
+
+  return ToTensorWithNulls();
+}
+
+Result<std::shared_ptr<Tensor>> Array::ToTensorWithNulls() const {
   return Status::NotImplemented("ToTensor is not implemented for Array type ",
                                 type()->name());
 }

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -252,9 +252,9 @@ class ARROW_EXPORT Array {
   ///
   /// When the data can reasonably be understood as a multidimensional numeric Tensor,
   /// return the data as such.
-  /// Example include NumericArray, FixedShapeTensorArray, nested FixedSizeListArray.
+  /// Examples include NumericArray, FixedShapeTensorArray, nested FixedSizeListArray.
   /// Nulls are ignored, leaving the output tensor with unspecified values where this
-  /// array null entries.
+  /// array has null entries.
   virtual Result<std::shared_ptr<Tensor>> ToTensor() const;
 
  protected:

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -29,14 +29,13 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 #include "arrow/visitor.h"
 
 namespace arrow {
-
-class Tensor;
 
 // ----------------------------------------------------------------------
 // User array accessor types

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -253,9 +253,11 @@ class ARROW_EXPORT Array {
   /// When the data can reasonably be understood as a multidimensional numeric Tensor,
   /// return the data as such.
   /// Examples include NumericArray, FixedShapeTensorArray, nested FixedSizeListArray.
-  /// Nulls are ignored, leaving the output tensor with unspecified values where this
-  /// array has null entries.
-  virtual Result<std::shared_ptr<Tensor>> ToTensor() const;
+  ///
+  /// \param[in] allow_nulls When true, nulls are ignored, leaving the output tensor with
+  ///            unspecified values where this array has null entries. When false, nulls
+  ///            are rejected.
+  Result<std::shared_ptr<Tensor>> ToTensor(bool allow_nulls = false) const;
 
  protected:
   Array() = default;
@@ -273,6 +275,9 @@ class ARROW_EXPORT Array {
     }
     data_ = data;
   }
+
+  /// Implementation of ToTensor with nulls as undefined.
+  virtual Result<std::shared_ptr<Tensor>> ToTensorWithNulls() const;
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Array);

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -36,6 +36,8 @@
 
 namespace arrow {
 
+class Tensor;
+
 // ----------------------------------------------------------------------
 // User array accessor types
 
@@ -245,6 +247,15 @@ class ARROW_EXPORT Array {
   ///
   /// \return const std::shared_ptr<ArrayStatistics>&
   const std::shared_ptr<ArrayStatistics>& statistics() const { return data_->statistics; }
+
+  /// \brief Create a Tensor from this Array
+  ///
+  /// When the data can reasonably be understood as a multidimensional numeric Tensor,
+  /// return the data as such.
+  /// Example include NumericArray, FixedShapeTensorArray, nested FixedSizeListArray.
+  /// Nulls are ignored, leaving the output tensor with unspecified values where this
+  /// array null entries.
+  virtual Result<std::shared_ptr<Tensor>> ToTensor() const;
 
  protected:
   Array() = default;

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -1903,7 +1903,7 @@ TEST_F(TestFixedSizeListArray, ToTensorNulls) {
   auto array = ArrayFromJSON(fixed_size_list(int32(), 2), "[[1, 2], null, [5, null]]");
 
   // Default behaviour is to not allow nulls
-  ASSERT_RAISES(NotImplemented, array->ToTensor());
+  ASSERT_RAISES(Invalid, array->ToTensor());
 
   // Nulls are ignored, leaving unspecified values in the output tensor.
   ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor(/* allow_nulls= */ true));
@@ -1923,12 +1923,12 @@ TEST_F(TestFixedSizeListArray, ToTensorZeroLength) {
 
 TEST_F(TestFixedSizeListArray, ToTensorUnsupportedType) {
   ASSERT_RAISES(
-      NotImplemented,
+      TypeError,
       ArrayFromJSON(fixed_size_list(utf8(), 1), R"([["a"], ["b"]])")->ToTensor());
   ASSERT_RAISES(
-      Invalid,
+      TypeError,
       ArrayFromJSON(fixed_size_list(boolean(), 2), "[[true, false]]")->ToTensor());
-  ASSERT_RAISES(Invalid,
+  ASSERT_RAISES(TypeError,
                 ArrayFromJSON(fixed_size_list(date32(), 2), "[[1, 2]]")->ToTensor());
 }
 

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -1887,13 +1887,15 @@ TEST_F(TestFixedSizeListArray, ToTensorNested) {
   CheckToTensor<float>(array->Slice(1, 2), {2, 3, 2},
                        {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
 
-  // Offsets accumulate at every level: the innermost values are offset by 2, the
-  // middle lists by 3 * 2 and the outer lists by 1 * 3 * 2.
+  // Slice offsets at each level contribute to the leaf offset, scaled by the list
+  // sizes above them.
   auto values = ArrayFromJSON(float32(), "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]")
                     ->Slice(2, 12);
   ASSERT_OK_AND_ASSIGN(auto inner, FixedSizeListArray::FromArrays(values, 2));
   ASSERT_OK_AND_ASSIGN(auto outer, FixedSizeListArray::FromArrays(inner, 3));
+  // Offset 2 for initial value slice
   CheckToTensor<float>(outer, {2, 3, 2}, {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13});
+  // Offset of 2 (initial values) + 1 * 3 * 2 (outer slice times parent dimensions) = 8
   CheckToTensor<float>(outer->Slice(1), {1, 3, 2}, {8, 9, 10, 11, 12, 13});
 }
 
@@ -1906,6 +1908,9 @@ TEST_F(TestFixedSizeListArray, ToTensorNulls) {
   // Nulls are ignored, leaving unspecified values in the output tensor.
   ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor(/* allow_nulls= */ true));
   ASSERT_OK(tensor->Validate());
+  ASSERT_EQ(tensor->Value<Int32Type>({0, 0}), 1);
+  ASSERT_EQ(tensor->Value<Int32Type>({0, 1}), 2);
+  ASSERT_EQ(tensor->Value<Int32Type>({2, 0}), 5);
   ASSERT_EQ(std::vector<int64_t>({3, 2}), tensor->shape());
 }
 

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -29,6 +29,7 @@
 #include "arrow/array/validate.h"
 #include "arrow/buffer.h"
 #include "arrow/status.h"
+#include "arrow/tensor.h"
 #include "arrow/testing/builder.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
@@ -1819,6 +1820,108 @@ TEST_F(TestFixedSizeListArray, FlattenRecursively) {
   ASSERT_EQ(2, flattened->null_count());
   AssertArraysEqual(*flattened,
                     *ArrayFromJSON(value_type_, "[0, 1, null, 3, 7, null, 2, 5]"));
+}
+
+namespace {
+
+/// The flat values a tensor views: the innermost values of the nested fixed size
+/// lists, windowed to what ``array`` covers.
+std::shared_ptr<Array> LeafValues(std::shared_ptr<Array> array) {
+  while (array->type_id() == Type::FIXED_SIZE_LIST) {
+    const auto& fsl = checked_cast<const FixedSizeListArray&>(*array);
+    array =
+        fsl.values()->Slice(fsl.value_offset(0), array->length() * fsl.value_length());
+  }
+  return array;
+}
+
+template <typename T>
+void CheckToTensor(const std::shared_ptr<Array>& array, const std::vector<int64_t>& shape,
+                   std::initializer_list<T> values) {
+  const auto value_type = CTypeTraits<T>::type_singleton();
+  ASSERT_OK_AND_ASSIGN(
+      auto expected,
+      Tensor::Make(value_type, Buffer::Wrap(values.begin(), values.size()), shape));
+
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+  ASSERT_OK(tensor->Validate());
+
+  AssertTypeEqual(*value_type, *tensor->type());
+  ASSERT_EQ(shape, tensor->shape());
+  ASSERT_TRUE(tensor->is_row_major());
+  ASSERT_TRUE(tensor->Equals(*expected));
+
+  // The tensor shares the values buffer, it does not copy
+  const auto leaf = LeafValues(array);
+  ASSERT_EQ(leaf->data()->buffers[1]->data() + leaf->offset() * sizeof(T),
+            tensor->data()->data());
+}
+
+}  // namespace
+
+TEST_F(TestFixedSizeListArray, ToTensor) {
+  auto array = ArrayFromJSON(fixed_size_list(int32(), 3),
+                             "[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]");
+  CheckToTensor<int32_t>(array, {4, 3}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+
+  // Offset on the list array itself
+  CheckToTensor<int32_t>(array->Slice(2, 2), {2, 3}, {7, 8, 9, 10, 11, 12});
+
+  // Offset on the values array
+  auto values = ArrayFromJSON(int32(), "[1, 2, 3, 4, 5, 6, 7, 8, 9]")->Slice(3);
+  ASSERT_OK_AND_ASSIGN(auto from_values, FixedSizeListArray::FromArrays(values, 3));
+  CheckToTensor<int32_t>(from_values, {2, 3}, {4, 5, 6, 7, 8, 9});
+
+  // Offsets on both the list array and its values
+  CheckToTensor<int32_t>(from_values->Slice(1), {1, 3}, {7, 8, 9});
+}
+
+TEST_F(TestFixedSizeListArray, ToTensorNested) {
+  auto array = ArrayFromJSON(fixed_size_list(fixed_size_list(float32(), 2), 3), R"([
+    [[1, 2], [3, 4], [5, 6]],
+    [[7, 8], [9, 10], [11, 12]],
+    [[13, 14], [15, 16], [17, 18]]
+  ])");
+  CheckToTensor<float>(array, {3, 3, 2},
+                       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+
+  CheckToTensor<float>(array->Slice(1, 2), {2, 3, 2},
+                       {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+
+  // Offsets accumulate at every level: the innermost values are offset by 2, the
+  // middle lists by 3 * 2 and the outer lists by 1 * 3 * 2.
+  auto values = ArrayFromJSON(float32(), "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]")
+                    ->Slice(2, 12);
+  ASSERT_OK_AND_ASSIGN(auto inner, FixedSizeListArray::FromArrays(values, 2));
+  ASSERT_OK_AND_ASSIGN(auto outer, FixedSizeListArray::FromArrays(inner, 3));
+  CheckToTensor<float>(outer, {2, 3, 2}, {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13});
+  CheckToTensor<float>(outer->Slice(1), {1, 3, 2}, {8, 9, 10, 11, 12, 13});
+}
+
+TEST_F(TestFixedSizeListArray, ToTensorNulls) {
+  // Nulls are ignored, leaving unspecified values in the output tensor.
+  auto array = ArrayFromJSON(fixed_size_list(int32(), 2), "[[1, 2], null, [5, null]]");
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+  ASSERT_OK(tensor->Validate());
+  ASSERT_EQ(std::vector<int64_t>({3, 2}), tensor->shape());
+}
+
+TEST_F(TestFixedSizeListArray, ToTensorZeroLength) {
+  auto array = ArrayFromJSON(fixed_size_list(int64(), 2), "[]");
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+  ASSERT_OK(tensor->Validate());
+  ASSERT_EQ(std::vector<int64_t>({0, 2}), tensor->shape());
+}
+
+TEST_F(TestFixedSizeListArray, ToTensorUnsupportedType) {
+  ASSERT_RAISES(
+      NotImplemented,
+      ArrayFromJSON(fixed_size_list(utf8(), 1), R"([["a"], ["b"]])")->ToTensor());
+  ASSERT_RAISES(
+      Invalid,
+      ArrayFromJSON(fixed_size_list(boolean(), 2), "[[true, false]]")->ToTensor());
+  ASSERT_RAISES(Invalid,
+                ArrayFromJSON(fixed_size_list(date32(), 2), "[[1, 2]]")->ToTensor());
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -1898,9 +1898,13 @@ TEST_F(TestFixedSizeListArray, ToTensorNested) {
 }
 
 TEST_F(TestFixedSizeListArray, ToTensorNulls) {
-  // Nulls are ignored, leaving unspecified values in the output tensor.
   auto array = ArrayFromJSON(fixed_size_list(int32(), 2), "[[1, 2], null, [5, null]]");
-  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+
+  // Default behaviour is to not allow nulls
+  ASSERT_RAISES(NotImplemented, array->ToTensor());
+
+  // Nulls are ignored, leaving unspecified values in the output tensor.
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor(/* allow_nulls= */ true));
   ASSERT_OK(tensor->Validate());
   ASSERT_EQ(std::vector<int64_t>({3, 2}), tensor->shape());
 }

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -1824,8 +1824,7 @@ TEST_F(TestFixedSizeListArray, FlattenRecursively) {
 
 namespace {
 
-/// The flat values a tensor views: the innermost values of the nested fixed size
-/// lists, windowed to what ``array`` covers.
+/// The innermost values of the nested fixed size lists.
 std::shared_ptr<Array> LeafValues(std::shared_ptr<Array> array) {
   while (array->type_id() == Type::FIXED_SIZE_LIST) {
     const auto& fsl = checked_cast<const FixedSizeListArray&>(*array);

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -1001,6 +1001,40 @@ Result<std::shared_ptr<Array>> FixedSizeListArray::Flatten(
   return FlattenListArray(*this, memory_pool);
 }
 
+Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensor() const {
+  const auto* data = this->data().get();
+  auto type = this->type();
+  int64_t offset = data->offset;
+  int64_t length = data->length;
+  std::vector<int64_t> shape{length};
+
+  // Iterate over nested fixed length container types.
+  // Each nested container increase the tensor dimension.
+  while (type->id() == Type::FIXED_SIZE_LIST) {
+    const auto* fsl = internal::checked_cast<const FixedSizeListType*>(type.get());
+    type = fsl->value_type();
+    data = data->child_data.front().get();
+
+    offset = offset * fsl->list_size() + data->offset;
+    length *= fsl->list_size();
+    shape.push_back(fsl->list_size());
+  }
+
+  // Only checking byte_width and leaving Tensor::Make error on unsupported types.
+  if (!is_fixed_width(*type)) {
+    return Status::NotImplemented("Expected a fixed width leaf type, got ", type->name());
+  }
+
+  std::shared_ptr<Buffer> buffer = nullptr;
+  if (const auto& buf = data->buffers[1]; buf != NULLPTR) {
+    const int64_t byte_width = type->byte_width();
+    ARROW_ASSIGN_OR_RAISE(buffer,
+                          SliceBufferSafe(buf, offset * byte_width, length * byte_width));
+  }
+
+  return Tensor::Make(std::move(type), std::move(buffer), std::move(shape));
+}
+
 // ----------------------------------------------------------------------
 // Struct
 

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -1003,7 +1003,7 @@ Result<std::shared_ptr<Array>> FixedSizeListArray::Flatten(
   return FlattenListArray(*this, memory_pool);
 }
 
-Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensor() const {
+Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensorWithNulls() const {
   const auto* data = this->data().get();
   auto type = this->type();
   int64_t offset = data->offset;

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -33,6 +33,7 @@
 #include "arrow/array/util.h"
 #include "arrow/buffer.h"
 #include "arrow/status.h"
+#include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
@@ -40,6 +41,7 @@
 #include "arrow/util/bitmap_generate.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/list_util.h"
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/unreachable.h"
@@ -1015,8 +1017,11 @@ Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensor() const {
     type = fsl->value_type();
     data = data->child_data.front().get();
 
-    offset = offset * fsl->list_size() + data->offset;
-    length *= fsl->list_size();
+    if (internal::MultiplyWithOverflow(offset, int64_t{fsl->list_size()}, &offset) ||
+        internal::AddWithOverflow(offset, data->offset, &offset) ||
+        internal::MultiplyWithOverflow(length, int64_t{fsl->list_size()}, &length)) {
+      return Status::Invalid("Flattened fixed size list does not fit in an int64");
+    }
     shape.push_back(fsl->list_size());
   }
 
@@ -1028,8 +1033,13 @@ Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensor() const {
   std::shared_ptr<Buffer> buffer = nullptr;
   if (const auto& buf = data->buffers[1]; buf != NULLPTR) {
     const int64_t byte_width = type->byte_width();
-    ARROW_ASSIGN_OR_RAISE(buffer,
-                          SliceBufferSafe(buf, offset * byte_width, length * byte_width));
+    int64_t boffset = 0;
+    int64_t blength = 0;
+    if (internal::MultiplyWithOverflow(offset, byte_width, &boffset) ||
+        internal::MultiplyWithOverflow(length, byte_width, &blength)) {
+      return Status::Invalid("Array byte size does not fit in an int64");
+    }
+    ARROW_ASSIGN_OR_RAISE(buffer, SliceBufferSafe(buf, boffset, blength));
   }
 
   return Tensor::Make(std::move(type), std::move(buffer), std::move(shape));

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -1023,9 +1023,10 @@ Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensorWithNulls() const {
     shape.push_back(fsl->list_size());
   }
 
-  // Only checking byte_width and leaving Tensor::Make error on unsupported types.
+  // Only checking byte_width which we need here and leaving Tensor::Make error on
+  // unsupported types.
   if (!is_fixed_width(*type)) {
-    return Status::NotImplemented("Expected a fixed width leaf type, got ", type->name());
+    return Status::TypeError("Expected a fixed width leaf type, got ", type->name());
   }
 
   std::shared_ptr<Buffer> buffer = nullptr;

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -1016,12 +1016,10 @@ Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensor() const {
     const auto* fsl = internal::checked_cast<const FixedSizeListType*>(type.get());
     type = fsl->value_type();
     data = data->child_data.front().get();
-
-    if (internal::MultiplyWithOverflow(offset, int64_t{fsl->list_size()}, &offset) ||
-        internal::AddWithOverflow(offset, data->offset, &offset) ||
-        internal::MultiplyWithOverflow(length, int64_t{fsl->list_size()}, &length)) {
-      return Status::Invalid("Flattened fixed size list does not fit in an int64");
-    }
+    // Overflow cannot happen on a valid array (its data needs to fit in memory,
+    // therefore be smaller than INT64_MAX)
+    offset = offset * fsl->list_size() + data->offset;
+    length = length * fsl->list_size();
     shape.push_back(fsl->list_size());
   }
 
@@ -1033,13 +1031,10 @@ Result<std::shared_ptr<Tensor>> FixedSizeListArray::ToTensor() const {
   std::shared_ptr<Buffer> buffer = nullptr;
   if (const auto& buf = data->buffers[1]; buf != NULLPTR) {
     const int64_t byte_width = type->byte_width();
-    int64_t boffset = 0;
-    int64_t blength = 0;
-    if (internal::MultiplyWithOverflow(offset, byte_width, &boffset) ||
-        internal::MultiplyWithOverflow(length, byte_width, &blength)) {
-      return Status::Invalid("Array byte size does not fit in an int64");
-    }
-    ARROW_ASSIGN_OR_RAISE(buffer, SliceBufferSafe(buf, boffset, blength));
+    // Buffer guarantees this fits into an int64_t.
+    const int64_t byte_offset = offset * byte_width;
+    const int64_t byte_length = length * byte_width;
+    ARROW_ASSIGN_OR_RAISE(buffer, SliceBufferSafe(buf, byte_offset, byte_length));
   }
 
   return Tensor::Make(std::move(type), std::move(buffer), std::move(shape));

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -645,6 +645,14 @@ class ARROW_EXPORT FixedSizeListArray : public Array {
       std::shared_ptr<Buffer> null_bitmap = NULLPTR,
       int64_t null_count = kUnknownNullCount);
 
+  /// \brief Return a Tensor sharing the data.
+  ///
+  /// The output tensor has a row major layout with the number of element as the first
+  /// dimension and the fixed sized list as the remaining one (possibly nested).
+  /// Nulls are ignored, leaving the output tensor with unspecified values where this
+  /// array null entries.
+  Result<std::shared_ptr<Tensor>> ToTensor() const override;
+
  protected:
   void SetData(const std::shared_ptr<ArrayData>& data);
   int32_t list_size_;

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -647,10 +647,10 @@ class ARROW_EXPORT FixedSizeListArray : public Array {
 
   /// \brief Return a Tensor sharing the data.
   ///
-  /// The output tensor has a row major layout with the number of element as the first
-  /// dimension and the fixed sized list as the remaining one (possibly nested).
+  /// The output tensor has a row major layout with the number of elements as the first
+  /// dimension and the fixed size list as the remaining ones (possibly nested).
   /// Nulls are ignored, leaving the output tensor with unspecified values where this
-  /// array null entries.
+  /// array has null entries.
   Result<std::shared_ptr<Tensor>> ToTensor() const override;
 
  protected:

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -645,17 +645,17 @@ class ARROW_EXPORT FixedSizeListArray : public Array {
       std::shared_ptr<Buffer> null_bitmap = NULLPTR,
       int64_t null_count = kUnknownNullCount);
 
+ protected:
+  void SetData(const std::shared_ptr<ArrayData>& data);
+  int32_t list_size_;
+
   /// \brief Return a Tensor sharing the data.
   ///
   /// The output tensor has a row major layout with the number of elements as the first
   /// dimension and the fixed size list as the remaining ones (possibly nested).
   /// Nulls are ignored, leaving the output tensor with unspecified values where this
   /// array has null entries.
-  Result<std::shared_ptr<Tensor>> ToTensor() const override;
-
- protected:
-  void SetData(const std::shared_ptr<ArrayData>& data);
-  int32_t list_size_;
+  Result<std::shared_ptr<Tensor>> ToTensorWithNulls() const override;
 
  private:
   std::shared_ptr<Array> values_;

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -131,8 +131,18 @@ class NumericArray : public PrimitiveArray {
 
   IteratorType end() const { return IteratorType(*this, length()); }
 
+ protected:
+  NumericArray() : values_(NULLPTR) {}
+
+  void SetData(const std::shared_ptr<ArrayData>& data) {
+    this->PrimitiveArray::SetData(data);
+    values_ = raw_values_
+                  ? (reinterpret_cast<const value_type*>(raw_values_) + data_->offset)
+                  : NULLPTR;
+  }
+
   /// \brief Return a one dimensional Tensor.
-  Result<std::shared_ptr<Tensor>> ToTensor() const override {
+  Result<std::shared_ptr<Tensor>> ToTensorWithNulls() const override {
     // Could be non-templated
     const int64_t byte_width = type()->byte_width();
     std::shared_ptr<Buffer> buffer;
@@ -144,16 +154,6 @@ class NumericArray : public PrimitiveArray {
                             SliceBufferSafe(data_->buffers[1], byte_offset, byte_length));
     }
     return Tensor::Make(type(), std::move(buffer), {length()});
-  }
-
- protected:
-  NumericArray() : values_(NULLPTR) {}
-
-  void SetData(const std::shared_ptr<ArrayData>& data) {
-    this->PrimitiveArray::SetData(data);
-    values_ = raw_values_
-                  ? (reinterpret_cast<const value_type*>(raw_values_) + data_->offset)
-                  : NULLPTR;
   }
 
   const value_type* values_;

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -25,7 +25,9 @@
 
 #include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
+#include "arrow/buffer.h"
 #include "arrow/stl_iterator.h"
+#include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"  // IWYU pragma: export
 #include "arrow/type_traits.h"
@@ -127,6 +129,19 @@ class NumericArray : public PrimitiveArray {
   IteratorType begin() const { return IteratorType(*this); }
 
   IteratorType end() const { return IteratorType(*this, length()); }
+
+  /// \brief Return a one dimensional Tensor.
+  Result<std::shared_ptr<Tensor>> ToTensor() const override {
+    // Could be non-templated
+    const int64_t byte_width = type()->byte_width();
+    std::shared_ptr<Buffer> buffer;
+    if (data_->buffers[1] != NULLPTR) {
+      const auto boffset = data_->offset * byte_width;
+      const auto blength = length() * byte_width;
+      ARROW_ASSIGN_OR_RAISE(buffer, SliceBufferSafe(data_->buffers[1], boffset, blength));
+    }
+    return Tensor::Make(type(), std::move(buffer), {length()});
+  }
 
  protected:
   NumericArray() : values_(NULLPTR) {}

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -32,6 +32,7 @@
 #include "arrow/type_fwd.h"  // IWYU pragma: export
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
@@ -136,8 +137,12 @@ class NumericArray : public PrimitiveArray {
     const int64_t byte_width = type()->byte_width();
     std::shared_ptr<Buffer> buffer;
     if (data_->buffers[1] != NULLPTR) {
-      const auto boffset = data_->offset * byte_width;
-      const auto blength = length() * byte_width;
+      int64_t boffset = 0;
+      int64_t blength = 0;
+      if (internal::MultiplyWithOverflow(data_->offset, byte_width, &boffset) ||
+          internal::MultiplyWithOverflow(length(), byte_width, &blength)) {
+        return Status::Invalid("Array byte size does not fit in an int64");
+      }
       ARROW_ASSIGN_OR_RAISE(buffer, SliceBufferSafe(data_->buffers[1], boffset, blength));
     }
     return Tensor::Make(type(), std::move(buffer), {length()});

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -137,13 +137,11 @@ class NumericArray : public PrimitiveArray {
     const int64_t byte_width = type()->byte_width();
     std::shared_ptr<Buffer> buffer;
     if (data_->buffers[1] != NULLPTR) {
-      int64_t boffset = 0;
-      int64_t blength = 0;
-      if (internal::MultiplyWithOverflow(data_->offset, byte_width, &boffset) ||
-          internal::MultiplyWithOverflow(length(), byte_width, &blength)) {
-        return Status::Invalid("Array byte size does not fit in an int64");
-      }
-      ARROW_ASSIGN_OR_RAISE(buffer, SliceBufferSafe(data_->buffers[1], boffset, blength));
+      // Array guarantees this will not overflow.
+      const int64_t byte_offset = data_->offset * byte_width;
+      const int64_t byte_length = length() * byte_width;
+      ARROW_ASSIGN_OR_RAISE(buffer,
+                            SliceBufferSafe(data_->buffers[1], byte_offset, byte_length));
     }
     return Tensor::Make(type(), std::move(buffer), {length()});
   }

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1250,9 +1250,13 @@ TEST(TestPrimitiveArray, ToTensorSliced) {
 TEST(TestPrimitiveArray, ToTensorNulls) {
   // Nulls are ignored, leaving unspecified values in the output tensor.
   const std::vector<int64_t> shape = {3};
-
   auto array = ArrayFromJSON(int32(), "[1, null, 3]");
-  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+
+  // Default behaviour is to not allow nulls
+  ASSERT_RAISES(NotImplemented, array->ToTensor());
+
+  // Nulls are ignored, leaving unspecified values in the output tensor.
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor(/* allow_nulls= */ true));
   ASSERT_OK(tensor->Validate());
 
   EXPECT_EQ(shape, tensor->shape());

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -50,6 +50,7 @@
 #include "arrow/result.h"
 #include "arrow/scalar.h"
 #include "arrow/status.h"
+#include "arrow/tensor.h"
 #include "arrow/testing/builder.h"
 #include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_compat.h"
@@ -1216,6 +1217,54 @@ TEST(TestPrimitiveArray, CtorNoValidityBitmap) {
   std::shared_ptr<Buffer> data = *AllocateBuffer(40);
   Int32Array arr(10, data);
   ASSERT_EQ(arr.data()->null_count, 0);
+}
+
+TEST(TestPrimitiveArray, ToTensor) {
+  const std::vector<int64_t> shape = {5};
+  const std::vector<int64_t> strides = {sizeof(int32_t)};
+
+  auto array = ArrayFromJSON(int32(), "[1, 2, 3, 4, 5]");
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+  ASSERT_OK(tensor->Validate());
+
+  EXPECT_EQ(int32(), tensor->type());
+  EXPECT_EQ(shape, std::vector<int64_t>{5});
+  EXPECT_EQ(strides, std::vector<int64_t>{sizeof(int32_t)});
+  EXPECT_EQ(shape, tensor->shape());
+  EXPECT_EQ(strides, tensor->strides());
+  EXPECT_TRUE(tensor->is_contiguous());
+  EXPECT_TRUE(
+      TensorFromJSON(int32(), "[1, 2, 3, 4, 5]", shape, strides)->Equals(*tensor));
+}
+
+TEST(TestPrimitiveArray, ToTensorSliced) {
+  const std::vector<int64_t> shape = {3};
+  const std::vector<int64_t> strides = {sizeof(int64_t)};
+
+  auto array = ArrayFromJSON(int64(), "[1, 2, 3, 4, 5]")->Slice(2);
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+  ASSERT_OK(tensor->Validate());
+
+  EXPECT_EQ(shape, tensor->shape());
+  EXPECT_TRUE(TensorFromJSON(int64(), "[3, 4, 5]", shape, strides)->Equals(*tensor));
+}
+
+TEST(TestPrimitiveArray, ToTensorNulls) {
+  // Nulls are ignored, leaving unspecified values in the output tensor.
+  const std::vector<int64_t> shape = {3};
+
+  auto array = ArrayFromJSON(int32(), "[1, null, 3]");
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+  ASSERT_OK(tensor->Validate());
+
+  EXPECT_EQ(shape, tensor->shape());
+}
+
+TEST(TestPrimitiveArray, ToTensorUnsupportedType) {
+  auto array = ArrayFromJSON(date32(), "[1, 2, 3]");
+  ASSERT_RAISES(Invalid, array->ToTensor());
+
+  ASSERT_RAISES(NotImplemented, ArrayFromJSON(utf8(), R"(["a"])")->ToTensor());
 }
 
 class TestBuilder : public ::testing::Test {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1264,7 +1264,7 @@ TEST(TestPrimitiveArray, ToTensorNulls) {
   auto array = ArrayFromJSON(int32(), "[1, null, 3]");
 
   // Default behaviour is to not allow nulls
-  ASSERT_RAISES(NotImplemented, array->ToTensor());
+  ASSERT_RAISES(Invalid, array->ToTensor());
 
   // Nulls are ignored, leaving unspecified values in the output tensor.
   ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor(/* allow_nulls= */ true));
@@ -1276,9 +1276,8 @@ TEST(TestPrimitiveArray, ToTensorNulls) {
 
 TEST(TestPrimitiveArray, ToTensorUnsupportedType) {
   auto array = ArrayFromJSON(date32(), "[1, 2, 3]");
-  ASSERT_RAISES(Invalid, array->ToTensor());
-
-  ASSERT_RAISES(NotImplemented, ArrayFromJSON(utf8(), R"(["a"])")->ToTensor());
+  ASSERT_RAISES(TypeError, array->ToTensor());
+  ASSERT_RAISES(TypeError, ArrayFromJSON(utf8(), R"(["a"])")->ToTensor());
 }
 
 class TestBuilder : public ::testing::Test {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1247,9 +1247,20 @@ TEST(TestPrimitiveArray, ToTensorSliced) {
   EXPECT_TRUE(TensorFromJSON(int64(), "[3, 4, 5]", shape, strides)->Equals(*tensor));
 }
 
+TEST(TestPrimitiveArray, ZeroLength) {
+  Int64Builder builder;
+  ASSERT_OK_AND_ASSIGN(auto array, builder.Finish());
+
+  ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor());
+  ASSERT_OK(tensor->Validate());
+
+  EXPECT_EQ(int64(), tensor->type());
+  EXPECT_EQ(std::vector<int64_t>{0}, tensor->shape());
+  EXPECT_EQ(std::vector<int64_t>{sizeof(int64_t)}, tensor->strides());
+}
+
 TEST(TestPrimitiveArray, ToTensorNulls) {
   // Nulls are ignored, leaving unspecified values in the output tensor.
-  const std::vector<int64_t> shape = {3};
   auto array = ArrayFromJSON(int32(), "[1, null, 3]");
 
   // Default behaviour is to not allow nulls
@@ -1258,8 +1269,9 @@ TEST(TestPrimitiveArray, ToTensorNulls) {
   // Nulls are ignored, leaving unspecified values in the output tensor.
   ASSERT_OK_AND_ASSIGN(auto tensor, array->ToTensor(/* allow_nulls= */ true));
   ASSERT_OK(tensor->Validate());
-
-  EXPECT_EQ(shape, tensor->shape());
+  ASSERT_EQ(tensor->Value<Int32Type>({0}), 1);
+  ASSERT_EQ(tensor->Value<Int32Type>({2}), 3);
+  EXPECT_EQ(std::vector<int64_t>{3}, tensor->shape());
 }
 
 TEST(TestPrimitiveArray, ToTensorUnsupportedType) {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1228,8 +1228,6 @@ TEST(TestPrimitiveArray, ToTensor) {
   ASSERT_OK(tensor->Validate());
 
   EXPECT_EQ(int32(), tensor->type());
-  EXPECT_EQ(shape, std::vector<int64_t>{5});
-  EXPECT_EQ(strides, std::vector<int64_t>{sizeof(int32_t)});
   EXPECT_EQ(shape, tensor->shape());
   EXPECT_EQ(strides, tensor->strides());
   EXPECT_TRUE(tensor->is_contiguous());

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -191,6 +191,17 @@ Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
   return ExportBuffer<DT>(std::move(params));
 }
 
+template <typename T>
+Result<DLDevice> ExportDeviceImpl(const std::shared_ptr<T>& a) {
+  // ArrayData reports the device of its buffers and children
+  if (a->data()->device_type() == DeviceAllocationType::kCPU) {
+    return {{.device_type = DLDeviceType::kDLCPU, .device_id = 0}};
+  } else {
+    return Status::NotImplemented(
+        "DLPack support is implemented only for buffers on CPU device.");
+  }
+}
+
 }  // namespace
 
 Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Array>& arr) {
@@ -203,13 +214,7 @@ Result<DLManagedTensorVersioned*> ExportArrayVersioned(const std::shared_ptr<Arr
 }
 
 Result<DLDevice> ExportDevice(const std::shared_ptr<Array>& arr) {
-  // ArrayData reports the device of its buffers and children
-  if (arr->data()->device_type() == DeviceAllocationType::kCPU) {
-    return {{.device_type = DLDeviceType::kDLCPU, .device_id = 0}};
-  } else {
-    return Status::NotImplemented(
-        "DLPack support is implemented only for buffers on CPU device.");
-  }
+  return ExportDeviceImpl(arr);
 }
 
 namespace {
@@ -273,13 +278,7 @@ Result<DLManagedTensorVersioned*> ExportTensorVersioned(const std::shared_ptr<Te
 }
 
 Result<DLDevice> ExportDevice(const std::shared_ptr<Tensor>& t) {
-  // Define DLDevice struct
-  if (t->data()->device_type() == DeviceAllocationType::kCPU) {
-    return {{.device_type = DLDeviceType::kDLCPU, .device_id = 0}};
-  } else {
-    return Status::NotImplemented(
-        "DLPack support is implemented only for buffers on CPU device.");
-  }
+  return ExportDeviceImpl(t);
 }
 
 }  // namespace arrow::dlpack

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -34,35 +34,24 @@ namespace arrow::dlpack {
 
 namespace {
 
-Result<DLDataType> GetDLDataType(const DataType& type) {
-  DLDataType dtype;
+Result<DLDataType> GetLeafDLDataType(const DataType& type) {
+  auto dtype = DLDataType{};
   dtype.lanes = 1;
   dtype.bits = type.bit_width();
-  switch (type.id()) {
-    case Type::INT8:
-    case Type::INT16:
-    case Type::INT32:
-    case Type::INT64:
-      dtype.code = DLDataTypeCode::kDLInt;
-      return dtype;
-    case Type::UINT8:
-    case Type::UINT16:
-    case Type::UINT32:
-    case Type::UINT64:
-      dtype.code = DLDataTypeCode::kDLUInt;
-      return dtype;
-    case Type::HALF_FLOAT:
-    case Type::FLOAT:
-    case Type::DOUBLE:
-      dtype.code = DLDataTypeCode::kDLFloat;
-      return dtype;
-    case Type::BOOL:
-      // DLPack supports byte-packed boolean values
-      return Status::TypeError("Bit-packed boolean data type not supported by DLPack.");
-    default:
-      return Status::TypeError("DataType is not compatible with DLPack spec: ",
-                               type.ToString());
+  if (is_signed_integer(type.id())) {
+    dtype.code = DLDataTypeCode::kDLInt;
+  } else if (is_unsigned_integer(type.id())) {
+    dtype.code = DLDataTypeCode::kDLUInt;
+  } else if (is_floating(type.id())) {
+    dtype.code = DLDataTypeCode::kDLFloat;
+  } else if (type.id() == Type::BOOL) {
+    // DLPack supports byte-packed boolean values
+    return Status::TypeError("Bit-packed boolean data type not supported by DLPack.");
+  } else {
+    return Status::TypeError("DataType is not compatible with DLPack spec: ",
+                             type.ToString());
   }
+  return {dtype};
 }
 
 template <typename DT, typename Vec>
@@ -137,7 +126,7 @@ Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
 
   // Define the DLDataType struct
   const auto& type = *arr->type();
-  ARROW_ASSIGN_OR_RAISE(auto dtype, GetDLDataType(type));
+  ARROW_ASSIGN_OR_RAISE(auto dtype, GetLeafDLDataType(type));
 
   auto params = ExportBufferParams<std::array<int64_t, 1>>{
       .size = arr->length(),
@@ -213,7 +202,7 @@ Result<DT*> ExportTensorImpl(const std::shared_ptr<Tensor>& t, bool copy) {
 
   // Define the DLDataType struct
   const auto& type = *t->type();
-  ARROW_ASSIGN_OR_RAISE(auto dtype, GetDLDataType(type));
+  ARROW_ASSIGN_OR_RAISE(auto dtype, GetLeafDLDataType(type));
 
   // Compute strides
   std::vector<int64_t> strides = {};
@@ -266,11 +255,8 @@ Result<DLManagedTensorVersioned*> ExportTensorVersioned(const std::shared_ptr<Te
 
 Result<DLDevice> ExportDevice(const std::shared_ptr<Tensor>& t) {
   // Define DLDevice struct
-  DLDevice device;
   if (t->data()->device_type() == DeviceAllocationType::kCPU) {
-    device.device_id = 0;
-    device.device_type = DLDeviceType::kDLCPU;
-    return device;
+    return {{.device_type = DLDeviceType::kDLCPU, .device_id = 0}};
   } else {
     return Status::NotImplemented(
         "DLPack support is implemented only for buffers on CPU device.");

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -17,9 +17,7 @@
 
 #include "arrow/c/dlpack.h"
 
-#include <functional>
 #include <memory>
-#include <numeric>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -122,14 +120,6 @@ DT* ExportBuffer(ExportBufferParams<Vec>&& p) {
   return &ctx.release()->tensor;
 }
 
-template <typename Vec>
-Vec RowMajorStrides(const Vec& shape) {
-  auto out = Vec(shape.size());
-  std::exclusive_scan(shape.crbegin(), shape.crend(), out.rbegin(), 1,
-                      std::multiplies<>{});
-  return out;
-}
-
 template <typename DT>
 Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
   ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(arr));
@@ -172,7 +162,8 @@ Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
   params.buffer_offset *= type->byte_width();
   params.buffer_size *= type->byte_width();
   // Compute strides as row major.
-  params.strides = RowMajorStrides(params.shape);
+  params.strides.resize(params.shape.size());
+  RETURN_NOT_OK(internal::ComputeRowMajorStrides(params.shape, 1, params.strides));
 
   if (copy) {
     // We copy the buffer slice instead of using Array copy functions to avoid copying
@@ -219,6 +210,14 @@ Result<DLDevice> ExportDevice(const std::shared_ptr<Array>& arr) {
 
 namespace {
 
+template <typename T>
+std::vector<T> StridesInElements(std::vector<T> strides, T byte_width) {
+  for (auto& s : strides) {
+    s /= byte_width;
+  }
+  return strides;
+}
+
 template <typename DT>
 Result<DT*> ExportTensorImpl(const std::shared_ptr<Tensor>& t, bool copy) {
   // Define DLDevice struct
@@ -228,18 +227,10 @@ Result<DT*> ExportTensorImpl(const std::shared_ptr<Tensor>& t, bool copy) {
   const auto& type = *t->type();
   ARROW_ASSIGN_OR_RAISE(auto dtype, GetLeafDLDataType(type));
 
-  // Compute strides
-  std::vector<int64_t> strides = {};
-  strides.reserve(t->ndim());
-  const auto byte_width = type.byte_width();
-  for (auto i : t->strides()) {
-    strides.emplace_back(i / byte_width);
-  }
-
   auto params = ExportBufferParams<std::vector<int64_t>>{
       .buffer_size = t->size(),
       .ndim = t->ndim(),
-      .strides = std::move(strides),
+      .strides = StridesInElements<int64_t>(t->strides(), type.byte_width()),
       .shape = t->shape(),
       .device = device,
       .dtype = dtype,

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -17,9 +17,11 @@
 
 #include "arrow/c/dlpack.h"
 
-#include <array>
+#include <functional>
 #include <memory>
+#include <numeric>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "arrow/array/array_base.h"
@@ -29,6 +31,8 @@
 #include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/small_vector.h"
 
 namespace arrow::dlpack {
 
@@ -67,14 +71,15 @@ struct ManagerCtx {
 template <typename Vec>
 struct ExportBufferParams {
   std::shared_ptr<Buffer> buffer = nullptr;
+  /// Data offset in the buffer in bytes.
   int64_t buffer_offset = 0;
-  /// Total number of values, i.e. the product of the shape.
-  int64_t size;
-  int32_t ndim;
-  Vec strides;
-  Vec shape;
-  DLDevice device;
-  DLDataType dtype;
+  /// Total number of bytes to read in the buffer.
+  int64_t buffer_size = 0;
+  int32_t ndim = 0;
+  Vec strides = {};
+  Vec shape = {};
+  DLDevice device = {};
+  DLDataType dtype = {};
   uint64_t flags = 0;
 };
 
@@ -91,7 +96,7 @@ DT* ExportBuffer(ExportBufferParams<Vec>&& p) {
 
   // Define the data pointer to the DLTensor
   // If array is of length 0, data pointer should be NULL
-  if (p.size == 0) {
+  if (p.buffer_size == 0) {
     ctx->tensor.dl_tensor.data = nullptr;
   } else {
     ctx->tensor.dl_tensor.data =
@@ -117,39 +122,69 @@ DT* ExportBuffer(ExportBufferParams<Vec>&& p) {
   return &ctx.release()->tensor;
 }
 
+template <typename Vec>
+Vec RowMajorStrides(const Vec& shape) {
+  auto out = Vec(shape.size());
+  std::exclusive_scan(shape.crbegin(), shape.crend(), out.rbegin(), 1,
+                      std::multiplies<>{});
+  return out;
+}
+
 template <typename DT>
 Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
-  // Define DLDevice struct and check if array type is supported
-  // by the DLPack protocol at the same time. Raise TypeError if not.
-  // Supported data types: int, uint, float with no validity buffer.
   ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(arr));
 
-  // Define the DLDataType struct
-  const auto& type = *arr->type();
-  ARROW_ASSIGN_OR_RAISE(auto dtype, GetLeafDLDataType(type));
+  using Vec = internal::SmallVector<int64_t, 2>;
 
-  auto params = ExportBufferParams<std::array<int64_t, 1>>{
-      .size = arr->length(),
+  const auto* data = arr->data().get();  // lifetime of data is bound by arr
+  const auto* type = arr->type().get();  // lifetime of data is bound by arr
+  auto params = ExportBufferParams<Vec>{
+      .buffer_offset = data->offset,
+      .buffer_size = data->length,
       .ndim = 1,
-      .strides = {1},
-      .shape = {arr->length()},
+      .shape = {data->length},
       .device = device,
-      .dtype = dtype,
   };
+  if (data->GetNullCount() > 0) {
+    return Status::TypeError("Can only use DLPack on arrays with no nulls.");
+  }
 
-  const auto& data = *arr->data();
+  // Iterate over nested fixed length container types.
+  // Each nested container increase the DLPack tensor dimension.
+  // Nulls are not supported by DLPack, at any nesting level.
+  while (type->id() == Type::FIXED_SIZE_LIST) {
+    const auto* fsl = internal::checked_cast<const FixedSizeListType*>(type);
+    type = fsl->value_type().get();
+    data = data->child_data.front().get();
+    if (data->GetNullCount() > 0) {
+      return Status::TypeError("Can only use DLPack on arrays with no nulls.");
+    }
+
+    params.ndim++;
+    params.buffer_offset = params.buffer_offset * fsl->list_size() + data->offset;
+    params.buffer_size *= fsl->list_size();
+    params.shape.push_back(fsl->list_size());
+  }
+
+  // Get the DLDataType struct of the type leaf, or fail if it is not supported.
+  ARROW_ASSIGN_OR_RAISE(params.dtype, GetLeafDLDataType(*type));
+  // Use byte domain indexing.
+  params.buffer_offset *= type->byte_width();
+  params.buffer_size *= type->byte_width();
+  // Compute strides as row major.
+  params.strides = RowMajorStrides(params.shape);
+
   if (copy) {
     // We copy the buffer slice instead of using Array copy functions to avoid copying
     // unused values outside of offset/length (e.g. with Slice).
-    const auto start = data.offset * type.byte_width();
-    const auto nbytes = data.length * type.byte_width();
-    ARROW_ASSIGN_OR_RAISE(params.buffer, data.buffers[1]->CopySlice(start, nbytes));
+    const auto start = std::exchange(params.buffer_offset, 0);
+    const auto nbytes = params.buffer_size;
+    ARROW_ASSIGN_OR_RAISE(params.buffer, data->buffers[1]->CopySlice(start, nbytes));
     // Since we make a copy only for the consumer, we do not need to mark it readonly.
     params.flags = DLPACK_FLAG_BITMASK_IS_COPIED;
   } else {
     // Shared buffer with Arrow Array. Arrays are readonly once constructed.
-    params.buffer = data.buffers[1];
-    params.buffer_offset = data.offset * type.byte_width();
+    params.buffer = data->buffers[1];
     params.flags = DLPACK_FLAG_BITMASK_READ_ONLY;
   }
 
@@ -168,25 +203,9 @@ Result<DLManagedTensorVersioned*> ExportArrayVersioned(const std::shared_ptr<Arr
 }
 
 Result<DLDevice> ExportDevice(const std::shared_ptr<Array>& arr) {
-  // Check if array is supported by the DLPack protocol.
-  if (arr->null_count() > 0) {
-    return Status::TypeError("Can only use DLPack on arrays with no nulls.");
-  }
-  const DataType& type = *arr->type();
-  if (type.id() == Type::BOOL) {
-    return Status::TypeError("Bit-packed boolean data type not supported by DLPack.");
-  }
-  if (!is_integer(type.id()) && !is_floating(type.id())) {
-    return Status::TypeError("DataType is not compatible with DLPack spec: ",
-                             type.ToString());
-  }
-
-  // Define DLDevice struct
-  DLDevice device;
-  if (arr->data()->buffers[1]->device_type() == DeviceAllocationType::kCPU) {
-    device.device_id = 0;
-    device.device_type = DLDeviceType::kDLCPU;
-    return device;
+  // ArrayData reports the device of its buffers and children
+  if (arr->data()->device_type() == DeviceAllocationType::kCPU) {
+    return {{.device_type = DLDeviceType::kDLCPU, .device_id = 0}};
   } else {
     return Status::NotImplemented(
         "DLPack support is implemented only for buffers on CPU device.");
@@ -213,7 +232,7 @@ Result<DT*> ExportTensorImpl(const std::shared_ptr<Tensor>& t, bool copy) {
   }
 
   auto params = ExportBufferParams<std::vector<int64_t>>{
-      .size = t->size(),
+      .buffer_size = t->size(),
       .ndim = t->ndim(),
       .strides = std::move(strides),
       .shape = t->shape(),

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -49,8 +49,9 @@ Result<DLDataType> GetDLDataType(const DataType& type) {
     // DLPack supports byte-packed boolean values
     return Status::TypeError("Bit-packed boolean data type not supported by DLPack.");
   } else {
-    return Status::TypeError("DataType is not compatible with DLPack spec: ",
-                             type.ToString());
+    return Status::TypeError(
+        "DataType is not compatible with DLPack spec: ", type.ToString(),
+        ", try converting to a Tensor for multi dimensional data support");
   }
   return {dtype};
 }

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/c/dlpack.h"
 
+#include <array>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -29,14 +30,12 @@
 #include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
-#include "arrow/util/checked_cast.h"
-#include "arrow/util/small_vector.h"
 
 namespace arrow::dlpack {
 
 namespace {
 
-Result<DLDataType> GetLeafDLDataType(const DataType& type) {
+Result<DLDataType> GetDLDataType(const DataType& type) {
   auto dtype = DLDataType{};
   dtype.lanes = 1;
   dtype.bits = type.bit_width();
@@ -124,14 +123,15 @@ template <typename DT>
 Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
   ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(arr));
 
-  using Vec = internal::SmallVector<int64_t, 2>;
+  using Vec = std::array<int64_t, 1>;
 
   const auto* data = arr->data().get();  // lifetime of data is bound by arr
-  const auto* type = arr->type().get();  // lifetime of data is bound by arr
+  const auto& type = *arr->type();
   auto params = ExportBufferParams<Vec>{
       .buffer_offset = data->offset,
       .buffer_size = data->length,
       .ndim = 1,
+      .strides = {1},
       .shape = {data->length},
       .device = device,
   };
@@ -139,31 +139,11 @@ Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
     return Status::TypeError("Can only use DLPack on arrays with no nulls.");
   }
 
-  // Iterate over nested fixed length container types.
-  // Each nested container increase the DLPack tensor dimension.
-  // Nulls are not supported by DLPack, at any nesting level.
-  while (type->id() == Type::FIXED_SIZE_LIST) {
-    const auto* fsl = internal::checked_cast<const FixedSizeListType*>(type);
-    type = fsl->value_type().get();
-    data = data->child_data.front().get();
-    if (data->GetNullCount() > 0) {
-      return Status::TypeError("Can only use DLPack on arrays with no nulls.");
-    }
-
-    params.ndim++;
-    params.buffer_offset = params.buffer_offset * fsl->list_size() + data->offset;
-    params.buffer_size *= fsl->list_size();
-    params.shape.push_back(fsl->list_size());
-  }
-
-  // Get the DLDataType struct of the type leaf, or fail if it is not supported.
-  ARROW_ASSIGN_OR_RAISE(params.dtype, GetLeafDLDataType(*type));
+  // Get the DLDataType struct of the type, or fail if it is not supported.
+  ARROW_ASSIGN_OR_RAISE(params.dtype, GetDLDataType(type));
   // Use byte domain indexing.
-  params.buffer_offset *= type->byte_width();
-  params.buffer_size *= type->byte_width();
-  // Compute strides as row major.
-  params.strides.resize(params.shape.size());
-  RETURN_NOT_OK(internal::ComputeRowMajorStrides(params.shape, 1, params.strides));
+  params.buffer_offset *= type.byte_width();
+  params.buffer_size *= type.byte_width();
 
   if (copy) {
     // We copy the buffer slice instead of using Array copy functions to avoid copying
@@ -225,7 +205,7 @@ Result<DT*> ExportTensorImpl(const std::shared_ptr<Tensor>& t, bool copy) {
 
   // Define the DLDataType struct
   const auto& type = *t->type();
-  ARROW_ASSIGN_OR_RAISE(auto dtype, GetLeafDLDataType(type));
+  ARROW_ASSIGN_OR_RAISE(auto dtype, GetDLDataType(type));
 
   auto params = ExportBufferParams<std::vector<int64_t>>{
       .buffer_size = t->size(),

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -20,7 +20,6 @@
 #include <array>
 #include <memory>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 #include "arrow/array/array_base.h"
@@ -71,13 +70,13 @@ struct ExportBufferParams {
   std::shared_ptr<Buffer> buffer = nullptr;
   /// Data offset in the buffer in bytes.
   int64_t buffer_offset = 0;
-  /// Total number of bytes to read in the buffer.
-  int64_t buffer_size = 0;
-  int32_t ndim = 0;
-  Vec strides = {};
-  Vec shape = {};
-  DLDevice device = {};
-  DLDataType dtype = {};
+  /// Total number of values, i.e. the product of the shape.
+  int64_t size;
+  int32_t ndim;
+  Vec strides;
+  Vec shape;
+  DLDevice device;
+  DLDataType dtype;
   uint64_t flags = 0;
 };
 
@@ -94,7 +93,7 @@ DT* ExportBuffer(ExportBufferParams<Vec>&& p) {
 
   // Define the data pointer to the DLTensor
   // If array is of length 0, data pointer should be NULL
-  if (p.buffer_size == 0) {
+  if (p.size == 0) {
     ctx->tensor.dl_tensor.data = nullptr;
   } else {
     ctx->tensor.dl_tensor.data =
@@ -122,41 +121,37 @@ DT* ExportBuffer(ExportBufferParams<Vec>&& p) {
 
 template <typename DT>
 Result<DT*> ExportArrayImpl(const std::shared_ptr<Array>& arr, bool copy) {
-  ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(arr));
-
-  using Vec = std::array<int64_t, 1>;
-
-  const auto* data = arr->data().get();  // lifetime of data is bound by arr
-  const auto& type = *arr->type();
-  auto params = ExportBufferParams<Vec>{
-      .buffer_offset = data->offset,
-      .buffer_size = data->length,
-      .ndim = 1,
-      .strides = {1},
-      .shape = {data->length},
-      .device = device,
-  };
-  if (data->GetNullCount() > 0) {
+  if (arr->null_count() > 0) {
     return Status::TypeError("Can only use DLPack on arrays with no nulls.");
   }
+  ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(arr));
 
-  // Get the DLDataType struct of the type, or fail if it is not supported.
-  ARROW_ASSIGN_OR_RAISE(params.dtype, GetDLDataType(type));
-  // Use byte domain indexing.
-  params.buffer_offset *= type.byte_width();
-  params.buffer_size *= type.byte_width();
+  // Define the DLDataType struct, or fail if the type is not supported.
+  const auto& type = *arr->type();
+  ARROW_ASSIGN_OR_RAISE(auto dtype, GetDLDataType(type));
 
+  auto params = ExportBufferParams<std::array<int64_t, 1>>{
+      .size = arr->length(),
+      .ndim = 1,
+      .strides = {1},
+      .shape = {arr->length()},
+      .device = device,
+      .dtype = dtype,
+  };
+
+  const auto& data = *arr->data();
   if (copy) {
     // We copy the buffer slice instead of using Array copy functions to avoid copying
     // unused values outside of offset/length (e.g. with Slice).
-    const auto start = std::exchange(params.buffer_offset, 0);
-    const auto nbytes = params.buffer_size;
-    ARROW_ASSIGN_OR_RAISE(params.buffer, data->buffers[1]->CopySlice(start, nbytes));
+    const auto start = data.offset * type.byte_width();
+    const auto nbytes = data.length * type.byte_width();
+    ARROW_ASSIGN_OR_RAISE(params.buffer, data.buffers[1]->CopySlice(start, nbytes));
     // Since we make a copy only for the consumer, we do not need to mark it readonly.
     params.flags = DLPACK_FLAG_BITMASK_IS_COPIED;
   } else {
     // Shared buffer with Arrow Array. Arrays are readonly once constructed.
-    params.buffer = data->buffers[1];
+    params.buffer = data.buffers[1];
+    params.buffer_offset = data.offset * type.byte_width();
     params.flags = DLPACK_FLAG_BITMASK_READ_ONLY;
   }
 
@@ -191,14 +186,6 @@ Result<DLDevice> ExportDevice(const std::shared_ptr<Array>& arr) {
 
 namespace {
 
-template <typename T>
-std::vector<T> StridesInElements(std::vector<T> strides, T byte_width) {
-  for (auto& s : strides) {
-    s /= byte_width;
-  }
-  return strides;
-}
-
 template <typename DT>
 Result<DT*> ExportTensorImpl(const std::shared_ptr<Tensor>& t, bool copy) {
   // Define DLDevice struct
@@ -208,10 +195,18 @@ Result<DT*> ExportTensorImpl(const std::shared_ptr<Tensor>& t, bool copy) {
   const auto& type = *t->type();
   ARROW_ASSIGN_OR_RAISE(auto dtype, GetDLDataType(type));
 
+  // Compute strides
+  std::vector<int64_t> strides = {};
+  strides.reserve(t->ndim());
+  const auto byte_width = type.byte_width();
+  for (auto i : t->strides()) {
+    strides.emplace_back(i / byte_width);
+  }
+
   auto params = ExportBufferParams<std::vector<int64_t>>{
-      .buffer_size = t->size(),
+      .size = t->size(),
       .ndim = t->ndim(),
-      .strides = StridesInElements<int64_t>(t->strides(), type.byte_width()),
+      .strides = std::move(strides),
       .shape = t->shape(),
       .device = device,
       .dtype = dtype,

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -15,19 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <span>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
 #include "arrow/buffer.h"
 #include "arrow/c/dlpack.h"
 #include "arrow/c/dlpack_abi.h"
 #include "arrow/memory_pool.h"
 #include "arrow/tensor.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/checked_cast.h"
 
 namespace arrow::dlpack {
 
@@ -73,28 +78,45 @@ class TestExportArray : public ::testing::Test {};
 
 TYPED_TEST_SUITE(TestExportArray, ProducerTypes, ProducerNames);
 
+/// The flat values a DLPack tensor views: the array itself, or the innermost
+/// values of nested fixed size lists, windowed to what ``arr`` covers.
+std::shared_ptr<Array> LeafValues(std::shared_ptr<Array> arr) {
+  while (arr->type_id() == Type::FIXED_SIZE_LIST) {
+    const auto& fsl = internal::checked_cast<const FixedSizeListArray&>(*arr);
+    arr = fsl.values()->Slice(fsl.value_offset(0), arr->length() * fsl.value_length());
+  }
+  return arr;
+}
+
 template <typename Producer>
 void CheckDLTensor(const std::shared_ptr<Array>& arr,
                    const std::shared_ptr<DataType>& arrow_type,
-                   DLDataTypeCode dlpack_type, int64_t length) {
+                   DLDataTypeCode dlpack_type, const std::vector<int64_t>& shape,
+                   const std::vector<int64_t>& strides) {
   ASSERT_OK_AND_ASSIGN(auto* dlmtensor, Producer::Export(arr));
   auto dltensor = dlmtensor->dl_tensor;
 
-  const auto byte_width = arr->type()->byte_width();
-  const auto start = arr->offset() * byte_width;
+  const auto values = LeafValues(arr);
+  ASSERT_EQ(arrow_type->id(), values->type_id());
+  const auto byte_width = arrow_type->byte_width();
+  const auto start = values->offset() * byte_width;
   ASSERT_OK_AND_ASSIGN(auto sliced_buffer,
-                       SliceBufferSafe(arr->data()->buffers[1], start));
+                       SliceBufferSafe(values->data()->buffers[1], start));
   if constexpr (Producer::copy) {
     ASSERT_NE(sliced_buffer->data(), dltensor.data);
-    ASSERT_EQ(0, std::memcmp(sliced_buffer->data(), dltensor.data, length * byte_width));
+    ASSERT_EQ(0, std::memcmp(sliced_buffer->data(), dltensor.data,
+                             values->length() * byte_width));
   } else {
     ASSERT_EQ(sliced_buffer->data(), dltensor.data);
   }
 
   ASSERT_EQ(0, dltensor.byte_offset);
-  ASSERT_EQ(length, dltensor.shape[0]);
-  ASSERT_EQ(1, dltensor.ndim);
-  ASSERT_EQ(1, *dltensor.strides);  // Must be non-null with ndim>0 since 1.2
+  ASSERT_EQ(shape.size(), static_cast<size_t>(dltensor.ndim));
+  ASSERT_THAT(std::span(dltensor.shape, dltensor.ndim),
+              ::testing::ElementsAreArray(shape));
+  // Strides must be non-null with ndim>0 since 1.2
+  ASSERT_THAT(std::span(dltensor.strides, dltensor.ndim),
+              ::testing::ElementsAreArray(strides));
 
   ASSERT_EQ(dlpack_type, dltensor.dtype.code);
   ASSERT_EQ(arrow_type->bit_width(), dltensor.dtype.bits);
@@ -148,16 +170,71 @@ TYPED_TEST(TestExportArray, TestSupportedArray) {
   for (auto [arrow_type, dlpack_type] : cases) {
     const std::shared_ptr<Array> array =
         ArrayFromJSON(arrow_type, "[1, 0, 10, 0, 2, 1, 3, 5, 1, 0]");
-    CheckDLTensor<TypeParam>(array, arrow_type, dlpack_type, 10);
+    CheckDLTensor<TypeParam>(array, arrow_type, dlpack_type, {10}, {1});
     ASSERT_OK_AND_ASSIGN(auto sliced_1, array->SliceSafe(1, 5));
-    CheckDLTensor<TypeParam>(sliced_1, arrow_type, dlpack_type, 5);
+    CheckDLTensor<TypeParam>(sliced_1, arrow_type, dlpack_type, {5}, {1});
     ASSERT_OK_AND_ASSIGN(auto sliced_2, array->SliceSafe(0, 5));
-    CheckDLTensor<TypeParam>(sliced_2, arrow_type, dlpack_type, 5);
+    CheckDLTensor<TypeParam>(sliced_2, arrow_type, dlpack_type, {5}, {1});
     ASSERT_OK_AND_ASSIGN(auto sliced_3, array->SliceSafe(3));
-    CheckDLTensor<TypeParam>(sliced_3, arrow_type, dlpack_type, 7);
+    CheckDLTensor<TypeParam>(sliced_3, arrow_type, dlpack_type, {7}, {1});
   }
 
   ASSERT_EQ(allocated_bytes, arrow::default_memory_pool()->bytes_allocated());
+}
+
+TYPED_TEST(TestExportArray, TestFixedSizeList) {
+  const auto type = fixed_size_list(int32(), 3);
+  const std::shared_ptr<Array> array = ArrayFromJSON(
+      type, "[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]");
+  CheckDLTensor<TypeParam>(array, int32(), DLDataTypeCode::kDLInt, {5, 3}, {3, 1});
+
+  // Offset on the list array itself
+  ASSERT_OK_AND_ASSIGN(auto sliced, array->SliceSafe(2, 3));
+  CheckDLTensor<TypeParam>(sliced, int32(), DLDataTypeCode::kDLInt, {3, 3}, {3, 1});
+
+  // Offset on the values array
+  ASSERT_OK_AND_ASSIGN(
+      auto values,
+      ArrayFromJSON(int32(), "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]")->SliceSafe(3, 9));
+  ASSERT_OK_AND_ASSIGN(auto from_values, FixedSizeListArray::FromArrays(values, 3));
+  CheckDLTensor<TypeParam>(from_values, int32(), DLDataTypeCode::kDLInt, {3, 3}, {3, 1});
+
+  // Offsets on both the list array and its values
+  ASSERT_OK_AND_ASSIGN(auto sliced_from_values, from_values->SliceSafe(1, 2));
+  CheckDLTensor<TypeParam>(sliced_from_values, int32(), DLDataTypeCode::kDLInt, {2, 3},
+                           {3, 1});
+}
+
+TYPED_TEST(TestExportArray, TestNestedFixedSizeList) {
+  const auto type = fixed_size_list(fixed_size_list(float32(), 2), 3);
+  const std::shared_ptr<Array> array = ArrayFromJSON(type, R"([
+      [[1, 2], [3, 4], [5, 6]],
+      [[7, 8], [9, 10], [11, 12]],
+      [[13, 14], [15, 16], [17, 18]],
+      [[19, 20], [21, 22], [23, 24]]
+  ])");
+  CheckDLTensor<TypeParam>(array, float32(), DLDataTypeCode::kDLFloat, {4, 3, 2},
+                           {6, 2, 1});
+
+  // Offset on the outer list array only
+  ASSERT_OK_AND_ASSIGN(auto sliced, array->SliceSafe(1, 2));
+  CheckDLTensor<TypeParam>(sliced, float32(), DLDataTypeCode::kDLFloat, {2, 3, 2},
+                           {6, 2, 1});
+
+  // Offsets accumulated at every level: the innermost values are offset by 2, the
+  // middle lists by 3 * 2, and the outer lists by 1 * 3 * 2.
+  ASSERT_OK_AND_ASSIGN(auto values,
+                       ArrayFromJSON(float32(),
+                                     "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, "
+                                     "12, 13, 14, 15, 16, 17, 18, 19]")
+                           ->SliceSafe(2, 18));
+  ASSERT_OK_AND_ASSIGN(auto inner, FixedSizeListArray::FromArrays(values, 2));
+  ASSERT_OK_AND_ASSIGN(auto outer, FixedSizeListArray::FromArrays(inner, 3));
+  CheckDLTensor<TypeParam>(outer, float32(), DLDataTypeCode::kDLFloat, {3, 3, 2},
+                           {6, 2, 1});
+  ASSERT_OK_AND_ASSIGN(auto sliced_outer, outer->SliceSafe(1, 2));
+  CheckDLTensor<TypeParam>(sliced_outer, float32(), DLDataTypeCode::kDLFloat, {2, 3, 2},
+                           {6, 2, 1});
 }
 
 TYPED_TEST(TestExportArray, TestErrors) {
@@ -179,10 +256,33 @@ TYPED_TEST(TestExportArray, TestErrors) {
                                  array_string->type()->ToString(),
                              TypeParam::Export(array_string));
 
+  const std::shared_ptr<Array> list_of_string =
+      ArrayFromJSON(fixed_size_list(utf8(), 1), R"([["itsy"], ["bitsy"]])");
+  ASSERT_RAISES_WITH_MESSAGE(
+      TypeError,
+      "Type error: DataType is not compatible with DLPack spec: " + utf8()->ToString(),
+      TypeParam::Export(list_of_string));
+
+  const std::shared_ptr<Array> list_with_null =
+      ArrayFromJSON(fixed_size_list(int8(), 2), "[[1, 2], null]");
+  ASSERT_RAISES_WITH_MESSAGE(TypeError,
+                             "Type error: Can only use DLPack on arrays with no nulls.",
+                             TypeParam::Export(list_with_null));
+
+  const std::shared_ptr<Array> list_with_null_value =
+      ArrayFromJSON(fixed_size_list(int8(), 2), "[[1, 2], [3, null]]");
+  ASSERT_RAISES_WITH_MESSAGE(TypeError,
+                             "Type error: Can only use DLPack on arrays with no nulls.",
+                             TypeParam::Export(list_with_null_value));
+
   const std::shared_ptr<Array> array_boolean = ArrayFromJSON(boolean(), "[true, false]");
   ASSERT_RAISES_WITH_MESSAGE(
       TypeError, "Type error: Bit-packed boolean data type not supported by DLPack.",
-      arrow::dlpack::ExportDevice(array_boolean));
+      TypeParam::Export(array_boolean));
+
+  // ExportDevice only reports the device, it does not validate the type
+  ASSERT_OK(arrow::dlpack::ExportDevice(array_boolean));
+  ASSERT_OK(arrow::dlpack::ExportDevice(array_null));
 }
 
 template <typename Producer>

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -25,14 +25,12 @@
 #include <vector>
 
 #include "arrow/array/array_base.h"
-#include "arrow/array/array_nested.h"
 #include "arrow/buffer.h"
 #include "arrow/c/dlpack.h"
 #include "arrow/c/dlpack_abi.h"
 #include "arrow/memory_pool.h"
 #include "arrow/tensor.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/util/checked_cast.h"
 
 namespace arrow::dlpack {
 
@@ -78,16 +76,6 @@ class TestExportArray : public ::testing::Test {};
 
 TYPED_TEST_SUITE(TestExportArray, ProducerTypes, ProducerNames);
 
-/// The flat values a DLPack tensor views: the array itself, or the innermost
-/// values of nested fixed size lists, windowed to what ``arr`` covers.
-std::shared_ptr<Array> LeafValues(std::shared_ptr<Array> arr) {
-  while (arr->type_id() == Type::FIXED_SIZE_LIST) {
-    const auto& fsl = internal::checked_cast<const FixedSizeListArray&>(*arr);
-    arr = fsl.values()->Slice(fsl.value_offset(0), arr->length() * fsl.value_length());
-  }
-  return arr;
-}
-
 template <typename Producer>
 void CheckDLTensor(const std::shared_ptr<Array>& arr,
                    const std::shared_ptr<DataType>& arrow_type,
@@ -96,16 +84,15 @@ void CheckDLTensor(const std::shared_ptr<Array>& arr,
   ASSERT_OK_AND_ASSIGN(auto* dlmtensor, Producer::Export(arr));
   auto dltensor = dlmtensor->dl_tensor;
 
-  const auto values = LeafValues(arr);
-  ASSERT_EQ(arrow_type->id(), values->type_id());
+  ASSERT_EQ(arrow_type->id(), arr->type_id());
   const auto byte_width = arrow_type->byte_width();
-  const auto start = values->offset() * byte_width;
+  const auto start = arr->offset() * byte_width;
   ASSERT_OK_AND_ASSIGN(auto sliced_buffer,
-                       SliceBufferSafe(values->data()->buffers[1], start));
+                       SliceBufferSafe(arr->data()->buffers[1], start));
   if constexpr (Producer::copy) {
     ASSERT_NE(sliced_buffer->data(), dltensor.data);
-    ASSERT_EQ(0, std::memcmp(sliced_buffer->data(), dltensor.data,
-                             values->length() * byte_width));
+    ASSERT_EQ(
+        0, std::memcmp(sliced_buffer->data(), dltensor.data, arr->length() * byte_width));
   } else {
     ASSERT_EQ(sliced_buffer->data(), dltensor.data);
   }
@@ -182,61 +169,6 @@ TYPED_TEST(TestExportArray, TestSupportedArray) {
   ASSERT_EQ(allocated_bytes, arrow::default_memory_pool()->bytes_allocated());
 }
 
-TYPED_TEST(TestExportArray, TestFixedSizeList) {
-  const auto type = fixed_size_list(int32(), 3);
-  const std::shared_ptr<Array> array = ArrayFromJSON(
-      type, "[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]");
-  CheckDLTensor<TypeParam>(array, int32(), DLDataTypeCode::kDLInt, {5, 3}, {3, 1});
-
-  // Offset on the list array itself
-  ASSERT_OK_AND_ASSIGN(auto sliced, array->SliceSafe(2, 3));
-  CheckDLTensor<TypeParam>(sliced, int32(), DLDataTypeCode::kDLInt, {3, 3}, {3, 1});
-
-  // Offset on the values array
-  ASSERT_OK_AND_ASSIGN(
-      auto values,
-      ArrayFromJSON(int32(), "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]")->SliceSafe(3, 9));
-  ASSERT_OK_AND_ASSIGN(auto from_values, FixedSizeListArray::FromArrays(values, 3));
-  CheckDLTensor<TypeParam>(from_values, int32(), DLDataTypeCode::kDLInt, {3, 3}, {3, 1});
-
-  // Offsets on both the list array and its values
-  ASSERT_OK_AND_ASSIGN(auto sliced_from_values, from_values->SliceSafe(1, 2));
-  CheckDLTensor<TypeParam>(sliced_from_values, int32(), DLDataTypeCode::kDLInt, {2, 3},
-                           {3, 1});
-}
-
-TYPED_TEST(TestExportArray, TestNestedFixedSizeList) {
-  const auto type = fixed_size_list(fixed_size_list(float32(), 2), 3);
-  const std::shared_ptr<Array> array = ArrayFromJSON(type, R"([
-      [[1, 2], [3, 4], [5, 6]],
-      [[7, 8], [9, 10], [11, 12]],
-      [[13, 14], [15, 16], [17, 18]],
-      [[19, 20], [21, 22], [23, 24]]
-  ])");
-  CheckDLTensor<TypeParam>(array, float32(), DLDataTypeCode::kDLFloat, {4, 3, 2},
-                           {6, 2, 1});
-
-  // Offset on the outer list array only
-  ASSERT_OK_AND_ASSIGN(auto sliced, array->SliceSafe(1, 2));
-  CheckDLTensor<TypeParam>(sliced, float32(), DLDataTypeCode::kDLFloat, {2, 3, 2},
-                           {6, 2, 1});
-
-  // Offsets accumulated at every level: the innermost values are offset by 2, the
-  // middle lists by 3 * 2, and the outer lists by 1 * 3 * 2.
-  ASSERT_OK_AND_ASSIGN(auto values,
-                       ArrayFromJSON(float32(),
-                                     "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, "
-                                     "12, 13, 14, 15, 16, 17, 18, 19]")
-                           ->SliceSafe(2, 18));
-  ASSERT_OK_AND_ASSIGN(auto inner, FixedSizeListArray::FromArrays(values, 2));
-  ASSERT_OK_AND_ASSIGN(auto outer, FixedSizeListArray::FromArrays(inner, 3));
-  CheckDLTensor<TypeParam>(outer, float32(), DLDataTypeCode::kDLFloat, {3, 3, 2},
-                           {6, 2, 1});
-  ASSERT_OK_AND_ASSIGN(auto sliced_outer, outer->SliceSafe(1, 2));
-  CheckDLTensor<TypeParam>(sliced_outer, float32(), DLDataTypeCode::kDLFloat, {2, 3, 2},
-                           {6, 2, 1});
-}
-
 TYPED_TEST(TestExportArray, TestErrors) {
   const std::shared_ptr<Array> array_null = ArrayFromJSON(null(), "[]");
   ASSERT_RAISES_WITH_MESSAGE(TypeError,
@@ -255,25 +187,6 @@ TYPED_TEST(TestExportArray, TestErrors) {
                              "Type error: DataType is not compatible with DLPack spec: " +
                                  array_string->type()->ToString(),
                              TypeParam::Export(array_string));
-
-  const std::shared_ptr<Array> list_of_string =
-      ArrayFromJSON(fixed_size_list(utf8(), 1), R"([["itsy"], ["bitsy"]])");
-  ASSERT_RAISES_WITH_MESSAGE(
-      TypeError,
-      "Type error: DataType is not compatible with DLPack spec: " + utf8()->ToString(),
-      TypeParam::Export(list_of_string));
-
-  const std::shared_ptr<Array> list_with_null =
-      ArrayFromJSON(fixed_size_list(int8(), 2), "[[1, 2], null]");
-  ASSERT_RAISES_WITH_MESSAGE(TypeError,
-                             "Type error: Can only use DLPack on arrays with no nulls.",
-                             TypeParam::Export(list_with_null));
-
-  const std::shared_ptr<Array> list_with_null_value =
-      ArrayFromJSON(fixed_size_list(int8(), 2), "[[1, 2], [3, null]]");
-  ASSERT_RAISES_WITH_MESSAGE(TypeError,
-                             "Type error: Can only use DLPack on arrays with no nulls.",
-                             TypeParam::Export(list_with_null_value));
 
   const std::shared_ptr<Array> array_boolean = ArrayFromJSON(boolean(), "[true, false]");
   ASSERT_RAISES_WITH_MESSAGE(

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
-#include <span>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -99,11 +98,8 @@ void CheckDLTensor(const std::shared_ptr<Array>& arr,
 
   ASSERT_EQ(0, dltensor.byte_offset);
   ASSERT_EQ(shape.size(), static_cast<size_t>(dltensor.ndim));
-  ASSERT_THAT(std::span(dltensor.shape, dltensor.ndim),
-              ::testing::ElementsAreArray(shape));
-  // Strides must be non-null with ndim>0 since 1.2
-  ASSERT_THAT(std::span(dltensor.strides, dltensor.ndim),
-              ::testing::ElementsAreArray(strides));
+  ASSERT_THAT(shape, ::testing::ElementsAreArray(dltensor.shape, dltensor.ndim));
+  ASSERT_THAT(strides, ::testing::ElementsAreArray(dltensor.strides, dltensor.ndim));
 
   ASSERT_EQ(dlpack_type, dltensor.dtype.code);
   ASSERT_EQ(arrow_type->bit_width(), dltensor.dtype.bits);

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -173,7 +173,9 @@ TYPED_TEST(TestExportArray, TestErrors) {
   const std::shared_ptr<Array> array_null = ArrayFromJSON(null(), "[]");
   ASSERT_RAISES_WITH_MESSAGE(TypeError,
                              "Type error: DataType is not compatible with DLPack spec: " +
-                                 array_null->type()->ToString(),
+                                 array_null->type()->ToString() +
+                                 ", try converting to a Tensor for multi"
+                                 " dimensional data support",
                              TypeParam::Export(array_null));
 
   const std::shared_ptr<Array> array_with_null = ArrayFromJSON(int8(), "[1, 100, null]");
@@ -185,7 +187,9 @@ TYPED_TEST(TestExportArray, TestErrors) {
       ArrayFromJSON(utf8(), R"(["itsy", "bitsy", "spider"])");
   ASSERT_RAISES_WITH_MESSAGE(TypeError,
                              "Type error: DataType is not compatible with DLPack spec: " +
-                                 array_string->type()->ToString(),
+                                 array_string->type()->ToString() +
+                                 ", try converting to a Tensor for multi"
+                                 " dimensional data support",
                              TypeParam::Export(array_string));
 
   const std::shared_ptr<Array> array_boolean = ArrayFromJSON(boolean(), "[true, false]");

--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -319,7 +319,7 @@ Result<std::shared_ptr<FixedShapeTensorArray>> FixedShapeTensorArray::FromTensor
   return std::static_pointer_cast<FixedShapeTensorArray>(ext_arr);
 }
 
-const Result<std::shared_ptr<Tensor>> FixedShapeTensorArray::ToTensor() const {
+Result<std::shared_ptr<Tensor>> FixedShapeTensorArray::ToTensor() const {
   // To convert an array of n dimensional tensors to a n+1 dimensional tensor we
   // interpret the array's length as the first dimension the new tensor.
 

--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -319,7 +319,7 @@ Result<std::shared_ptr<FixedShapeTensorArray>> FixedShapeTensorArray::FromTensor
   return std::static_pointer_cast<FixedShapeTensorArray>(ext_arr);
 }
 
-Result<std::shared_ptr<Tensor>> FixedShapeTensorArray::ToTensor() const {
+Result<std::shared_ptr<Tensor>> FixedShapeTensorArray::ToTensorWithNulls() const {
   // To convert an array of n dimensional tensors to a n+1 dimensional tensor we
   // interpret the array's length as the first dimension the new tensor.
 

--- a/cpp/src/arrow/extension/fixed_shape_tensor.h
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.h
@@ -43,7 +43,10 @@ class ARROW_EXPORT FixedShapeTensorArray : public ExtensionArray {
   /// dimension as length equal to the FixedShapeTensorArray's length and the remaining
   /// dimensions as the FixedShapeTensorType's shape. Shape and dim_names will be
   /// permuted according to permutation stored in the FixedShapeTensorType metadata.
-  const Result<std::shared_ptr<Tensor>> ToTensor() const;
+  ///
+  /// Nulls are ignored, leaving the output tensor with unspecified values where this
+  /// array null entries.
+  Result<std::shared_ptr<Tensor>> ToTensor() const override;
 };
 
 /// \brief Concrete type class for constant-size Tensor data.

--- a/cpp/src/arrow/extension/fixed_shape_tensor.h
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.h
@@ -45,7 +45,7 @@ class ARROW_EXPORT FixedShapeTensorArray : public ExtensionArray {
   /// permuted according to permutation stored in the FixedShapeTensorType metadata.
   ///
   /// Nulls are ignored, leaving the output tensor with unspecified values where this
-  /// array null entries.
+  /// array has null entries.
   Result<std::shared_ptr<Tensor>> ToTensor() const override;
 };
 

--- a/cpp/src/arrow/extension/fixed_shape_tensor.h
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.h
@@ -37,6 +37,7 @@ class ARROW_EXPORT FixedShapeTensorArray : public ExtensionArray {
   static Result<std::shared_ptr<FixedShapeTensorArray>> FromTensor(
       const std::shared_ptr<Tensor>& tensor);
 
+ protected:
   /// \brief Create a Tensor from FixedShapeTensorArray
   ///
   /// This method will create a Tensor from a FixedShapeTensorArray, setting its first
@@ -46,7 +47,7 @@ class ARROW_EXPORT FixedShapeTensorArray : public ExtensionArray {
   ///
   /// Nulls are ignored, leaving the output tensor with unspecified values where this
   /// array has null entries.
-  Result<std::shared_ptr<Tensor>> ToTensor() const override;
+  Result<std::shared_ptr<Tensor>> ToTensorWithNulls() const override;
 };
 
 /// \brief Concrete type class for constant-size Tensor data.

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -45,34 +45,36 @@ using internal::checked_cast;
 
 namespace internal {
 
-Status ComputeRowMajorStrides(const FixedWidthType& type,
-                              const std::vector<int64_t>& shape,
-                              std::vector<int64_t>* strides) {
-  const int byte_width = type.byte_width();
-  const size_t ndim = shape.size();
-
-  int64_t remaining = 0;
-  if (!shape.empty() && shape.front() > 0) {
-    remaining = byte_width;
-    for (size_t i = 1; i < ndim; ++i) {
-      if (internal::MultiplyWithOverflow(remaining, shape[i], &remaining)) {
-        return Status::Invalid(
-            "Row-major strides computed from shape would not fit in 64-bit integer");
-      }
-    }
+Status ComputeRowMajorStrides(std::span<const int64_t> shape, int64_t elem_size,
+                              std::span<int64_t> strides) {
+  if (strides.size() != shape.size()) {
+    return Status::Invalid("strides must have the same length as shape");
   }
 
-  if (remaining == 0) {
-    strides->assign(shape.size(), byte_width);
+  // An empty dimension makes the whole tensor empty, so any stride is as good.
+  if (std::find(shape.begin(), shape.end(), 0) != shape.end()) {
+    std::fill(strides.begin(), strides.end(), elem_size);
     return Status::OK();
   }
 
-  strides->push_back(remaining);
-  for (size_t i = 1; i < ndim; ++i) {
-    remaining /= shape[i];
-    strides->push_back(remaining);
+  // The outermost dimension is never a factor of the strides, so a shape whose total
+  // number of elements overflows can still have valid strides.
+  int64_t stride = elem_size;
+  for (auto i = static_cast<int64_t>(shape.size()) - 1; i >= 0; --i) {
+    strides[i] = stride;
+    if (i > 0 && internal::MultiplyWithOverflow(stride, shape[i], &stride)) {
+      return Status::Invalid(
+          "Row-major strides computed from shape would not fit in 64-bit integer");
+    }
   }
+  return Status::OK();
+}
 
+Status ComputeRowMajorStrides(const FixedWidthType& type, std::span<const int64_t> shape,
+                              std::vector<int64_t>* strides) {
+  auto computed = std::vector<int64_t>(shape.size());
+  RETURN_NOT_OK(ComputeRowMajorStrides(shape, type.byte_width(), computed));
+  *strides = std::move(computed);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -488,6 +488,11 @@ Status RecordBatchToTensor(const RecordBatch& batch, bool null_to_nan, bool row_
 
 }  // namespace internal
 
+Result<std::shared_ptr<Tensor>> Tensor::FromArray(const std::shared_ptr<Array>& array,
+                                                  bool allow_nulls) {
+  return array->ToTensor(allow_nulls);
+}
+
 /// Constructor with strides and dimension names
 Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
                const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -45,36 +45,34 @@ using internal::checked_cast;
 
 namespace internal {
 
-Status ComputeRowMajorStrides(std::span<const int64_t> shape, int64_t elem_size,
-                              std::span<int64_t> strides) {
-  if (strides.size() != shape.size()) {
-    return Status::Invalid("strides must have the same length as shape");
+Status ComputeRowMajorStrides(const FixedWidthType& type,
+                              const std::vector<int64_t>& shape,
+                              std::vector<int64_t>* strides) {
+  const int byte_width = type.byte_width();
+  const size_t ndim = shape.size();
+
+  int64_t remaining = 0;
+  if (!shape.empty() && shape.front() > 0) {
+    remaining = byte_width;
+    for (size_t i = 1; i < ndim; ++i) {
+      if (internal::MultiplyWithOverflow(remaining, shape[i], &remaining)) {
+        return Status::Invalid(
+            "Row-major strides computed from shape would not fit in 64-bit integer");
+      }
+    }
   }
 
-  // An empty dimension makes the whole tensor empty, so any stride is as good.
-  if (std::find(shape.begin(), shape.end(), 0) != shape.end()) {
-    std::fill(strides.begin(), strides.end(), elem_size);
+  if (remaining == 0) {
+    strides->assign(shape.size(), byte_width);
     return Status::OK();
   }
 
-  // The outermost dimension is never a factor of the strides, so a shape whose total
-  // number of elements overflows can still have valid strides.
-  int64_t stride = elem_size;
-  for (auto i = static_cast<int64_t>(shape.size()) - 1; i >= 0; --i) {
-    strides[i] = stride;
-    if (i > 0 && internal::MultiplyWithOverflow(stride, shape[i], &stride)) {
-      return Status::Invalid(
-          "Row-major strides computed from shape would not fit in 64-bit integer");
-    }
+  strides->push_back(remaining);
+  for (size_t i = 1; i < ndim; ++i) {
+    remaining /= shape[i];
+    strides->push_back(remaining);
   }
-  return Status::OK();
-}
 
-Status ComputeRowMajorStrides(const FixedWidthType& type, std::span<const int64_t> shape,
-                              std::vector<int64_t>* strides) {
-  auto computed = std::vector<int64_t>(shape.size());
-  RETURN_NOT_OK(ComputeRowMajorStrides(shape, type.byte_width(), computed));
-  *strides = std::move(computed);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -144,7 +144,7 @@ inline Status CheckTensorValidity(const std::shared_ptr<DataType>& type,
     return Status::Invalid("Null type is supplied");
   }
   if (!is_tensor_supported(type->id())) {
-    return Status::Invalid(type->ToString(), " is not valid data type for a tensor");
+    return Status::TypeError(type->ToString(), " is not valid data type for a tensor");
   }
   if (!data) {
     return Status::Invalid("Null data is supplied");

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -56,9 +57,16 @@ constexpr bool is_tensor_supported(Type::type type_id) {
 namespace internal {
 
 ARROW_EXPORT
-Status ComputeRowMajorStrides(const FixedWidthType& type,
-                              const std::vector<int64_t>& shape,
+Status ComputeRowMajorStrides(const FixedWidthType& type, std::span<const int64_t> shape,
                               std::vector<int64_t>* strides);
+
+/// Compute the row-major strides of a tensor with the given shape.
+///
+/// Pass `elem_size=1` to get the strides in number of elements, or the element size in
+/// bytes to get them in bytes. On error, the contents of `strides` are unspecified.
+ARROW_EXPORT
+Status ComputeRowMajorStrides(std::span<const int64_t> shape, int64_t elem_size,
+                              std::span<int64_t> strides);
 
 ARROW_EXPORT
 Status ComputeColumnMajorStrides(const FixedWidthType& type,

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -27,13 +27,12 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
-
-class Array;
 
 constexpr bool is_tensor_supported(Type::type type_id) {
   switch (type_id) {

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <span>
 #include <string>
 #include <vector>
 
@@ -57,16 +56,9 @@ constexpr bool is_tensor_supported(Type::type type_id) {
 namespace internal {
 
 ARROW_EXPORT
-Status ComputeRowMajorStrides(const FixedWidthType& type, std::span<const int64_t> shape,
+Status ComputeRowMajorStrides(const FixedWidthType& type,
+                              const std::vector<int64_t>& shape,
                               std::vector<int64_t>* strides);
-
-/// Compute the row-major strides of a tensor with the given shape.
-///
-/// Pass `elem_size=1` to get the strides in number of elements, or the element size in
-/// bytes to get them in bytes. On error, the contents of `strides` are unspecified.
-ARROW_EXPORT
-Status ComputeRowMajorStrides(std::span<const int64_t> shape, int64_t elem_size,
-                              std::span<int64_t> strides);
 
 ARROW_EXPORT
 Status ComputeColumnMajorStrides(const FixedWidthType& type,

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -33,6 +33,8 @@
 
 namespace arrow {
 
+class Array;
+
 constexpr bool is_tensor_supported(Type::type type_id) {
   switch (type_id) {
     case Type::UINT8:

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -109,6 +109,12 @@ class ARROW_EXPORT Tensor {
     return std::make_shared<Tensor>(type, data, shape, strides, dim_names);
   }
 
+  /// \brief Attempt to create a Tensor from an Array.
+  ///
+  /// \see Array::ToTensor
+  static Result<std::shared_ptr<Tensor>> FromArray(const std::shared_ptr<Array>& array,
+                                                   bool allow_nulls = false);
+
   virtual ~Tensor() = default;
 
   /// Constructor with no dimension names or strides, data assumed to be row-major

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -235,7 +235,7 @@ TEST(TestTensor, MakeFailureCases) {
   ASSERT_RAISES(Invalid, Tensor::Make(nullptr, data, shape));
 
   // invalid type
-  ASSERT_RAISES(Invalid, Tensor::Make(binary(), data, shape));
+  ASSERT_RAISES(TypeError, Tensor::Make(binary(), data, shape));
 
   // null data
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), nullptr, shape));

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1841,6 +1841,28 @@ cdef class Array(_PandasConvertible):
             array = array.copy()
         return array
 
+    def to_tensor(self):
+        """
+        Convert this array to a pyarrow.Tensor.
+
+        This is supported when the data can reasonably be understood as a
+        multi-dimensional numeric tensor, such as numeric arrays (1D), nested
+        fixed size list arrays, and fixed shape tensor arrays.
+        The resulting tensor has a row major layout with the array elements
+        as the first dimension.
+        Null values are ignored, leaving the corresponding entries of the
+        tensor with unspecified values.
+        The conversion is zero-copy.
+
+        Returns
+        -------
+        pyarrow.Tensor
+        """
+        cdef shared_ptr[CTensor] ctensor
+        with nogil:
+            ctensor = GetResultValue(self.ap.ToTensor())
+        return pyarrow_wrap_tensor(ctensor)
+
     def to_pylist(self, *, maps_as_pydicts=None):
         """
         Convert to a list of native Python objects.
@@ -4967,12 +4989,7 @@ cdef class FixedShapeTensorArray(ExtensionArray):
             along the first dimension.
         """
 
-        cdef:
-            CFixedShapeTensorArray* ext_array = <CFixedShapeTensorArray*>(self.ap)
-            CResult[shared_ptr[CTensor]] ctensor
-        with nogil:
-            ctensor = ext_array.ToTensor()
-        return pyarrow_wrap_tensor(GetResultValue(ctensor))
+        return Array.to_tensor(self)
 
     @staticmethod
     def from_numpy_ndarray(obj, dim_names=None):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4842,15 +4842,12 @@ cdef class ExtensionArray(Array):
         -------
         ext_array : ExtensionArray
         """
-        cdef:
-            shared_ptr[CExtensionArray] ext_array
-
         if storage.type != typ.storage_type:
             raise TypeError(f"Incompatible storage type {storage.type} "
                             f"for extension type {typ}")
 
-        ext_array = make_shared[CExtensionArray](typ.sp_type, storage.sp_array)
-        cdef Array result = pyarrow_wrap_array(<shared_ptr[CArray]> ext_array)
+        cdef Array result = pyarrow_wrap_array(
+            typ.ext_type.WrapArray(typ.sp_type, storage.sp_array))
         result.validate()
         return result
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1841,7 +1841,7 @@ cdef class Array(_PandasConvertible):
             array = array.copy()
         return array
 
-    def to_tensor(self):
+    def to_tensor(self, allow_nulls=False):
         """
         Convert this array to a pyarrow.Tensor.
 
@@ -1849,18 +1849,24 @@ cdef class Array(_PandasConvertible):
         multi-dimensional numeric tensor, such as numeric arrays (1D), nested
         fixed size list arrays, and fixed shape tensor arrays.
         The resulting tensor has a row major layout with the array elements
-        as the first dimension.
-        Null values are ignored, leaving the corresponding entries of the
-        tensor with unspecified values.
-        The conversion is zero-copy.
+        as the first dimension. The conversion is zero-copy.
+
+        Parameters
+        ----------
+        allow_nulls: bool, default `True`
+            When true, nulls are ignored, leaving the output tensor with
+            unspecified values where this array has null entries.
+            When false, nulls are rejected.
 
         Returns
         -------
         pyarrow.Tensor
         """
-        cdef shared_ptr[CTensor] ctensor
+        cdef:
+            shared_ptr[CTensor] ctensor
+            c_bool c_allow_nulls = allow_nulls
         with nogil:
-            ctensor = GetResultValue(self.ap.ToTensor())
+            ctensor = GetResultValue(self.ap.ToTensor(c_allow_nulls))
         return pyarrow_wrap_tensor(ctensor)
 
     def to_pylist(self, *, maps_as_pydicts=None):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1853,7 +1853,7 @@ cdef class Array(_PandasConvertible):
 
         Parameters
         ----------
-        allow_nulls: bool, default `True`
+        allow_nulls : bool, default `False`
             When true, nulls are ignored, leaving the output tensor with
             unspecified values where this array has null entries.
             When false, nulls are rejected.
@@ -4974,7 +4974,7 @@ cdef class FixedShapeTensorArray(ExtensionArray):
 
         return self.to_tensor().to_numpy()
 
-    def to_tensor(self):
+    def to_tensor(self, allow_nulls=False):
         """
         Convert fixed shape tensor extension array to a pyarrow.Tensor.
 
@@ -4985,6 +4985,13 @@ cdef class FixedShapeTensorArray(ExtensionArray):
 
         The conversion is zero-copy.
 
+        Parameters
+        ----------
+        allow_nulls : bool, default `False`
+            When true, nulls are ignored, leaving the output tensor with
+            unspecified values where this array has null entries.
+            When false, nulls are rejected.
+
         Returns
         -------
         pyarrow.Tensor
@@ -4992,7 +4999,7 @@ cdef class FixedShapeTensorArray(ExtensionArray):
             along the first dimension.
         """
 
-        return Array.to_tensor(self)
+        return Array.to_tensor(self, allow_nulls=allow_nulls)
 
     @staticmethod
     def from_numpy_ndarray(obj, dim_names=None):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1841,7 +1841,7 @@ cdef class Array(_PandasConvertible):
             array = array.copy()
         return array
 
-    def to_tensor(self, allow_nulls=False):
+    def to_tensor(self, *, allow_nulls=False):
         """
         Convert this array to a pyarrow.Tensor.
 
@@ -4973,33 +4973,6 @@ cdef class FixedShapeTensorArray(ExtensionArray):
         """
 
         return self.to_tensor().to_numpy()
-
-    def to_tensor(self, allow_nulls=False):
-        """
-        Convert fixed shape tensor extension array to a pyarrow.Tensor.
-
-        The resulting Tensor will have (ndim + 1) dimensions.
-        The size of the first dimension will be the length of the fixed shape tensor array
-        and the rest of the dimensions will match the permuted shape of the fixed
-        shape tensor.
-
-        The conversion is zero-copy.
-
-        Parameters
-        ----------
-        allow_nulls : bool, default `False`
-            When true, nulls are ignored, leaving the output tensor with
-            unspecified values where this array has null entries.
-            When false, nulls are rejected.
-
-        Returns
-        -------
-        pyarrow.Tensor
-            Tensor representing tensors in the fixed shape tensor array concatenated
-            along the first dimension.
-        """
-
-        return Array.to_tensor(self, allow_nulls=allow_nulls)
 
     @staticmethod
     def from_numpy_ndarray(obj, dim_names=None):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -280,6 +280,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         const shared_ptr[CArrayStatistics]& statistics() const
 
+        CResult[shared_ptr[CTensor]] ToTensor() const
+
     shared_ptr[CArray] MakeArray(const shared_ptr[CArrayData]& data)
     CResult[shared_ptr[CArray]] MakeArrayOfNull(
         const shared_ptr[CDataType]& type, int64_t length, CMemoryPool* pool)
@@ -3087,10 +3089,6 @@ cdef extern from "arrow/extension/fixed_shape_tensor.h" namespace "arrow::extens
         const vector[int64_t] shape()
         const vector[int64_t] permutation()
         const vector[c_string] dim_names()
-
-    cdef cppclass CFixedShapeTensorArray \
-            " arrow::extension::FixedShapeTensorArray"(CExtensionArray):
-        const CResult[shared_ptr[CTensor]] ToTensor() const
 
 
 cdef extern from "arrow/extension/opaque.h" namespace "arrow::extension" nogil:

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -280,7 +280,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         const shared_ptr[CArrayStatistics]& statistics() const
 
-        CResult[shared_ptr[CTensor]] ToTensor() const
+        CResult[shared_ptr[CTensor]] ToTensor(c_bool allow_nulls) const
 
     shared_ptr[CArray] MakeArray(const shared_ptr[CArrayData]& data)
     CResult[shared_ptr[CArray]] MakeArrayOfNull(

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -168,7 +168,13 @@ def test_array_to_tensor_dlpack(arr, expected):
                     "strict keyword in assert_array_equal added in numpy version "
                     "1.24.0")
 
-    check_dlpack_export(arr.to_tensor(), expected)
+    tensor = arr.to_tensor()
+    # A Tensor sharing an Array buffer is immutable, so it can only be exported
+    # through the versioned DLPack protocol.
+    assert not tensor.is_mutable
+    result = np.from_dlpack(DLPackForwarder(tensor, max_version=(1, 0)))
+    np.testing.assert_array_equal(result, expected, strict=True)
+    assert tensor.__dlpack_device__() == (1, 0)
 
 
 def dlpack_objects():

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -175,6 +175,38 @@ def test_array_to_tensor_dlpack(arr, expected):
     assert tensor.__dlpack_device__() == (1, 0)
 
 
+def multidim_arrays_with_nulls():
+    np_arr = np.arange(6, dtype=np.int32).reshape(3, 2)
+    # Masked entries keep defined values in the child array, so the tensor
+    # contents stay fully predictable.
+    nested_list = pa.FixedSizeListArray.from_arrays(
+        pa.array(np_arr.ravel(), type=pa.int32()), 2,
+        mask=pa.array([False, True, False]))
+    return [
+        pytest.param(nested_list, np_arr, id="fixed_size_list"),
+        pytest.param(
+            pa.ExtensionArray.from_storage(
+                pa.fixed_shape_tensor(pa.int32(), [2]), nested_list),
+            np_arr,
+            id="fixed_shape_tensor",
+        ),
+    ]
+
+
+@check_bytes_allocated
+@pytest.mark.parametrize(('arr', 'expected'), multidim_arrays_with_nulls())
+def test_array_to_tensor_dlpack_nulls(arr, expected):
+    if Version(np.__version__) < Version("2.1.0"):
+        pytest.skip("Versioned DLPack capsules require numpy 2.1.0 or later")
+
+    with pytest.raises(pa.ArrowNotImplementedError, match="Array contains nulls"):
+        arr.to_tensor()
+
+    tensor = arr.to_tensor(allow_nulls=True)
+    result = np.from_dlpack(DLPackForwarder(tensor, max_version=(1, 0)))
+    np.testing.assert_array_equal(result, expected, strict=True)
+
+
 def dlpack_objects():
     arr = pa.array([1, 2, 3], type=pa.int32())
     return [

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -199,7 +199,7 @@ def test_array_to_tensor_dlpack_nulls(arr, expected):
     if Version(np.__version__) < Version("2.1.0"):
         pytest.skip("Versioned DLPack capsules require numpy 2.1.0 or later")
 
-    with pytest.raises(pa.ArrowNotImplementedError, match="Array contains nulls"):
+    with pytest.raises(pa.ArrowInvalid, match="Array contains nulls"):
         arr.to_tensor()
 
     tensor = arr.to_tensor(allow_nulls=True)

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -163,10 +163,8 @@ def multidim_arrays():
 @check_bytes_allocated
 @pytest.mark.parametrize(('arr', 'expected'), multidim_arrays())
 def test_array_to_tensor_dlpack(arr, expected):
-    if Version(np.__version__) < Version("1.24.0"):
-        pytest.skip("No dlpack support in numpy versions older than 1.22.0, "
-                    "strict keyword in assert_array_equal added in numpy version "
-                    "1.24.0")
+    if Version(np.__version__) < Version("2.1.0"):
+        pytest.skip("Versioned DLPack capsules require numpy 2.1.0 or later")
 
     tensor = arr.to_tensor()
     # A Tensor sharing an Array buffer is immutable, so it can only be exported

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -145,6 +145,32 @@ def test_tensor_dlpack(np_type):
     check_dlpack_export(t, expected)
 
 
+def multidim_arrays():
+    np_arr = np.arange(12, dtype=np.int32).reshape(3, 2, 2)
+    values = pa.array(np_arr.ravel(), type=pa.int32())
+    nested_list = pa.FixedSizeListArray.from_arrays(
+        pa.FixedSizeListArray.from_arrays(values, 2), 2)
+    return [
+        pytest.param(nested_list, np_arr, id="nested_fixed_size_list"),
+        pytest.param(
+            pa.FixedShapeTensorArray.from_numpy_ndarray(np_arr),
+            np_arr,
+            id="fixed_shape_tensor",
+        ),
+    ]
+
+
+@check_bytes_allocated
+@pytest.mark.parametrize(('arr', 'expected'), multidim_arrays())
+def test_array_to_tensor_dlpack(arr, expected):
+    if Version(np.__version__) < Version("1.24.0"):
+        pytest.skip("No dlpack support in numpy versions older than 1.22.0, "
+                    "strict keyword in assert_array_equal added in numpy version "
+                    "1.24.0")
+
+    check_dlpack_export(arr.to_tensor(), expected)
+
+
 def dlpack_objects():
     arr = pa.array([1, 2, 3], type=pa.int32())
     return [


### PR DESCRIPTION
### Rationale for this change
Enable multidimensional DLPack support for Array via `to_tensor`.

### What changes are included in this PR?
- Add virtual `Array::ToTensor`
- Add `NumericArray::ToTensor` for 1D arrays
- Add `FixedSizeListArray::ToTensor` for multidimensional arrays
- Add DLPack error suggestiong tensor convertion
- Add DLPack tests with `arr.to_tensor().__dlpack__()`

Note: Nulls are explicitly supported in `to_tensor` as unspecified data. This was the current behaviour.

### Are these changes tested?
Yes

### Are there any user-facing changes?
New public Array function.

* GitHub Issue: #38868