### PR TITLE
MINOR: [Python] Fix FeatherDataset.read_pandas docstring referencing Parquet

### DIFF
--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -76,7 +76,7 @@ class FeatherDataset:
 
     def read_pandas(self, columns=None, use_threads=True):
         """
-        Read multiple Parquet files as a single pandas DataFrame
+        Read multiple Feather files as a single pandas DataFrame
 
         Parameters
         ----------


### PR DESCRIPTION
### Rationale for this change
In `pyarrow.feather.FeatherDataset.read_pandas`, the docstring previously stated:
```
Read multiple Parquet files as a single pandas DataFrame
```
which was copied from Parquet reader utilities.

### What changes are included in this PR?
Updates the docstring to correctly reference Feather files:
```
Read multiple Feather files as a single pandas DataFrame
```

### Are these changes tested?
Docstring update.