### PR TITLE
Fix Gandiva integer overflow and UTF-8 OOB reads

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -28,6 +28,7 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/double_conversion_internal.h"
+#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/value_parsing.h"
 
 #include "gandiva/encrypt_utils.h"
@@ -663,8 +664,14 @@ const char* mask_utf8_utf8_utf8_utf8(int64_t context, const char* data, int32_t 
     return nullptr;
   }
 
-  int32_t max_length =
-      std::max(upper_length, std::max(lower_length, num_length)) * data_len;
+  int32_t max_length;
+  if (ARROW_PREDICT_FALSE(arrow::internal::MultiplyWithOverflow(
+          std::max(upper_length, std::max(lower_length, num_length)), data_len,
+          &max_length))) {
+    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    *out_len = 0;
+    return nullptr;
+  }
   char* out = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, max_length));
   if (out == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");

--- a/cpp/src/gandiva/gdv_string_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_string_function_stubs.cc
@@ -289,6 +289,14 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
     }
 
     // Control reaches here when we encounter a multibyte character
+    // Ensure the multibyte sequence fits within the buffer to avoid
+    // reading past data_len (truncated trailing multibyte sequence).
+    if (i + char_len > data_len) {
+      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      *out_len = 0;
+      return "";
+    }
+
     const auto* in_char = (const uint8_t*)(data + i);
 
     // Decode the multibyte character
@@ -366,6 +374,14 @@ const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_le
     }
 
     // Control reaches here when we encounter a multibyte character
+    // Ensure the multibyte sequence fits within the buffer to avoid
+    // reading past data_len (truncated trailing multibyte sequence).
+    if (i + char_len > data_len) {
+      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      *out_len = 0;
+      return "";
+    }
+
     const auto* in_char = (const uint8_t*)(data + i);
 
     // Decode the multibyte character
@@ -584,6 +600,14 @@ const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_
     char_len = gdv_fn_utf8_char_length(data[i]);
 
     // Control reaches here when we encounter a multibyte character
+    // Ensure the multibyte sequence fits within the buffer to avoid
+    // reading past data_len (truncated trailing multibyte sequence).
+    if (i + char_len > data_len) {
+      gdv_fn_set_error_for_invalid_utf8(context, data[i]);
+      *out_len = 0;
+      return "";
+    }
+
     const auto* in_char = (const uint8_t*)(data + i);
 
     // Decode the multibyte character


### PR DESCRIPTION
Fixes #50472 and #50504

## Fix 1: Integer overflow in mask_utf8 (#50472)
In mask_utf8_utf8_utf8_utf8(), the output buffer size is computed as
std::max(upper_length, std::max(lower_length, num_length)) * data_len
without an overflow guard. The multiplication is done in int32_t, so
a large replacement string combined with a large input wraps around,
producing a small or negative max_length. The arena allocation is then
far smaller than needed, causing a heap buffer overflow in the
subsequent memcpy loop.

Fix: use arrow::internal::MultiplyWithOverflow, consistent with sibling
functions (repeat_utf8_int32, to_hex_binary, translate).

## Fix 2: Out-of-bounds read in upper/lower/initcap (#50504)
gdv_fn_upper_utf8, gdv_fn_lower_utf8, and gdv_fn_initcap_utf8 call
arrow::util::UTF8Decode without checking that the multibyte sequence
fits within data_len. When the input ends in a truncated multibyte
sequence, UTF8Decode reads past the buffer.

Fix: add bounds check (i + char_len > data_len) before UTF8Decode,
returning an error consistent with existing invalid UTF-8 handling.