### PR TITLE
MINOR: [R] Add 25.0.1 NEWS entry

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -21,6 +21,10 @@
 
 # arrow 25.0.1
 
+## Minor improvements and fixes
+
+- Improved mimalloc memory allocator configuration on macOS (#50428).
+
 # arrow 25.0.0
 
 ## Breaking changes


### PR DESCRIPTION
### Rationale for this change

The 25.0.1 section of r/NEWS.md on main is empty; the CRAN 25.0.1 release branch has an entry for the mimalloc change that shipped in the patch release.

### What changes are included in this PR?

Adds the 25.0.1 NEWS entry to match the CRAN release branch.

### Are these changes tested?

No, documentation only.

### Are there any user-facing changes?

No.