### PR TITLE
Fix out-of-bounds read in Gandiva soundex_utf8

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -28,6 +28,7 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/double_conversion_internal.h"
+#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/value_parsing.h"
 
 #include "gandiva/encrypt_utils.h"
@@ -663,8 +664,14 @@ const char* mask_utf8_utf8_utf8_utf8(int64_t context, const char* data, int32_t 
     return nullptr;
   }
 
-  int32_t max_length =
-      std::max(upper_length, std::max(lower_length, num_length)) * data_len;
+  int32_t max_length;
+  if (ARROW_PREDICT_FALSE(arrow::internal::MultiplyWithOverflow(
+          std::max(upper_length, std::max(lower_length, num_length)), data_len,
+          &max_length))) {
+    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    *out_len = 0;
+    return nullptr;
+  }
   char* out = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, max_length));
   if (out == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -3125,9 +3125,14 @@ const char* soundex_utf8(gdv_int64 context, const char* in, gdv_int32 in_len,
 
   int start_idx = 0;
   for (int i = 0; i < in_len; ++i) {
-    if (isalpha(static_cast<unsigned char>(in[i])) > 0) {
+    unsigned char ch = static_cast<unsigned char>(in[i]);
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
       // Retain the first letter
-      ret[0] = toupper(static_cast<unsigned char>(in[i]));
+      if (ch >= 'a') {
+        ret[0] = static_cast<char>(ch - 'a' + 'A');
+      } else {
+        ret[0] = static_cast<char>(ch);
+      }
       start_idx = i + 1;
       break;
     }
@@ -3143,12 +3148,17 @@ const char* soundex_utf8(gdv_int64 context, const char* in, gdv_int32 in_len,
   soundex[0] = '\0';
   // Replace consonants with digits and special letters with 0
   for (int i = start_idx; i < in_len; i++) {
-    if (isalpha(static_cast<unsigned char>(in[i])) > 0) {
-      c = toupper(static_cast<unsigned char>(in[i])) - 65;
-      if (mappings[c] != soundex[si - 1]) {
-        soundex[si] = mappings[c];
-        si++;
-      }
+    unsigned char ch = static_cast<unsigned char>(in[i]);
+    if (ch >= 'A' && ch <= 'Z') {
+      c = ch - 'A';
+    } else if (ch >= 'a' && ch <= 'z') {
+      c = ch - 'a';
+    } else {
+      continue;
+    }
+    if (mappings[c] != soundex[si - 1]) {
+      soundex[si] = mappings[c];
+      si++;
     }
   }
 


### PR DESCRIPTION
Fixes #50893

soundex_utf8 in cpp/src/gandiva/precompiled/string_ops.cc used locale-sensitive
isalpha()/toupper() to classify characters. Under non-C locales (e.g. en_US.UTF-8),
isalpha accepts bytes 0x80-0xFF as letters, and toupper leaves them past 'Z',
so mappings[c] (26-element table, A-Z) is indexed out of bounds.

Replace with ASCII-only range checks, consistent with the soundex specification
which only processes A-Z.