### PR TITLE
GH-50934: [C++][Dev] Fix shellcheck errors in cpp/build-support/run-test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -288,12 +288,7 @@ repos:
           (
           ?^c_glib/.*\.sh$|
           ?^ci/.*\.sh$|
-          ?^cpp/build-support/build-lz4-lib\.sh$|
-          ?^cpp/build-support/build-zstd-lib\.sh$|
-          ?^cpp/build-support/get-upstream-commit\.sh$|
-          ?^cpp/build-support/update-flatbuffers\.sh$|
-          ?^cpp/build-support/update-thrift\.sh$|
-          ?^cpp/build-support/vendor-flatbuffers\.sh$|
+          ?^cpp/build-support/.*\.sh$|
           ?^cpp/examples/minimal_build/run\.sh$|
           ?^cpp/examples/tutorial_examples/run\.sh$|
           ?^cpp/src/arrow/flight/sql/odbc/install/mac/postinstall$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -288,7 +288,13 @@ repos:
           (
           ?^c_glib/.*\.sh$|
           ?^ci/.*\.sh$|
-          ?^cpp/build-support/.*\.sh$|
+          ?^cpp/build-support/build-lz4-lib\.sh$|
+          ?^cpp/build-support/build-zstd-lib\.sh$|
+          ?^cpp/build-support/get-upstream-commit\.sh$|
+          ?^cpp/build-support/run-test\.sh$|
+          ?^cpp/build-support/update-flatbuffers\.sh$|
+          ?^cpp/build-support/update-thrift\.sh$|
+          ?^cpp/build-support/vendor-flatbuffers\.sh$|
           ?^cpp/examples/minimal_build/run\.sh$|
           ?^cpp/examples/tutorial_examples/run\.sh$|
           ?^cpp/src/arrow/flight/sql/odbc/install/mac/postinstall$|

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -23,7 +23,7 @@
 #    $ARGN - arguments for executable
 #
 
-set -e
+set -euo pipefail
 
 OUTPUT_ROOT="$1"
 shift

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -23,11 +23,12 @@
 #    $ARGN - arguments for executable
 #
 
-set -euo pipefail
-
 OUTPUT_ROOT="$1"
 shift
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) || {
+  echo "Failed to determine project root directory" >&2
+  exit 1
+}
 
 TEST_LOGDIR="$OUTPUT_ROOT/build/$1-logs"
 mkdir -p "$TEST_LOGDIR"
@@ -37,7 +38,10 @@ shift
 TEST_DEBUGDIR="$OUTPUT_ROOT/build/$RUN_TYPE-debug"
 mkdir -p "$TEST_DEBUGDIR"
 
-TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd)
+TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd) || {
+  echo "Failed to change to test directory: $(dirname "$1")" >&2
+  exit 1
+}
 TEST_FILENAME=$(basename "$1")
 shift
 TEST_EXECUTABLE="$TEST_DIRNAME/$TEST_FILENAME"
@@ -46,7 +50,10 @@ TEST_NAME=$(echo "$TEST_FILENAME" | sed -E -e 's/\..+$//') # Remove path and ext
 # We run each test in its own subdir to avoid core file related races.
 TEST_WORKDIR="$OUTPUT_ROOT/build/test-work/$TEST_NAME"
 mkdir -p "$TEST_WORKDIR"
-pushd "$TEST_WORKDIR"
+pushd "$TEST_WORKDIR" >/dev/null || {
+  echo "Failed to change to test working directory: $TEST_WORKDIR" >&2
+  exit 1
+}
 rm -f ./*
 
 set -o pipefail
@@ -236,7 +243,10 @@ fi
 
 print_coredumps
 
-popd
+popd || {
+  echo "Failed to restore the previous working directory" >&2
+  exit 1
+}
 rm -Rf "$TEST_WORKDIR"
 
 exit "$STATUS"

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -23,12 +23,11 @@
 #    $ARGN - arguments for executable
 #
 
+set -euo pipefail
+
 OUTPUT_ROOT="$1"
 shift
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) || {
-  echo "Failed to determine project root directory" >&2
-  exit 1
-}
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 TEST_LOGDIR="$OUTPUT_ROOT/build/$1-logs"
 mkdir -p "$TEST_LOGDIR"
@@ -38,10 +37,7 @@ shift
 TEST_DEBUGDIR="$OUTPUT_ROOT/build/$RUN_TYPE-debug"
 mkdir -p "$TEST_DEBUGDIR"
 
-TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd) || {
-  echo "Failed to change to test directory: $(dirname "$1")" >&2
-  exit 1
-}
+TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd)
 TEST_FILENAME=$(basename "$1")
 shift
 TEST_EXECUTABLE="$TEST_DIRNAME/$TEST_FILENAME"
@@ -50,10 +46,7 @@ TEST_NAME=$(echo "$TEST_FILENAME" | sed -E -e 's/\..+$//') # Remove path and ext
 # We run each test in its own subdir to avoid core file related races.
 TEST_WORKDIR="$OUTPUT_ROOT/build/test-work/$TEST_NAME"
 mkdir -p "$TEST_WORKDIR"
-pushd "$TEST_WORKDIR" >/dev/null || {
-  echo "Failed to change to test working directory: $TEST_WORKDIR" >&2
-  exit 1
-}
+pushd "$TEST_WORKDIR"
 rm -f ./*
 
 set -o pipefail
@@ -243,10 +236,7 @@ fi
 
 print_coredumps
 
-popd || {
-  echo "Failed to restore the previous working directory" >&2
-  exit 1
-}
+popd
 rm -Rf "$TEST_WORKDIR"
 
 exit "$STATUS"

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -23,7 +23,7 @@
 #    $ARGN - arguments for executable
 #
 
-OUTPUT_ROOT=$1
+OUTPUT_ROOT="$1"
 shift
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) || {
   echo "Failed to determine project root directory" >&2
@@ -38,11 +38,11 @@ shift
 TEST_DEBUGDIR="$OUTPUT_ROOT/build/$RUN_TYPE-debug"
 mkdir -p "$TEST_DEBUGDIR"
 
-TEST_FILENAME=$(basename "$1")
 TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd) || {
   echo "Failed to change to test directory: $(dirname "$1")" >&2
   exit 1
 }
+TEST_FILENAME=$(basename "$1")
 shift
 TEST_EXECUTABLE="$TEST_DIRNAME/$TEST_FILENAME"
 TEST_NAME=$(echo "$TEST_FILENAME" | sed -E -e 's/\..+$//') # Remove path and extension (if any).
@@ -101,12 +101,12 @@ function run_test() {
   # even when retries are successful.
   rm -f "$XMLFILE"
 
-  $TEST_EXECUTABLE "$@" > "${LOGFILE}.raw" 2>&1
+  "$TEST_EXECUTABLE" "$@" > "${LOGFILE}.raw" 2>&1
   STATUS=$?
   cat "${LOGFILE}.raw" \
-    | ${PYTHON:-python} "$ROOT"/build-support/asan_symbolize.py \
-    | ${CXXFILT:-c++filt} \
-    | $pipe_cmd 2>&1 | tee "$LOGFILE"
+    | "${PYTHON:-python}" "${ROOT}/build-support/asan_symbolize.py" \
+    | "${CXXFILT:-c++filt}" \
+    | "$pipe_cmd" 2>&1 | tee "$LOGFILE"
   rm -f "${LOGFILE}.raw"
 
   # TSAN doesn't always exit with a non-zero exit code due to a bug:
@@ -184,7 +184,7 @@ function post_process_tests() {
 
 function run_other() {
   # Generic run function for test like executables that aren't actually gtest
-  $TEST_EXECUTABLE "$@" 2>&1 | $pipe_cmd > "$LOGFILE"
+  "$TEST_EXECUTABLE" "$@" 2>&1 | "$pipe_cmd" > "$LOGFILE"
   STATUS=$?
 }
 
@@ -193,8 +193,8 @@ if [ "$RUN_TYPE" = "test" ]; then
 fi
 
 # Run the actual test.
-for ATTEMPT_NUMBER in $(seq 1 $TEST_EXECUTION_ATTEMPTS) ; do
-  if [ "$ATTEMPT_NUMBER" -lt $TEST_EXECUTION_ATTEMPTS ]; then
+for ATTEMPT_NUMBER in $(seq 1 "$TEST_EXECUTION_ATTEMPTS") ; do
+  if [ "$ATTEMPT_NUMBER" -lt "$TEST_EXECUTION_ATTEMPTS" ]; then
     # If the test fails, the test output may or may not be left behind,
     # depending on whether the test cleaned up or exited immediately. Either
     # way we need to clean it up. We do this by comparing the data directory
@@ -204,7 +204,7 @@ for ATTEMPT_NUMBER in $(seq 1 $TEST_EXECUTION_ATTEMPTS) ; do
     TEST_TMPDIR_BEFORE=$(find "$TEST_TMPDIR" -maxdepth 1 -type d | sort)
   fi
 
-  if [ "$ATTEMPT_NUMBER" -lt $TEST_EXECUTION_ATTEMPTS ]; then
+  if [ "$ATTEMPT_NUMBER" -lt "$TEST_EXECUTION_ATTEMPTS" ]; then
     # Now delete any new test output.
     TEST_TMPDIR_AFTER=$(find "$TEST_TMPDIR" -maxdepth 1 -type d | sort)
     DIFF=$(comm -13 <(echo "$TEST_TMPDIR_BEFORE") \

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -23,12 +23,11 @@
 #    $ARGN - arguments for executable
 #
 
+set -e
+
 OUTPUT_ROOT="$1"
 shift
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) || {
-  echo "Failed to determine project root directory" >&2
-  exit 1
-}
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 TEST_LOGDIR="$OUTPUT_ROOT/build/$1-logs"
 mkdir -p "$TEST_LOGDIR"
@@ -38,10 +37,7 @@ shift
 TEST_DEBUGDIR="$OUTPUT_ROOT/build/$RUN_TYPE-debug"
 mkdir -p "$TEST_DEBUGDIR"
 
-TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd) || {
-  echo "Failed to change to test directory: $(dirname "$1")" >&2
-  exit 1
-}
+TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd)
 TEST_FILENAME=$(basename "$1")
 shift
 TEST_EXECUTABLE="$TEST_DIRNAME/$TEST_FILENAME"
@@ -50,10 +46,7 @@ TEST_NAME=$(echo "$TEST_FILENAME" | sed -E -e 's/\..+$//') # Remove path and ext
 # We run each test in its own subdir to avoid core file related races.
 TEST_WORKDIR="$OUTPUT_ROOT/build/test-work/$TEST_NAME"
 mkdir -p "$TEST_WORKDIR"
-pushd "$TEST_WORKDIR" >/dev/null || {
-  echo "Failed to change to test working directory: $TEST_WORKDIR" >&2
-  exit 1
-}
+pushd "$TEST_WORKDIR" >/dev/null
 rm -f ./*
 
 set -o pipefail
@@ -101,8 +94,11 @@ function run_test() {
   # even when retries are successful.
   rm -f "$XMLFILE"
 
-  "$TEST_EXECUTABLE" "$@" > "${LOGFILE}.raw" 2>&1
-  STATUS=$?
+  if "$TEST_EXECUTABLE" "$@" > "${LOGFILE}.raw" 2>&1 ; then
+    STATUS=0
+  else
+    STATUS=1
+  fi
   cat "${LOGFILE}.raw" \
     | "${PYTHON:-python}" "${ROOT}/build-support/asan_symbolize.py" \
     | "${CXXFILT:-c++filt}" \
@@ -144,9 +140,8 @@ function print_coredumps() {
   # the pattern for the first 15 characters
   FILENAME=$(basename "${TEST_EXECUTABLE}")
   FILENAME=$(echo "${FILENAME}" | cut -c-15)
-  PATTERN="^core\.${FILENAME}"
 
-  COREFILES=$(find /tmp -maxdepth 1 -type f -exec basename {} \; | grep "$PATTERN")
+  COREFILES=$(find /tmp -maxdepth 1 -type f -name "core.${FILENAME}*" -exec basename {} \;)
   if [ -n "$COREFILES" ]; then
     for COREFILE in $COREFILES; do
       COREPATH="/tmp/${COREFILE}"
@@ -184,8 +179,11 @@ function post_process_tests() {
 
 function run_other() {
   # Generic run function for test like executables that aren't actually gtest
-  "$TEST_EXECUTABLE" "$@" 2>&1 | "$pipe_cmd" > "$LOGFILE"
-  STATUS=$?
+  if "$TEST_EXECUTABLE" "$@" 2>&1 | "$pipe_cmd" > "$LOGFILE" ; then
+    STATUS=0
+  else
+    STATUS=1
+  fi
 }
 
 if [ "$RUN_TYPE" = "test" ]; then
@@ -243,10 +241,7 @@ fi
 
 print_coredumps
 
-popd || {
-  echo "Failed to restore the previous working directory" >&2
-  exit 1
-}
+popd
 rm -Rf "$TEST_WORKDIR"
 
 exit "$STATUS"

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -223,9 +223,9 @@ for ATTEMPT_NUMBER in $(seq 1 "$TEST_EXECUTION_ATTEMPTS") ; do
   echo "Running $TEST_NAME, redirecting output into $LOGFILE" \
     "(attempt ${ATTEMPT_NUMBER}/$TEST_EXECUTION_ATTEMPTS)"
   if [ "$RUN_TYPE" = "test" ]; then
-    run_test "$*"
+    run_test "$@"
   else
-    run_other "$*"
+    run_other "$@"
   fi
   if [ "$STATUS" -eq "0" ]; then
     break

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -23,7 +23,7 @@
 #    $ARGN - arguments for executable
 #
 
-set -euo pipefail
+set -e
 
 OUTPUT_ROOT="$1"
 shift

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -38,6 +38,7 @@ shift
 TEST_DEBUGDIR="$OUTPUT_ROOT/build/$RUN_TYPE-debug"
 mkdir -p "$TEST_DEBUGDIR"
 
+TEST_FILENAME=$(basename "$1")
 TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd) || {
   echo "Failed to change to test directory: $(dirname "$1")" >&2
   exit 1

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -53,7 +53,7 @@ pushd "$TEST_WORKDIR" >/dev/null || {
   echo "Failed to change to test working directory: $TEST_WORKDIR" >&2
   exit 1
 }
-rm -f *
+rm -f ./*
 
 set -o pipefail
 

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -25,40 +25,48 @@
 
 OUTPUT_ROOT=$1
 shift
-ROOT=$(cd $(dirname $BASH_SOURCE)/..; pwd)
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) || {
+  echo "Failed to determine project root directory" >&2
+  exit 1
+}
 
-TEST_LOGDIR=$OUTPUT_ROOT/build/$1-logs
-mkdir -p $TEST_LOGDIR
+TEST_LOGDIR="$OUTPUT_ROOT/build/$1-logs"
+mkdir -p "$TEST_LOGDIR"
 
-RUN_TYPE=$1
+RUN_TYPE="$1"
 shift
-TEST_DEBUGDIR=$OUTPUT_ROOT/build/$RUN_TYPE-debug
-mkdir -p $TEST_DEBUGDIR
+TEST_DEBUGDIR="$OUTPUT_ROOT/build/$RUN_TYPE-debug"
+mkdir -p "$TEST_DEBUGDIR"
 
-TEST_DIRNAME=$(cd $(dirname $1); pwd)
-TEST_FILENAME=$(basename $1)
+TEST_DIRNAME=$(cd "$(dirname "$1")" && pwd) || {
+  echo "Failed to change to test directory: $(dirname "$1")" >&2
+  exit 1
+}
 shift
 TEST_EXECUTABLE="$TEST_DIRNAME/$TEST_FILENAME"
-TEST_NAME=$(echo $TEST_FILENAME | sed -E -e 's/\..+$//') # Remove path and extension (if any).
+TEST_NAME=$(echo "$TEST_FILENAME" | sed -E -e 's/\..+$//') # Remove path and extension (if any).
 
 # We run each test in its own subdir to avoid core file related races.
-TEST_WORKDIR=$OUTPUT_ROOT/build/test-work/$TEST_NAME
-mkdir -p $TEST_WORKDIR
-pushd $TEST_WORKDIR >/dev/null || exit 1
+TEST_WORKDIR="$OUTPUT_ROOT/build/test-work/$TEST_NAME"
+mkdir -p "$TEST_WORKDIR"
+pushd "$TEST_WORKDIR" >/dev/null || {
+  echo "Failed to change to test working directory: $TEST_WORKDIR" >&2
+  exit 1
+}
 rm -f *
 
 set -o pipefail
 
-LOGFILE=$TEST_LOGDIR/$TEST_NAME.txt
-XMLFILE=$TEST_LOGDIR/$TEST_NAME.xml
+LOGFILE="$TEST_LOGDIR/$TEST_NAME.txt"
+XMLFILE="$TEST_LOGDIR/$TEST_NAME.xml"
 
 TEST_EXECUTION_ATTEMPTS=1
 
 # Remove both the uncompressed output, so the developer doesn't accidentally get confused
 # and read output from a prior test run.
-rm -f $LOGFILE $LOGFILE.gz
+rm -f "$LOGFILE" "${LOGFILE}.gz"
 
-pipe_cmd=cat
+pipe_cmd="cat"
 
 function setup_sanitizers() {
   # Sets environment variables for different sanitizers (it configures how) the run_tests. Function works.
@@ -90,15 +98,15 @@ function run_test() {
 
   # gtest won't overwrite old junit test files, resulting in a build failure
   # even when retries are successful.
-  rm -f $XMLFILE
+  rm -f "$XMLFILE"
 
-  $TEST_EXECUTABLE "$@" > $LOGFILE.raw 2>&1
+  $TEST_EXECUTABLE "$@" > "${LOGFILE}.raw" 2>&1
   STATUS=$?
-  cat $LOGFILE.raw \
-    | ${PYTHON:-python} $ROOT/build-support/asan_symbolize.py \
+  cat "${LOGFILE}.raw" \
+    | ${PYTHON:-python} "$ROOT"/build-support/asan_symbolize.py \
     | ${CXXFILT:-c++filt} \
-    | $pipe_cmd 2>&1 | tee $LOGFILE
-  rm -f $LOGFILE.raw
+    | $pipe_cmd 2>&1 | tee "$LOGFILE"
+  rm -f "${LOGFILE}.raw"
 
   # TSAN doesn't always exit with a non-zero exit code due to a bug:
   # mutex errors don't get reported through the normal error reporting infrastructure.
@@ -108,10 +116,10 @@ function run_test() {
   # XML output from gtest. We assume that gtest knows better than us and our
   # regexes in most cases, but for certain errors we delete the resulting xml
   # file and let our own post-processing step regenerate it.
-  if grep -E -q "ThreadSanitizer|Leak check.*detected leaks" $LOGFILE ; then
-    echo ThreadSanitizer or leak check failures in $LOGFILE
+  if grep -E -q "ThreadSanitizer|Leak check.*detected leaks" "$LOGFILE" ; then
+    echo ThreadSanitizer or leak check failures in "$LOGFILE"
     STATUS=1
-    rm -f $XMLFILE
+    rm -f "$XMLFILE"
   fi
 }
 
@@ -134,10 +142,10 @@ function print_coredumps() {
   # filename is truncated to the first 15 characters in case of linux, so limit
   # the pattern for the first 15 characters
   FILENAME=$(basename "${TEST_EXECUTABLE}")
-  FILENAME=$(echo ${FILENAME} | cut -c-15)
+  FILENAME=$(echo "${FILENAME}" | cut -c-15)
   PATTERN="^core\.${FILENAME}"
 
-  COREFILES=$(ls /tmp | grep $PATTERN)
+  COREFILES=$(find /tmp -maxdepth 1 -type f -exec basename {} \; | grep "$PATTERN")
   if [ -n "$COREFILES" ]; then
     for COREFILE in $COREFILES; do
       COREPATH="/tmp/${COREFILE}"
@@ -147,7 +155,7 @@ function print_coredumps() {
       if [ "$(uname)" == "Darwin" ]; then
         lldb -c "${COREPATH}" --batch --one-line "thread backtrace all -e true"
       else
-        gdb -c "${COREPATH}" $TEST_EXECUTABLE -ex "thread apply all bt" -ex "set pagination 0" -batch
+        gdb -c "${COREPATH}" "$TEST_EXECUTABLE" -ex "thread apply all bt" -ex "set pagination 0" -batch
       fi
       echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
       # Remove the coredump, it can be regenerated via running the test case directly
@@ -160,7 +168,7 @@ function post_process_tests() {
   # If we have a LeakSanitizer report, and XML reporting is configured, add a new test
   # case result to the XML file for the leak report. Otherwise Jenkins won't show
   # us which tests had LSAN errors.
-  if grep -E -q "ERROR: LeakSanitizer: detected memory leaks" $LOGFILE ; then
+  if grep -E -q "ERROR: LeakSanitizer: detected memory leaks" "$LOGFILE" ; then
     echo Test had memory leaks. Editing XML
     sed -i.bak -e '/<\/testsuite>/ i\
   <testcase name="LeakSanitizer" status="run" classname="LSAN">\
@@ -168,36 +176,36 @@ function post_process_tests() {
       See txt log file for details\
     </failure>\
   </testcase>' \
-      $XMLFILE
-    mv $XMLFILE.bak $XMLFILE
+      "$XMLFILE"
+    mv "${XMLFILE}.bak" "$XMLFILE"
   fi
 }
 
 function run_other() {
   # Generic run function for test like executables that aren't actually gtest
-  $TEST_EXECUTABLE "$@" 2>&1 | $pipe_cmd > $LOGFILE
+  $TEST_EXECUTABLE "$@" 2>&1 | $pipe_cmd > "$LOGFILE"
   STATUS=$?
 }
 
-if [ $RUN_TYPE = "test" ]; then
+if [ "$RUN_TYPE" = "test" ]; then
   setup_sanitizers
 fi
 
 # Run the actual test.
 for ATTEMPT_NUMBER in $(seq 1 $TEST_EXECUTION_ATTEMPTS) ; do
-  if [ $ATTEMPT_NUMBER -lt $TEST_EXECUTION_ATTEMPTS ]; then
+  if [ "$ATTEMPT_NUMBER" -lt $TEST_EXECUTION_ATTEMPTS ]; then
     # If the test fails, the test output may or may not be left behind,
     # depending on whether the test cleaned up or exited immediately. Either
     # way we need to clean it up. We do this by comparing the data directory
     # contents before and after the test runs, and deleting anything new.
     #
     # The comm program requires that its two inputs be sorted.
-    TEST_TMPDIR_BEFORE=$(find $TEST_TMPDIR -maxdepth 1 -type d | sort)
+    TEST_TMPDIR_BEFORE=$(find "$TEST_TMPDIR" -maxdepth 1 -type d | sort)
   fi
 
-  if [ $ATTEMPT_NUMBER -lt $TEST_EXECUTION_ATTEMPTS ]; then
+  if [ "$ATTEMPT_NUMBER" -lt $TEST_EXECUTION_ATTEMPTS ]; then
     # Now delete any new test output.
-    TEST_TMPDIR_AFTER=$(find $TEST_TMPDIR -maxdepth 1 -type d | sort)
+    TEST_TMPDIR_AFTER=$(find "$TEST_TMPDIR" -maxdepth 1 -type d | sort)
     DIFF=$(comm -13 <(echo "$TEST_TMPDIR_BEFORE") \
                     <(echo "$TEST_TMPDIR_AFTER"))
     for DIR in $DIFF; do
@@ -215,26 +223,29 @@ for ATTEMPT_NUMBER in $(seq 1 $TEST_EXECUTION_ATTEMPTS) ; do
   fi
   echo "Running $TEST_NAME, redirecting output into $LOGFILE" \
     "(attempt ${ATTEMPT_NUMBER}/$TEST_EXECUTION_ATTEMPTS)"
-  if [ $RUN_TYPE = "test" ]; then
-    run_test $*
+  if [ "$RUN_TYPE" = "test" ]; then
+    run_test "$*"
   else
-    run_other $*
+    run_other "$*"
   fi
   if [ "$STATUS" -eq "0" ]; then
     break
   elif [ "$ATTEMPT_NUMBER" -lt "$TEST_EXECUTION_ATTEMPTS" ]; then
-    echo Test failed attempt number $ATTEMPT_NUMBER
+    echo Test failed attempt number "$ATTEMPT_NUMBER"
     echo Will retry...
   fi
 done
 
-if [ $RUN_TYPE = "test" ]; then
+if [ "$RUN_TYPE" = "test" ]; then
   post_process_tests
 fi
 
 print_coredumps
 
-popd
-rm -Rf $TEST_WORKDIR
+popd || {
+  echo "Failed to restore the previous working directory" >&2
+  exit 1
+}
+rm -Rf "$TEST_WORKDIR"
 
-exit $STATUS
+exit "$STATUS"


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2010: Don't use ls | grep. Use a glob or a for loop with a condition to allow non-alphanumeric filenames.
* SC2035: Use ./*glob* or -- *glob* so names with dashes won't become options.
* SC2046: Quote this to prevent word splitting.
* SC2048: Use "$@" (with quotes) to prevent whitespace problems.
* SC2086: Double quote to prevent globbing and word splitting.
* SC2128: Expanding an array without an index only gives the element in the index 0.
* SC2164: Use cd ... || exit in case cd fails.
* SC2209: Use var=$(command) to assign output (or quote to assign string).


```

In cpp/build-support/run-test.sh line 28:
ROOT=$(cd $(dirname $BASH_SOURCE)/..; pwd)
       ^---------------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
          ^---------------------^ SC2046 (warning): Quote this to prevent word splitting.
                    ^----------^ SC2128 (warning): Expanding an array without an index only gives the first element.
                    ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
ROOT=$(cd $(dirname "$BASH_SOURCE")/.. || exit; pwd)


In cpp/build-support/run-test.sh line 31:
mkdir -p $TEST_LOGDIR
         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "$TEST_LOGDIR"


In cpp/build-support/run-test.sh line 36:
mkdir -p $TEST_DEBUGDIR
         ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "$TEST_DEBUGDIR"


In cpp/build-support/run-test.sh line 38:
TEST_DIRNAME=$(cd $(dirname $1); pwd)
               ^--------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
                  ^-----------^ SC2046 (warning): Quote this to prevent word splitting.
                            ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
TEST_DIRNAME=$(cd $(dirname "$1") || exit; pwd)


In cpp/build-support/run-test.sh line 39:
TEST_FILENAME=$(basename $1)
                         ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
TEST_FILENAME=$(basename "$1")


In cpp/build-support/run-test.sh line 42:
TEST_NAME=$(echo $TEST_FILENAME | sed -E -e 's/\..+$//') # Remove path and extension (if any).
                 ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
TEST_NAME=$(echo "$TEST_FILENAME" | sed -E -e 's/\..+$//') # Remove path and extension (if any).


In cpp/build-support/run-test.sh line 46:
mkdir -p $TEST_WORKDIR
         ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "$TEST_WORKDIR"


In cpp/build-support/run-test.sh line 47:
pushd $TEST_WORKDIR >/dev/null || exit 1
      ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "$TEST_WORKDIR" >/dev/null || exit 1


In cpp/build-support/run-test.sh line 48:
rm -f *
      ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/build-support/run-test.sh line 59:
rm -f $LOGFILE $LOGFILE.gz
      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
               ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -f "$LOGFILE" "$LOGFILE".gz


In cpp/build-support/run-test.sh line 61:
pipe_cmd=cat
^------^ SC2209 (warning): Use var=$(command) to assign output (or quote to assign string).


In cpp/build-support/run-test.sh line 93:
  rm -f $XMLFILE
        ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm -f "$XMLFILE"


In cpp/build-support/run-test.sh line 95:
  $TEST_EXECUTABLE "$@" > $LOGFILE.raw 2>&1
                          ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  $TEST_EXECUTABLE "$@" > "$LOGFILE".raw 2>&1


In cpp/build-support/run-test.sh line 97:
  cat $LOGFILE.raw \
      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cat "$LOGFILE".raw \


In cpp/build-support/run-test.sh line 98:
    | ${PYTHON:-python} $ROOT/build-support/asan_symbolize.py \
                        ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    | ${PYTHON:-python} "$ROOT"/build-support/asan_symbolize.py \


In cpp/build-support/run-test.sh line 100:
    | $pipe_cmd 2>&1 | tee $LOGFILE
                           ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    | $pipe_cmd 2>&1 | tee "$LOGFILE"


In cpp/build-support/run-test.sh line 101:
  rm -f $LOGFILE.raw
        ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm -f "$LOGFILE".raw


In cpp/build-support/run-test.sh line 111:
  if grep -E -q "ThreadSanitizer|Leak check.*detected leaks" $LOGFILE ; then
                                                             ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  if grep -E -q "ThreadSanitizer|Leak check.*detected leaks" "$LOGFILE" ; then


In cpp/build-support/run-test.sh line 112:
    echo ThreadSanitizer or leak check failures in $LOGFILE
                                                   ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    echo ThreadSanitizer or leak check failures in "$LOGFILE"


In cpp/build-support/run-test.sh line 114:
    rm -f $XMLFILE
          ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    rm -f "$XMLFILE"


In cpp/build-support/run-test.sh line 137:
  FILENAME=$(echo ${FILENAME} | cut -c-15)
                  ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  FILENAME=$(echo "${FILENAME}" | cut -c-15)


In cpp/build-support/run-test.sh line 140:
  COREFILES=$(ls /tmp | grep $PATTERN)
              ^-- SC2010 (warning): Don't use ls | grep. Use a glob or a for loop with a condition to allow non-alphanumeric filenames.
                             ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  COREFILES=$(ls /tmp | grep "$PATTERN")


In cpp/build-support/run-test.sh line 150:
        gdb -c "${COREPATH}" $TEST_EXECUTABLE -ex "thread apply all bt" -ex "set pagination 0" -batch
                             ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
        gdb -c "${COREPATH}" "$TEST_EXECUTABLE" -ex "thread apply all bt" -ex "set pagination 0" -batch


In cpp/build-support/run-test.sh line 163:
  if grep -E -q "ERROR: LeakSanitizer: detected memory leaks" $LOGFILE ; then
                                                              ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  if grep -E -q "ERROR: LeakSanitizer: detected memory leaks" "$LOGFILE" ; then


In cpp/build-support/run-test.sh line 171:
      $XMLFILE
      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
      "$XMLFILE"


In cpp/build-support/run-test.sh line 172:
    mv $XMLFILE.bak $XMLFILE
       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                    ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    mv "$XMLFILE".bak "$XMLFILE"


In cpp/build-support/run-test.sh line 178:
  $TEST_EXECUTABLE "$@" 2>&1 | $pipe_cmd > $LOGFILE
                                           ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  $TEST_EXECUTABLE "$@" 2>&1 | $pipe_cmd > "$LOGFILE"


In cpp/build-support/run-test.sh line 182:
if [ $RUN_TYPE = "test" ]; then
     ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "$RUN_TYPE" = "test" ]; then


In cpp/build-support/run-test.sh line 188:
  if [ $ATTEMPT_NUMBER -lt $TEST_EXECUTION_ATTEMPTS ]; then
       ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  if [ "$ATTEMPT_NUMBER" -lt $TEST_EXECUTION_ATTEMPTS ]; then


In cpp/build-support/run-test.sh line 195:
    TEST_TMPDIR_BEFORE=$(find $TEST_TMPDIR -maxdepth 1 -type d | sort)
                              ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    TEST_TMPDIR_BEFORE=$(find "$TEST_TMPDIR" -maxdepth 1 -type d | sort)


In cpp/build-support/run-test.sh line 198:
  if [ $ATTEMPT_NUMBER -lt $TEST_EXECUTION_ATTEMPTS ]; then
       ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  if [ "$ATTEMPT_NUMBER" -lt $TEST_EXECUTION_ATTEMPTS ]; then


In cpp/build-support/run-test.sh line 200:
    TEST_TMPDIR_AFTER=$(find $TEST_TMPDIR -maxdepth 1 -type d | sort)
                             ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    TEST_TMPDIR_AFTER=$(find "$TEST_TMPDIR" -maxdepth 1 -type d | sort)


In cpp/build-support/run-test.sh line 218:
  if [ $RUN_TYPE = "test" ]; then
       ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  if [ "$RUN_TYPE" = "test" ]; then


In cpp/build-support/run-test.sh line 219:
    run_test $*
             ^-- SC2048 (warning): Use "$@" (with quotes) to prevent whitespace problems.
             ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    run_test "$*"


In cpp/build-support/run-test.sh line 221:
    run_other $*
              ^-- SC2048 (warning): Use "$@" (with quotes) to prevent whitespace problems.
              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    run_other "$*"


In cpp/build-support/run-test.sh line 226:
    echo Test failed attempt number $ATTEMPT_NUMBER
                                    ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    echo Test failed attempt number "$ATTEMPT_NUMBER"


In cpp/build-support/run-test.sh line 231:
if [ $RUN_TYPE = "test" ]; then
     ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ "$RUN_TYPE" = "test" ]; then


In cpp/build-support/run-test.sh line 237:
popd
^--^ SC2164 (warning): Use 'popd ... || exit' or 'popd ... || return' in case popd fails.

Did you mean:
popd || exit


In cpp/build-support/run-test.sh line 238:
rm -Rf $TEST_WORKDIR
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -Rf "$TEST_WORKDIR"


In cpp/build-support/run-test.sh line 240:
exit $STATUS
     ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
exit "$STATUS"

For more information:
  https://www.shellcheck.net/wiki/SC2010 -- Don't use ls | grep. Use a glob o...
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2048 -- Use "$@" (with quotes) to prevent...
```

### What changes are included in this PR?

* SC2010: Replace ls | grep with find
* SC2035: Prefix globs with ./ to prevent filenames from being treated as options
* SC2046: Quote command substitutions to prevent word splitting
* SC2048: Use "$@" to preserve arguments containing whitespace
* SC2086: Quote variables to prevent word splitting and globbing
* SC2128: Specify the array index explicitly
* SC2164: Handle cd failures explicitly
* SC2209: Use command substitution when assigning command output

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50934