### PR TITLE
GH-38809: [Python] Add tests for struct type promotion in concat_tables

### DIFF
--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2098,6 +2098,65 @@ def test_concat_tables_with_promotion_error():
         pa.concat_tables([t1, t2], promote_options="default")
 
 
+def test_concat_tables_with_struct_promotion():
+    # GH-38809: fields of a struct are unified, and fields missing from one
+    # of the tables are filled with nulls
+    t1 = pa.Table.from_pydict(
+        {'a': [1.0, 2.0], 'b': [{'k1': 0, 'k2': 1}, {'k3': 'ok'}]})
+    t2 = pa.Table.from_pydict(
+        {'a': [1.0, None], 'b': [{'k1': None}, {'k3': None}]})
+
+    expected_type = pa.struct(
+        [('k1', pa.int64()), ('k2', pa.int64()), ('k3', pa.string())])
+    expected_values = [
+        {'k1': 0, 'k2': 1, 'k3': None},
+        {'k1': None, 'k2': None, 'k3': 'ok'},
+        {'k1': None, 'k2': None, 'k3': None},
+        {'k1': None, 'k2': None, 'k3': None},
+    ]
+
+    for promote_options in ["default", "permissive"]:
+        result = pa.concat_tables([t1, t2], promote_options=promote_options)
+        assert result.schema.field('b').type == expected_type
+        assert result.column('b').to_pylist() == expected_values
+
+    # the unified struct keeps the field order of the first table
+    result = pa.concat_tables([t2, t1], promote_options="permissive")
+    assert result.schema.field('b').type == pa.struct(
+        [('k1', pa.int64()), ('k3', pa.string()), ('k2', pa.int64())])
+
+
+def test_concat_tables_with_nested_struct_promotion():
+    # GH-38809: types nested inside a struct are promoted as well
+    t1 = pa.Table.from_pydict(
+        {'a': [{'k': 1}]},
+        schema=pa.schema([('a', pa.struct([('k', pa.int32())]))]))
+    t2 = pa.Table.from_pydict(
+        {'a': [{'k': 2.5}]},
+        schema=pa.schema([('a', pa.struct([('k', pa.float64())]))]))
+
+    result = pa.concat_tables([t1, t2], promote_options="permissive")
+    assert result.schema.field('a').type == pa.struct([('k', pa.float64())])
+    assert result.column('a').to_pylist() == [{'k': 1.0}, {'k': 2.5}]
+
+    with pytest.raises(pa.ArrowTypeError, match="Unable to merge:"):
+        pa.concat_tables([t1, t2], promote_options="default")
+
+
+def test_concat_tables_with_list_of_struct_promotion():
+    # GH-38809: struct promotion also applies below a list
+    t1 = pa.Table.from_pydict({'a': [[{'k1': 1}]]})
+    t2 = pa.Table.from_pydict({'a': [[{'k2': 'ok'}]]})
+
+    result = pa.concat_tables([t1, t2], promote_options="permissive")
+    assert result.schema.field('a').type == pa.list_(
+        pa.struct([('k1', pa.int64()), ('k2', pa.string())]))
+    assert result.column('a').to_pylist() == [
+        [{'k1': 1, 'k2': None}],
+        [{'k1': None, 'k2': 'ok'}],
+    ]
+
+
 def test_table_negative_indexing():
     data = [
         pa.array(range(5)),


### PR DESCRIPTION
### Rationale for this change

GH-38809 reports that `pa.concat_tables` cannot promote struct types. That is no longer true: the snippet in the issue works from 19.0.0 onwards. Schema unification of structs was there from the start (`MergeStructs` in `cpp/src/arrow/type.cc`, added in #36846); what was missing was the cast side, which GH-44555 / #44587 fixed by letting `CastStruct` fill absent output fields with nulls. #45246 later added field reordering.

None of that is covered by a Python test — the existing `test_concat_tables_with_promotion*` tests use flat types only — so the behaviour could regress unnoticed. These tests pin it down and give GH-38809 something to close on.

### What changes are included in this PR?

Three tests in `python/pyarrow/tests/test_table.py`:

* `test_concat_tables_with_struct_promotion` — the exact case from GH-38809: a struct field present in one table only is filled with null, `null`-typed fields are promoted, and the unified struct keeps the first table's field order.
* `test_concat_tables_with_nested_struct_promotion` — `int32` and `float64` nested inside a struct promote to `float64` under `permissive`, and still fail under `default`.
* `test_concat_tables_with_list_of_struct_promotion` — the same promotion below a list.

No library changes.

### Are these changes tested?

They are tests.

Verified: `pytest -k struct_promotion` against pyarrow 25.0.1 → 3 passed. The first case fails on 18.1.0 with exactly the error quoted in GH-38809 (`struct fields don't match or are in the wrong order`) and passes on 19.0.0, which is how the fixing release was identified.

### Are there any user-facing changes?

No.

*This change was created with AI assistance.* The version bisect, the assertions and the claim about which commit fixed it were each checked by running them; the expected values in the tests are the observed output of `concat_tables`, not hand-written guesses.

* GitHub Issue: #38809