### PR TITLE
GH-42018: [Python] Add NumPy StringDType -> Arrow support

### DIFF
--- a/cpp/src/arrow/acero/hash_join_benchmark.cc
+++ b/cpp/src/arrow/acero/hash_join_benchmark.cc
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <memory>
+#include <numeric>
 
 namespace arrow {
 namespace acero {

--- a/cpp/src/arrow/array/array_binary_test.cc
+++ b/cpp/src/arrow/array/array_binary_test.cc
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -673,6 +674,24 @@ class TestStringBuilder : public ::testing::Test {
     CheckStringArray(*result_, strings, valid_bytes, reps);
   }
 
+  void TestStringViewAppend() {
+    std::vector<std::string> strings = {"", "bb", "a", "ignored", "ccc"};
+    std::vector<std::string_view> views(strings.begin(), strings.end());
+    std::vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
+
+    constexpr int reps = 1000;
+    for (int j = 0; j < reps; ++j) {
+      ASSERT_OK(builder_->AppendValues(std::span<const std::string_view>(views),
+                                       valid_bytes.data()));
+    }
+    Done();
+
+    ASSERT_EQ(reps * static_cast<int>(strings.size()), result_->length());
+    ASSERT_EQ(reps, result_->null_count());
+    ASSERT_EQ(reps * 6, result_->value_data()->size());
+    CheckStringArray(*result_, strings, valid_bytes, reps);
+  }
+
   void TestAppendCStringsWithValidBytes() {
     const char* strings[] = {nullptr, "aaa", nullptr, "ignored", ""};
     std::vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
@@ -798,6 +817,8 @@ TYPED_TEST(TestStringBuilder, TestExtendCurrentUnsafe) {
 
 TYPED_TEST(TestStringBuilder, TestVectorAppend) { this->TestVectorAppend(); }
 
+TYPED_TEST(TestStringBuilder, TestStringViewAppend) { this->TestStringViewAppend(); }
+
 TYPED_TEST(TestStringBuilder, TestAppendCStringsWithValidBytes) {
   this->TestAppendCStringsWithValidBytes();
 }
@@ -811,6 +832,26 @@ TYPED_TEST(TestStringBuilder, TestCapacityReserve) { this->TestCapacityReserve()
 TYPED_TEST(TestStringBuilder, TestZeroLength) { this->TestZeroLength(); }
 
 TYPED_TEST(TestStringBuilder, TestOverflowCheck) { this->TestOverflowCheck(); }
+
+TEST(TestStringViewBuilder, AppendStringViews) {
+  std::vector<std::string> strings = {"short", "long string; not inlined", "ignored", ""};
+  std::vector<std::string_view> views(strings.begin(), strings.end());
+  std::vector<uint8_t> valid_bytes = {1, 1, 0, 1};
+  StringViewBuilder builder;
+
+  ASSERT_OK(
+      builder.AppendValues(std::span<const std::string_view>(views), valid_bytes.data()));
+  ASSERT_OK(builder.AppendValues(std::span<const std::string_view>(views).first(2)));
+  strings.clear();
+
+  ASSERT_OK_AND_ASSIGN(auto result, builder.Finish());
+  ASSERT_OK(result->ValidateFull());
+  AssertArraysEqual(
+      *ArrayFromJSON(
+          utf8_view(),
+          R"(["short", "long string; not inlined", null, "", "short", "long string; not inlined"])"),
+      *result);
+}
 
 // ----------------------------------------------------------------------
 // ChunkedBinaryBuilder tests
@@ -944,6 +985,37 @@ TEST_F(TestChunkedBinaryBuilder, LargeElementCount) {
     const auto& chunk = checked_cast<const BinaryArray&>(*boxed_chunk);
     ASSERT_EQ(chunk.value_offset(0), chunk.value_offset(chunk.length()));
   }
+}
+
+TEST_F(TestChunkedBinaryBuilder, AppendStringViews) {
+  Init(/*chunksize=*/6, /*chunklength=*/4);
+  std::vector<std::string> strings = {"aa", "bbb", "ignored", "cc", "", "1234567", "z"};
+  std::vector<std::string_view> views(strings.begin(), strings.end());
+  std::vector<uint8_t> valid_bytes = {1, 1, 0, 1, 1, 1, 1};
+
+  ASSERT_OK(builder_->AppendValues(std::span<const std::string_view>(views),
+                                   valid_bytes.data()));
+  ArrayVector chunks;
+  ASSERT_OK(builder_->Finish(&chunks));
+
+  ASSERT_EQ(chunks.size(), 4);
+  AssertArraysEqual(*ArrayFromJSON(binary(), R"(["aa", "bbb", null])"), *chunks[0]);
+  AssertArraysEqual(*ArrayFromJSON(binary(), R"(["cc", ""])"), *chunks[1]);
+  AssertArraysEqual(*ArrayFromJSON(binary(), R"(["1234567"])"), *chunks[2]);
+  AssertArraysEqual(*ArrayFromJSON(binary(), R"(["z"])"), *chunks[3]);
+}
+
+TEST_F(TestChunkedBinaryBuilder, AppendNulls) {
+  Init(/*chunksize=*/6, /*chunklength=*/3);
+  ASSERT_OK(builder_->Append("a"));
+  ASSERT_OK(builder_->AppendNulls(5));
+
+  ArrayVector chunks;
+  ASSERT_OK(builder_->Finish(&chunks));
+
+  ASSERT_EQ(chunks.size(), 2);
+  AssertArraysEqual(*ArrayFromJSON(binary(), R"(["a", null, null])"), *chunks[0]);
+  AssertArraysEqual(*ArrayFromJSON(binary(), R"([null, null, null])"), *chunks[1]);
 }
 
 TEST(TestChunkedStringBuilder, BasicOperation) {

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -49,6 +49,63 @@ BinaryViewBuilder::BinaryViewBuilder(const std::shared_ptr<DataType>& type,
                                      MemoryPool* pool)
     : BinaryViewBuilder(pool) {}
 
+Status BinaryViewBuilder::AppendValues(std::span<const std::string_view> values,
+                                       const uint8_t* valid_bytes) {
+  int64_t out_of_line_total = 0;
+  bool reserve_data = true;
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (valid_bytes != NULLPTR && !valid_bytes[i]) {
+      continue;
+    }
+    const auto value_size = values[i].size();
+    if (ARROW_PREDICT_FALSE(
+            value_size >
+            static_cast<size_t>(internal::StringHeapBuilder::ValueSizeLimit()))) {
+      return Status::CapacityError(
+          "BinaryView or StringView elements cannot reference strings larger than 2GB");
+    }
+    if (reserve_data && value_size > BinaryViewType::kInlineSize) {
+      if (value_size >
+          static_cast<uint64_t>(internal::StringHeapBuilder::ValueSizeLimit() -
+                                out_of_line_total)) {
+        reserve_data = false;
+      } else {
+        out_of_line_total += static_cast<int64_t>(value_size);
+      }
+    }
+  }
+
+  RETURN_NOT_OK(Reserve(static_cast<int64_t>(values.size())));
+  if (reserve_data) {
+    RETURN_NOT_OK(ReserveData(out_of_line_total));
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (valid_bytes != NULLPTR && !valid_bytes[i]) {
+        data_builder_.UnsafeAppend(BinaryViewType::c_type{});
+      } else {
+        const auto value = values[i];
+        data_builder_.UnsafeAppend(data_heap_builder_.Append</*Safe=*/false>(
+            reinterpret_cast<const uint8_t*>(value.data()),
+            static_cast<int64_t>(value.size())));
+      }
+    }
+  } else {
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (valid_bytes != NULLPTR && !valid_bytes[i]) {
+        data_builder_.UnsafeAppend(BinaryViewType::c_type{});
+      } else {
+        const auto value = values[i];
+        ARROW_ASSIGN_OR_RAISE(auto view,
+                              data_heap_builder_.Append</*Safe=*/true>(
+                                  reinterpret_cast<const uint8_t*>(value.data()),
+                                  static_cast<int64_t>(value.size())));
+        data_builder_.UnsafeAppend(view);
+      }
+    }
+  }
+  UnsafeAppendToBitmap(valid_bytes, static_cast<int64_t>(values.size()));
+  return Status::OK();
+}
+
 Status BinaryViewBuilder::AppendArraySlice(const ArraySpan& array, int64_t offset,
                                            int64_t length) {
   auto bitmap = array.GetValues<uint8_t>(0, 0);
@@ -212,6 +269,74 @@ ChunkedBinaryBuilder::ChunkedBinaryBuilder(int32_t max_chunk_value_length,
                                            int32_t max_chunk_length, MemoryPool* pool)
     : ChunkedBinaryBuilder(max_chunk_value_length, pool) {
   max_chunk_length_ = max_chunk_length;
+}
+
+Status ChunkedBinaryBuilder::AppendValues(std::span<const std::string_view> values,
+                                          const uint8_t* valid_bytes) {
+  size_t offset = 0;
+  while (offset < values.size()) {
+    if (ARROW_PREDICT_FALSE(builder_->length() == max_chunk_length_)) {
+      RETURN_NOT_OK(NextChunk());
+    }
+
+    const int64_t available_values = max_chunk_length_ - builder_->length();
+    size_t batch_length = 0;
+    int64_t batch_bytes = 0;
+    bool oversized_chunk = false;
+    while (batch_length < static_cast<size_t>(available_values) &&
+           offset + batch_length < values.size()) {
+      const size_t i = offset + batch_length;
+      if (valid_bytes != NULLPTR && !valid_bytes[i]) {
+        ++batch_length;
+        continue;
+      }
+
+      if (ARROW_PREDICT_FALSE(values[i].size() >
+                              static_cast<size_t>(BinaryBuilder::memory_limit()))) {
+        return Status::CapacityError("Binary values cannot exceed 2GB, got ",
+                                     values[i].size(), " bytes");
+      }
+      const int64_t value_length = static_cast<int64_t>(values[i].size());
+      const int64_t current_bytes = builder_->value_data_length() + batch_bytes;
+      if (value_length > max_chunk_value_length_ - current_bytes) {
+        if (current_bytes == 0) {
+          batch_bytes += value_length;
+          ++batch_length;
+          oversized_chunk = true;
+        }
+        break;
+      }
+      batch_bytes += value_length;
+      ++batch_length;
+    }
+
+    if (batch_length == 0) {
+      RETURN_NOT_OK(NextChunk());
+      continue;
+    }
+
+    RETURN_NOT_OK(builder_->Reserve(static_cast<int64_t>(batch_length)));
+    RETURN_NOT_OK(builder_->ReserveData(batch_bytes));
+    builder_->UnsafeAppendValues(values.subspan(offset, batch_length),
+                                 valid_bytes == NULLPTR ? NULLPTR : valid_bytes + offset);
+    offset += batch_length;
+    if (oversized_chunk) {
+      RETURN_NOT_OK(NextChunk());
+    }
+  }
+  return Status::OK();
+}
+
+Status ChunkedBinaryBuilder::AppendNulls(int64_t length) {
+  while (length > 0) {
+    if (ARROW_PREDICT_FALSE(builder_->length() == max_chunk_length_)) {
+      RETURN_NOT_OK(NextChunk());
+    }
+    const int64_t batch_length = std::min(length, max_chunk_length_ - builder_->length());
+    RETURN_NOT_OK(builder_->AppendNulls(batch_length));
+    length -= batch_length;
+  }
+  return Status::OK();
 }
 
 Status ChunkedBinaryBuilder::Finish(ArrayVector* out) {

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
-#include <numeric>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -190,30 +190,30 @@ class BaseBinaryBuilder
   /// \return Status
   Status AppendValues(const std::vector<std::string>& values,
                       const uint8_t* valid_bytes = NULLPTR) {
-    std::size_t total_length = std::accumulate(
-        values.begin(), values.end(), 0ULL,
-        [](uint64_t sum, const std::string& str) { return sum + str.size(); });
-    ARROW_RETURN_NOT_OK(Reserve(values.size()));
-    ARROW_RETURN_NOT_OK(ReserveData(total_length));
+    return AppendValuesInternal(values, valid_bytes);
+  }
 
-    if (valid_bytes != NULLPTR) {
-      for (std::size_t i = 0; i < values.size(); ++i) {
-        UnsafeAppendNextOffset();
-        if (valid_bytes[i]) {
-          value_data_builder_.UnsafeAppend(
-              reinterpret_cast<const uint8_t*>(values[i].data()), values[i].size());
-        }
-      }
-    } else {
-      for (const auto& value : values) {
-        UnsafeAppendNextOffset();
-        value_data_builder_.UnsafeAppend(reinterpret_cast<const uint8_t*>(value.data()),
-                                         value.size());
-      }
-    }
+  /// \brief Append a sequence of borrowed string views in one shot.
+  ///
+  /// The referenced data is copied before this method returns.
+  ///
+  /// \param[in] values a span of string views
+  /// \param[in] valid_bytes an optional sequence of bytes where non-zero
+  /// indicates a valid (non-null) value
+  /// \return Status
+  Status AppendValues(std::span<const std::string_view> values,
+                      const uint8_t* valid_bytes = NULLPTR) {
+    return AppendValuesInternal(values, valid_bytes);
+  }
 
-    UnsafeAppendToBitmap(valid_bytes, values.size());
-    return Status::OK();
+  /// \brief Append borrowed string views without checking capacity.
+  ///
+  /// Offsets and data should have been presized using Reserve() and
+  /// ReserveData(), respectively. The referenced data is copied before this
+  /// method returns.
+  void UnsafeAppendValues(std::span<const std::string_view> values,
+                          const uint8_t* valid_bytes = NULLPTR) {
+    UnsafeAppendValuesInternal(values, valid_bytes);
   }
 
   /// \brief Append a sequence of nul-terminated strings in one shot.
@@ -390,6 +390,48 @@ class BaseBinaryBuilder
   }
 
  protected:
+  template <typename StringSequence>
+  Status AppendValuesInternal(const StringSequence& values, const uint8_t* valid_bytes) {
+    uint64_t total_length = 0;
+    const uint64_t available =
+        static_cast<uint64_t>(memory_limit() - value_data_builder_.length());
+    for (std::size_t i = 0; i < values.size(); ++i) {
+      if (valid_bytes == NULLPTR || valid_bytes[i]) {
+        if (values[i].size() > available - total_length) {
+          return Status::CapacityError("array cannot contain more than ", memory_limit(),
+                                       " bytes");
+        }
+        total_length += values[i].size();
+      }
+    }
+
+    ARROW_RETURN_NOT_OK(Reserve(static_cast<int64_t>(values.size())));
+    ARROW_RETURN_NOT_OK(ReserveData(static_cast<int64_t>(total_length)));
+    UnsafeAppendValuesInternal(values, valid_bytes);
+    return Status::OK();
+  }
+
+  template <typename StringSequence>
+  void UnsafeAppendValuesInternal(const StringSequence& values,
+                                  const uint8_t* valid_bytes) {
+    if (valid_bytes == NULLPTR) {
+      for (const auto& value : values) {
+        UnsafeAppendNextOffset();
+        value_data_builder_.UnsafeAppend(reinterpret_cast<const uint8_t*>(value.data()),
+                                         value.size());
+      }
+    } else {
+      for (std::size_t i = 0; i < values.size(); ++i) {
+        UnsafeAppendNextOffset();
+        if (valid_bytes[i]) {
+          value_data_builder_.UnsafeAppend(
+              reinterpret_cast<const uint8_t*>(values[i].data()), values[i].size());
+        }
+      }
+    }
+    UnsafeAppendToBitmap(valid_bytes, static_cast<int64_t>(values.size()));
+  }
+
   TypedBufferBuilder<offset_type> offsets_builder_;
   TypedBufferBuilder<uint8_t> value_data_builder_;
 
@@ -644,6 +686,17 @@ class ARROW_EXPORT BinaryViewBuilder : public ArrayBuilder {
   void UnsafeAppend(std::string_view value) {
     UnsafeAppend(value.data(), static_cast<int64_t>(value.size()));
   }
+
+  /// \brief Append a sequence of borrowed string views in one shot.
+  ///
+  /// The referenced data is copied before this method returns.
+  ///
+  /// \param[in] values a span of string views
+  /// \param[in] valid_bytes an optional sequence of bytes where non-zero
+  /// indicates a valid (non-null) value
+  /// \return Status
+  Status AppendValues(std::span<const std::string_view> values,
+                      const uint8_t* valid_bytes = NULLPTR);
 
   /// \brief Ensures there is enough allocated available capacity in the
   /// out-of-line data heap to append the indicated number of bytes without
@@ -949,9 +1002,16 @@ class ARROW_EXPORT ChunkedBinaryBuilder {
   }
 
   Status Append(std::string_view value) {
+    if (ARROW_PREDICT_FALSE(value.size() >
+                            static_cast<size_t>(BinaryBuilder::memory_limit()))) {
+      return Status::CapacityError("Binary values cannot exceed 2GB");
+    }
     return Append(reinterpret_cast<const uint8_t*>(value.data()),
                   static_cast<int32_t>(value.size()));
   }
+
+  Status AppendValues(std::span<const std::string_view> values,
+                      const uint8_t* valid_bytes = NULLPTR);
 
   Status AppendNull() {
     if (ARROW_PREDICT_FALSE(builder_->length() == max_chunk_length_)) {
@@ -959,6 +1019,8 @@ class ARROW_EXPORT ChunkedBinaryBuilder {
     }
     return builder_->AppendNull();
   }
+
+  Status AppendNulls(int64_t length);
 
   Status Reserve(int64_t values);
 

--- a/cpp/src/arrow/compute/kernels/chunked_internal.cc
+++ b/cpp/src/arrow/compute/kernels/chunked_internal.cc
@@ -18,6 +18,7 @@
 #include "arrow/compute/kernels/chunked_internal.h"
 
 #include <algorithm>
+#include <numeric>
 #include <span>
 
 #include "arrow/record_batch.h"

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <numeric>
 
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernels/vector_sort_internal.h"

--- a/cpp/src/arrow/compute/kernels/vector_select_k.cc
+++ b/cpp/src/arrow/compute/kernels/vector_select_k.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <algorithm>
+#include <numeric>
 #include <queue>
 #include <span>
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <numeric>
 #include <span>
 #include <unordered_set>
 

--- a/cpp/src/arrow/extension/variable_shape_tensor.cc
+++ b/cpp/src/arrow/extension/variable_shape_tensor.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <numeric>
 #include <sstream>
 
 #include "arrow/extension/tensor_internal.h"

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <numeric>
 #include <random>
 
 #include "arrow/array.h"

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <functional>
 #include <limits>
+#include <numeric>
 #include <span>
 #include <utility>
 #include <vector>

--- a/python/pyarrow/src/arrow/python/numpy_convert.cc
+++ b/python/pyarrow/src/arrow/python/numpy_convert.cc
@@ -151,6 +151,7 @@ Result<std::shared_ptr<DataType>> NumPyDtypeToArrow(PyArray_Descr* descr) {
     TO_ARROW_TYPE_CASE(FLOAT64, float64);
     TO_ARROW_TYPE_CASE(STRING, binary);
     TO_ARROW_TYPE_CASE(UNICODE, utf8);
+    TO_ARROW_TYPE_CASE(VSTRING, utf8);
     case NPY_DATETIME: {
       auto date_dtype =
           reinterpret_cast<PyArray_DatetimeDTypeMetaData*>(PyDataType_C_METADATA(descr));

--- a/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -717,36 +718,125 @@ Status NumPyConverter::VisitStringDType(T* builder) {
   std::unique_ptr<npy_string_allocator, decltype(&NpyString_release_allocator)>
       allocator_guard(allocator, &NpyString_release_allocator);
 
-  npy_static_string value = {0, nullptr};
-  const auto append_value = [&](const char* item) -> Status {
-    const auto* packed = reinterpret_cast<const npy_packed_static_string*>(item);
-    const int is_null = NpyString_load(allocator, packed, &value);
-    if (is_null == -1) {
-      return Status::Invalid("Failed to load NumPy StringDType value");
+  if constexpr (std::is_same_v<T, ::arrow::internal::ChunkedStringBuilder>) {
+    RETURN_NOT_OK(builder->Reserve(length_));
+    npy_static_string value = {0, nullptr};
+    Ndarray1DIndexer<uint8_t> mask_values;
+    if (mask_ != nullptr) {
+      mask_values = Ndarray1DIndexer<uint8_t>(mask_);
     }
-    if (is_null) {
-      return builder->AppendNull();
-    }
-    return builder->Append(std::string_view(value.buf, value.size));
-  };
-
-  if (mask_ != nullptr) {
-    Ndarray1DIndexer<uint8_t> mask_values(mask_);
     for (int64_t i = 0; i < length_; ++i) {
-      if (mask_values[i]) {
+      if (mask_ != nullptr && mask_values[i]) {
+        RETURN_NOT_OK(builder->AppendNull());
+        data += stride_;
+        continue;
+      }
+
+      const auto* packed = reinterpret_cast<const npy_packed_static_string*>(data);
+      const int is_null = NpyString_load(allocator, packed, &value);
+      if (is_null == -1) {
+        return Status::Invalid("Failed to load NumPy StringDType value");
+      }
+      if (is_null) {
         RETURN_NOT_OK(builder->AppendNull());
       } else {
-        RETURN_NOT_OK(append_value(data));
+        if (value.size > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+          return Status::CapacityError("Arrow string values cannot exceed 2GB, got ",
+                                       value.size, " bytes");
+        }
+        RETURN_NOT_OK(builder->Append(std::string_view(value.buf, value.size)));
       }
       data += stride_;
     }
+    return Status::OK();
   } else {
-    for (int64_t i = 0; i < length_; ++i) {
-      RETURN_NOT_OK(append_value(data));
-      data += stride_;
+    constexpr int64_t kBatchSize = 4096;
+    // NpyString_load returns borrowed views into storage protected by allocator. Stage
+    // small batches while the allocator is locked, then reserve once and copy them into
+    // Arrow-owned storage with the unchecked builder APIs.
+    std::vector<npy_static_string> values(kBatchSize);
+    std::vector<uint8_t> valid(kBatchSize);
+    Ndarray1DIndexer<uint8_t> mask_values;
+    if (mask_ != nullptr) {
+      mask_values = Ndarray1DIndexer<uint8_t>(mask_);
     }
+
+    for (int64_t offset = 0; offset < length_; offset += kBatchSize) {
+      const int64_t batch_length = std::min(kBatchSize, length_ - offset);
+      int64_t null_count = 0;
+      int64_t data_bytes = 0;
+
+      for (int64_t i = 0; i < batch_length; ++i) {
+        if (mask_ != nullptr && mask_values[offset + i]) {
+          valid[i] = false;
+          ++null_count;
+          data += stride_;
+          continue;
+        }
+
+        const auto* packed = reinterpret_cast<const npy_packed_static_string*>(data);
+        const int is_null = NpyString_load(allocator, packed, &values[i]);
+        if (is_null == -1) {
+          return Status::Invalid("Failed to load NumPy StringDType value");
+        }
+        valid[i] = !is_null;
+        if (is_null) {
+          ++null_count;
+        } else {
+          size_t value_bytes = values[i].size;
+          if constexpr (std::is_same_v<T, StringViewBuilder>) {
+            if (value_bytes <= BinaryViewType::kInlineSize) {
+              value_bytes = 0;
+            }
+          }
+          if (value_bytes >
+              static_cast<size_t>(std::numeric_limits<int64_t>::max() - data_bytes)) {
+            return Status::CapacityError("String data size exceeds int64 capacity");
+          }
+          data_bytes += static_cast<int64_t>(value_bytes);
+        }
+        data += stride_;
+      }
+
+      if (null_count == batch_length) {
+        RETURN_NOT_OK(builder->AppendNulls(batch_length));
+        continue;
+      }
+
+      RETURN_NOT_OK(builder->Reserve(batch_length));
+      bool use_safe_append = false;
+      if constexpr (std::is_same_v<T, StringViewBuilder>) {
+        use_safe_append = data_bytes > std::numeric_limits<int32_t>::max();
+      }
+      if (!use_safe_append) {
+        RETURN_NOT_OK(builder->ReserveData(data_bytes));
+      }
+
+      if (use_safe_append) {
+        for (int64_t i = 0; i < batch_length; ++i) {
+          if (valid[i]) {
+            RETURN_NOT_OK(
+                builder->Append(std::string_view(values[i].buf, values[i].size)));
+          } else {
+            RETURN_NOT_OK(builder->AppendNull());
+          }
+        }
+      } else if (null_count == 0) {
+        for (int64_t i = 0; i < batch_length; ++i) {
+          builder->UnsafeAppend(std::string_view(values[i].buf, values[i].size));
+        }
+      } else {
+        for (int64_t i = 0; i < batch_length; ++i) {
+          if (valid[i]) {
+            builder->UnsafeAppend(std::string_view(values[i].buf, values[i].size));
+          } else {
+            builder->UnsafeAppendNull();
+          }
+        }
+      }
+    }
+    return Status::OK();
   }
-  return Status::OK();
 }
 
 template <typename T>

--- a/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
@@ -27,6 +27,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -295,6 +296,9 @@ class NumPyConverter {
   template <typename T>
   Status VisitString(T* builder);
 
+  template <typename T>
+  Status VisitStringDType(T* builder);
+
   Status TypeNotImplemented(std::string type_name) {
     return Status::NotImplemented("NumPyConverter doesn't implement <", type_name,
                                   "> conversion. ");
@@ -340,6 +344,11 @@ Status NumPyConverter::Convert() {
 
   if (type_ == nullptr) {
     return Status::Invalid("Must pass data type for non-object arrays");
+  }
+
+  if (dtype_->type_num == NPY_VSTRING && !is_string_or_string_view(type_->id())) {
+    return Status::TypeError(
+        "NumPy StringDType can only be converted to Arrow string types");
   }
 
   // Visit the type to perform conversion
@@ -698,7 +707,54 @@ Status AppendUTF32(const char* data, int64_t itemsize, int byteorder, T* builder
 }  // namespace
 
 template <typename T>
+Status NumPyConverter::VisitStringDType(T* builder) {
+  const char* data = PyArray_BYTES(arr_);
+  auto* allocator =
+      NpyString_acquire_allocator(reinterpret_cast<PyArray_StringDTypeObject*>(dtype_));
+  if (allocator == nullptr) {
+    return Status::Invalid("Failed to acquire NumPy StringDType allocator");
+  }
+  std::unique_ptr<npy_string_allocator, decltype(&NpyString_release_allocator)>
+      allocator_guard(allocator, &NpyString_release_allocator);
+
+  npy_static_string value = {0, nullptr};
+  const auto append_value = [&](const char* item) -> Status {
+    const auto* packed = reinterpret_cast<const npy_packed_static_string*>(item);
+    const int is_null = NpyString_load(allocator, packed, &value);
+    if (is_null == -1) {
+      return Status::Invalid("Failed to load NumPy StringDType value");
+    }
+    if (is_null) {
+      return builder->AppendNull();
+    }
+    return builder->Append(std::string_view(value.buf, value.size));
+  };
+
+  if (mask_ != nullptr) {
+    Ndarray1DIndexer<uint8_t> mask_values(mask_);
+    for (int64_t i = 0; i < length_; ++i) {
+      if (mask_values[i]) {
+        RETURN_NOT_OK(builder->AppendNull());
+      } else {
+        RETURN_NOT_OK(append_value(data));
+      }
+      data += stride_;
+    }
+  } else {
+    for (int64_t i = 0; i < length_; ++i) {
+      RETURN_NOT_OK(append_value(data));
+      data += stride_;
+    }
+  }
+  return Status::OK();
+}
+
+template <typename T>
 Status NumPyConverter::VisitString(T* builder) {
+  if (dtype_->type_num == NPY_VSTRING) {
+    return VisitStringDType(builder);
+  }
+
   auto data = reinterpret_cast<const uint8_t*>(PyArray_DATA(arr_));
 
   char numpy_byteorder = dtype_->byteorder;

--- a/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
@@ -24,11 +24,10 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <limits>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -709,6 +708,10 @@ Status AppendUTF32(const char* data, int64_t itemsize, int byteorder, T* builder
 
 template <typename T>
 Status NumPyConverter::VisitStringDType(T* builder) {
+  if (length_ == 0) {
+    return Status::OK();
+  }
+
   const char* data = PyArray_BYTES(arr_);
   auto* allocator =
       NpyString_acquire_allocator(reinterpret_cast<PyArray_StringDTypeObject*>(dtype_));
@@ -720,13 +723,25 @@ Status NumPyConverter::VisitStringDType(T* builder) {
     mask_values = Ndarray1DIndexer<uint8_t>(mask_);
   }
 
-  if constexpr (std::is_same_v<T, ::arrow::internal::ChunkedStringBuilder>) {
-    npy_static_string value{};
-    for (int64_t i = 0; i < length_; ++i) {
+  constexpr int64_t kBatchSize = 4096;
+  // NpyString_load returns borrowed views that remain valid while the allocator is
+  // locked.
+  const int64_t batch_capacity = std::min(length_, kBatchSize);
+  std::vector<std::string_view> values(batch_capacity);
+  std::vector<uint8_t> valid(batch_capacity);
+  npy_static_string value{};
+
+  for (int64_t offset = 0; offset < length_; offset += kBatchSize) {
+    const int64_t batch_length = std::min(kBatchSize, length_ - offset);
+    int64_t null_count = 0;
+
+    for (int64_t i = 0; i < batch_length; ++i) {
       const char* item = data;
       data += stride_;
-      if (has_mask && mask_values[i]) {
-        RETURN_NOT_OK(builder->AppendNull());
+      if (has_mask && mask_values[offset + i]) {
+        values[i] = {};
+        valid[i] = false;
+        ++null_count;
         continue;
       }
 
@@ -735,98 +750,24 @@ Status NumPyConverter::VisitStringDType(T* builder) {
       if (is_null == -1) {
         return Status::Invalid("Failed to load NumPy StringDType value");
       }
+      valid[i] = !is_null;
       if (is_null) {
-        RETURN_NOT_OK(builder->AppendNull());
+        values[i] = {};
+        ++null_count;
       } else {
-        if (value.size > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
-          return Status::CapacityError("Arrow string values cannot exceed 2GB, got ",
-                                       value.size, " bytes");
-        }
-        RETURN_NOT_OK(builder->Append(std::string_view(value.buf, value.size)));
+        values[i] = std::string_view(value.buf, value.size);
       }
     }
-    return Status::OK();
-  } else {
-    constexpr int64_t kBatchSize = 4096;
-    // Loaded strings remain valid while the allocator is locked.
-    const int64_t batch_capacity = std::min(length_, kBatchSize);
-    std::vector<npy_static_string> values(batch_capacity);
-    std::vector<uint8_t> valid(batch_capacity);
 
-    for (int64_t offset = 0; offset < length_; offset += kBatchSize) {
-      const int64_t batch_length = std::min(kBatchSize, length_ - offset);
-      int64_t null_count = 0;
-      int64_t data_bytes = 0;
-
-      for (int64_t i = 0; i < batch_length; ++i) {
-        const char* item = data;
-        data += stride_;
-        if (has_mask && mask_values[offset + i]) {
-          valid[i] = false;
-          ++null_count;
-          continue;
-        }
-
-        const auto* packed = reinterpret_cast<const npy_packed_static_string*>(item);
-        const int is_null = NpyString_load(allocator, packed, &values[i]);
-        if (is_null == -1) {
-          return Status::Invalid("Failed to load NumPy StringDType value");
-        }
-        valid[i] = !is_null;
-        if (is_null) {
-          ++null_count;
-        } else {
-          size_t value_bytes = values[i].size;
-          if constexpr (std::is_same_v<T, StringViewBuilder>) {
-            if (value_bytes <= BinaryViewType::kInlineSize) {
-              value_bytes = 0;
-            }
-          }
-          if (value_bytes >
-              static_cast<size_t>(std::numeric_limits<int64_t>::max() - data_bytes)) {
-            return Status::CapacityError("String data size exceeds int64 capacity");
-          }
-          data_bytes += static_cast<int64_t>(value_bytes);
-        }
-      }
-
-      if (null_count == batch_length) {
-        RETURN_NOT_OK(builder->AppendNulls(batch_length));
-        continue;
-      }
-
-      RETURN_NOT_OK(builder->Reserve(batch_length));
-      const bool use_safe_append = std::is_same_v<T, StringViewBuilder> &&
-                                   data_bytes > std::numeric_limits<int32_t>::max();
-      if (!use_safe_append) {
-        RETURN_NOT_OK(builder->ReserveData(data_bytes));
-      }
-
-      if (use_safe_append) {
-        for (int64_t i = 0; i < batch_length; ++i) {
-          if (valid[i]) {
-            RETURN_NOT_OK(
-                builder->Append(std::string_view(values[i].buf, values[i].size)));
-          } else {
-            RETURN_NOT_OK(builder->AppendNull());
-          }
-        }
-      } else if (null_count == 0) {
-        for (int64_t i = 0; i < batch_length; ++i) {
-          builder->UnsafeAppend(std::string_view(values[i].buf, values[i].size));
-        }
-      } else {
-        for (int64_t i = 0; i < batch_length; ++i) {
-          if (valid[i]) {
-            builder->UnsafeAppend(std::string_view(values[i].buf, values[i].size));
-          } else {
-            builder->UnsafeAppendNull();
-          }
-        }
-      }
+    if (null_count == batch_length) {
+      RETURN_NOT_OK(builder->AppendNulls(batch_length));
+    } else {
+      RETURN_NOT_OK(builder->AppendValues(
+          std::span<const std::string_view>(values.data(), batch_length),
+          null_count == 0 ? NULLPTR : valid.data()));
     }
-    return Status::OK();
   }
+  return Status::OK();
 }
 
 template <typename T>

--- a/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
@@ -712,27 +712,25 @@ Status NumPyConverter::VisitStringDType(T* builder) {
   const char* data = PyArray_BYTES(arr_);
   auto* allocator =
       NpyString_acquire_allocator(reinterpret_cast<PyArray_StringDTypeObject*>(dtype_));
-  if (allocator == nullptr) {
-    return Status::Invalid("Failed to acquire NumPy StringDType allocator");
-  }
   std::unique_ptr<npy_string_allocator, decltype(&NpyString_release_allocator)>
       allocator_guard(allocator, &NpyString_release_allocator);
+  const bool has_mask = mask_ != nullptr;
+  Ndarray1DIndexer<uint8_t> mask_values;
+  if (has_mask) {
+    mask_values = Ndarray1DIndexer<uint8_t>(mask_);
+  }
 
   if constexpr (std::is_same_v<T, ::arrow::internal::ChunkedStringBuilder>) {
-    RETURN_NOT_OK(builder->Reserve(length_));
-    npy_static_string value = {0, nullptr};
-    Ndarray1DIndexer<uint8_t> mask_values;
-    if (mask_ != nullptr) {
-      mask_values = Ndarray1DIndexer<uint8_t>(mask_);
-    }
+    npy_static_string value{};
     for (int64_t i = 0; i < length_; ++i) {
-      if (mask_ != nullptr && mask_values[i]) {
+      const char* item = data;
+      data += stride_;
+      if (has_mask && mask_values[i]) {
         RETURN_NOT_OK(builder->AppendNull());
-        data += stride_;
         continue;
       }
 
-      const auto* packed = reinterpret_cast<const npy_packed_static_string*>(data);
+      const auto* packed = reinterpret_cast<const npy_packed_static_string*>(item);
       const int is_null = NpyString_load(allocator, packed, &value);
       if (is_null == -1) {
         return Status::Invalid("Failed to load NumPy StringDType value");
@@ -746,20 +744,14 @@ Status NumPyConverter::VisitStringDType(T* builder) {
         }
         RETURN_NOT_OK(builder->Append(std::string_view(value.buf, value.size)));
       }
-      data += stride_;
     }
     return Status::OK();
   } else {
     constexpr int64_t kBatchSize = 4096;
-    // NpyString_load returns borrowed views into storage protected by allocator. Stage
-    // small batches while the allocator is locked, then reserve once and copy them into
-    // Arrow-owned storage with the unchecked builder APIs.
-    std::vector<npy_static_string> values(kBatchSize);
-    std::vector<uint8_t> valid(kBatchSize);
-    Ndarray1DIndexer<uint8_t> mask_values;
-    if (mask_ != nullptr) {
-      mask_values = Ndarray1DIndexer<uint8_t>(mask_);
-    }
+    // Loaded strings remain valid while the allocator is locked.
+    const int64_t batch_capacity = std::min(length_, kBatchSize);
+    std::vector<npy_static_string> values(batch_capacity);
+    std::vector<uint8_t> valid(batch_capacity);
 
     for (int64_t offset = 0; offset < length_; offset += kBatchSize) {
       const int64_t batch_length = std::min(kBatchSize, length_ - offset);
@@ -767,14 +759,15 @@ Status NumPyConverter::VisitStringDType(T* builder) {
       int64_t data_bytes = 0;
 
       for (int64_t i = 0; i < batch_length; ++i) {
-        if (mask_ != nullptr && mask_values[offset + i]) {
+        const char* item = data;
+        data += stride_;
+        if (has_mask && mask_values[offset + i]) {
           valid[i] = false;
           ++null_count;
-          data += stride_;
           continue;
         }
 
-        const auto* packed = reinterpret_cast<const npy_packed_static_string*>(data);
+        const auto* packed = reinterpret_cast<const npy_packed_static_string*>(item);
         const int is_null = NpyString_load(allocator, packed, &values[i]);
         if (is_null == -1) {
           return Status::Invalid("Failed to load NumPy StringDType value");
@@ -795,7 +788,6 @@ Status NumPyConverter::VisitStringDType(T* builder) {
           }
           data_bytes += static_cast<int64_t>(value_bytes);
         }
-        data += stride_;
       }
 
       if (null_count == batch_length) {
@@ -804,10 +796,8 @@ Status NumPyConverter::VisitStringDType(T* builder) {
       }
 
       RETURN_NOT_OK(builder->Reserve(batch_length));
-      bool use_safe_append = false;
-      if constexpr (std::is_same_v<T, StringViewBuilder>) {
-        use_safe_append = data_bytes > std::numeric_limits<int32_t>::max();
-      }
+      const bool use_safe_append = std::is_same_v<T, StringViewBuilder> &&
+                                   data_bytes > std::numeric_limits<int32_t>::max();
       if (!use_safe_append) {
         RETURN_NOT_OK(builder->ReserveData(data_bytes));
       }

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2925,6 +2925,69 @@ def test_array_from_numpy_unicode(string_type):
     assert arrow_arr.equals(expected)
 
 
+@pytest.fixture
+def numpy_string_dtype():
+    dtypes = pytest.importorskip("numpy.dtypes")
+    return dtypes.StringDType
+
+
+@pytest.mark.numpy
+@pytest.mark.parametrize('string_type', [
+    None,
+    pa.string(),
+    pa.large_string(),
+    pa.string_view()])
+def test_array_from_numpy_string_dtype(numpy_string_dtype, string_type):
+    values = [
+        "short",
+        "a" * 100,
+        "b" * 300,
+        "árvíztűrő tükörfúrógép 🥐 你好",
+        "🥐" * 200,
+        "",
+    ]
+    arr = np.array(values, dtype=numpy_string_dtype())
+
+    arrow_arr = pa.array(arr, type=string_type)
+
+    arrow_arr.validate(full=True)
+    assert arrow_arr.type == (string_type or pa.string())
+    assert arrow_arr.to_pylist() == arr.tolist()
+
+    strided = np.array(list(itertools.chain.from_iterable(
+        zip(values, itertools.repeat("skip")))),
+        dtype=numpy_string_dtype())[::2]
+    arrow_arr = pa.array(strided, type=string_type)
+    arrow_arr.validate(full=True)
+    assert arrow_arr.to_pylist() == values
+
+
+@pytest.mark.numpy
+@pytest.mark.parametrize('na_object', [None, "__placeholder__"])
+def test_array_from_numpy_string_dtype_nulls_and_mask(
+        numpy_string_dtype, na_object):
+    arr = np.array(["some", na_object, "strings"],
+                   dtype=numpy_string_dtype(na_object=na_object))
+
+    arrow_arr = pa.array(arr)
+    arrow_arr.validate(full=True)
+    assert arrow_arr.to_pylist() == ["some", None, "strings"]
+
+    mask = np.array([False, False, True])
+    arrow_arr = pa.array(arr, mask=mask)
+    arrow_arr.validate(full=True)
+    assert arrow_arr.to_pylist() == ["some", None, None]
+
+
+@pytest.mark.numpy
+def test_array_from_numpy_string_dtype_rejects_non_string_type(
+        numpy_string_dtype):
+    arr = np.array(["some", "strings"], dtype=numpy_string_dtype())
+
+    with pytest.raises(TypeError, match="can only be converted"):
+        pa.array(arr, type=pa.binary())
+
+
 @pytest.mark.numpy
 def test_array_string_from_non_string():
     # ARROW-5682 - when converting to string raise on non string-like dtype

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2954,12 +2954,10 @@ def test_array_from_numpy_string_dtype(numpy_string_dtype, string_type):
     assert arrow_arr.type == (string_type or pa.string())
     assert arrow_arr.to_pylist() == arr.tolist()
 
-    strided = np.array(list(itertools.chain.from_iterable(
-        zip(values, itertools.repeat("skip")))),
-        dtype=numpy_string_dtype())[::2]
-    arrow_arr = pa.array(strided, type=string_type)
-    arrow_arr.validate(full=True)
-    assert arrow_arr.to_pylist() == values
+    for sliced in (arr[:0], arr[::2], arr[::-1]):
+        arrow_arr = pa.array(sliced, type=string_type)
+        arrow_arr.validate(full=True)
+        assert arrow_arr.to_pylist() == sliced.tolist()
 
 
 @pytest.mark.numpy
@@ -2968,7 +2966,7 @@ def test_array_from_numpy_string_dtype(numpy_string_dtype, string_type):
     pa.large_string(),
     pa.string_view(),
 ])
-@pytest.mark.parametrize('na_object', [None, "__placeholder__", np.nan])
+@pytest.mark.parametrize('na_object', [None, "__placeholder__", float("nan")])
 def test_array_from_numpy_string_dtype_nulls_and_mask(
         numpy_string_dtype, string_type, na_object):
     arr = np.array(["some", na_object, "strings"],
@@ -2979,7 +2977,7 @@ def test_array_from_numpy_string_dtype_nulls_and_mask(
     assert arrow_arr.to_pylist() == ["some", None, "strings"]
 
     mask = np.array([False, False, True])
-    arrow_arr = pa.array(arr, mask=mask)
+    arrow_arr = pa.array(arr, mask=mask, type=string_type)
     arrow_arr.validate(full=True)
     assert arrow_arr.to_pylist() == ["some", None, None]
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2963,13 +2963,18 @@ def test_array_from_numpy_string_dtype(numpy_string_dtype, string_type):
 
 
 @pytest.mark.numpy
-@pytest.mark.parametrize('na_object', [None, "__placeholder__"])
+@pytest.mark.parametrize('string_type', [
+    None,
+    pa.large_string(),
+    pa.string_view(),
+])
+@pytest.mark.parametrize('na_object', [None, "__placeholder__", np.nan])
 def test_array_from_numpy_string_dtype_nulls_and_mask(
-        numpy_string_dtype, na_object):
+        numpy_string_dtype, string_type, na_object):
     arr = np.array(["some", na_object, "strings"],
                    dtype=numpy_string_dtype(na_object=na_object))
 
-    arrow_arr = pa.array(arr)
+    arrow_arr = pa.array(arr, type=string_type)
     arrow_arr.validate(full=True)
     assert arrow_arr.to_pylist() == ["some", None, "strings"]
 
@@ -2977,6 +2982,19 @@ def test_array_from_numpy_string_dtype_nulls_and_mask(
     arrow_arr = pa.array(arr, mask=mask)
     arrow_arr.validate(full=True)
     assert arrow_arr.to_pylist() == ["some", None, None]
+
+
+@pytest.mark.numpy
+@pytest.mark.parametrize('string_type', [pa.large_string(), pa.string_view()])
+def test_array_from_numpy_string_dtype_batches(
+        numpy_string_dtype, string_type):
+    values = [None] * 4096 + [f"value-{i}" for i in range(904)]
+    arr = np.array(values, dtype=numpy_string_dtype(na_object=None))
+
+    arrow_arr = pa.array(arr, type=string_type)
+
+    arrow_arr.validate(full=True)
+    assert arrow_arr.to_pylist() == values
 
 
 @pytest.mark.numpy


### PR DESCRIPTION
### Rationale for this change
Implement https://github.com/apache/arrow/issues/42018

### What changes are included in this PR?
Conversion in numpy->arrow direction with multiple string types

### Are these changes tested?
Two basic conversion tests added and one boundary that only string(), large_string(), string_view() is supported.

### Are there any user-facing changes?
Yes, adds support to numpy.StringDType as source

cc @jorisvandenbossche as he opened the original issue

This PR was created using GPT-5.6-Sol-xhigh, every line read & reviewed by me.
* GitHub Issue: #42018