### PR TITLE
GH-32503: [Docs][Benchmarking] Document pull request benchmark hooks

### DIFF
--- a/docs/source/developers/benchmarks.rst
+++ b/docs/source/developers/benchmarks.rst
@@ -51,6 +51,27 @@ Additionally a full CMake build directory may be specified.
 
    archery benchmark run $HOME/arrow/cpp/release-build
 
+Benchmarking a pull request
+===========================
+
+To run the remote benchmark suite for a pull request, add this comment to the
+pull request:
+
+.. code-block:: text
+
+   @ursabot please benchmark
+
+The bot schedules benchmark runs for the pull request commit. When they finish,
+Conbench posts a report comparing the pull request (the contender) with its base
+commit (the baseline).
+
+The benchmark jobs use the environment variables and build hooks in
+``dev/conbench_envs`` from the commit being tested. This means that changes to
+``benchmarks.env`` or ``hooks.sh`` can be tested in the same pull request. See
+the `benchmark build environment and hooks documentation
+<https://github.com/apache/arrow/tree/main/dev/conbench_envs>`_ for details and
+the requirements for changing existing hooks.
+
 Comparison
 ==========
 


### PR DESCRIPTION
### Rationale for this change

Fixes #32503.

The developer benchmark guide explains local Archery runs but does not describe how pull requests use the remote benchmark service or repository-owned build hooks.

### What changes are included in this PR?

- Document the pull request comment that schedules remote benchmarks.
- Explain how Conbench compares the contender and baseline commits.
- Link the benchmark environment and hooks documentation and clarify that hook changes are tested from the pull request commit.

### Are these changes tested?

- uvx sphinx-lint docs/source/developers/benchmarks.rst
- make -C docs dev with the documented requirements installed in an isolated environment
- Inspected the rendered benchmarks page to verify the new section, command block, and link.

### Are there any user-facing changes?

Yes. The developer documentation now explains pull request benchmarking and benchmark hook changes.

### AI usage

This documentation update was drafted with Codex assistance. I reviewed the current workflow against recent Arrow pull request benchmark comments, checked every line of the change, and verified the rendered output locally.

* GitHub Issue: #32503