### PR TITLE
GH-50957: [Python] Reject unexpected concat_tables keywords

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -6292,6 +6292,8 @@ def concat_tables(tables, MemoryPool memory_pool=None, str promote_options="none
     promote_options : str, default none
         Accepts strings "none", "default" and "permissive".
     **kwargs : dict, optional
+        Additional arguments. The deprecated ``promote`` argument is accepted
+        for backward compatibility.
 
     Examples
     --------
@@ -6320,6 +6322,12 @@ def concat_tables(tables, MemoryPool memory_pool=None, str promote_options="none
         Table table
         CConcatenateTablesOptions options = (
             CConcatenateTablesOptions.Defaults())
+
+    unexpected_kwargs = [key for key in kwargs if key != "promote"]
+    if unexpected_kwargs:
+        raise TypeError(
+            f"concat_tables() got an unexpected keyword argument "
+            f"'{unexpected_kwargs[0]}'")
 
     if "promote" in kwargs:
         warnings.warn(

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2013,6 +2013,15 @@ def test_concat_tables_invalid_option():
         pa.concat_tables([t, t], promote_options="invalid")
 
 
+def test_concat_tables_rejects_unknown_keyword_arguments():
+    t = pa.Table.from_arrays([list(range(10))], names=('a',))
+
+    with pytest.raises(
+            TypeError,
+            match="unexpected keyword argument 'totally_bogus_kwarg'"):
+        pa.concat_tables([t, t], totally_bogus_kwarg=True)
+
+
 def test_concat_tables_none_table():
     # ARROW-11997
     with pytest.raises(AttributeError):


### PR DESCRIPTION
### Rationale for this change

`concat_tables()` keeps `**kwargs` only for the deprecated `promote` argument, but previously discarded every other key. As a result, keyword typos and apparently meaningful inputs such as `unify_schemas` were silently accepted without affecting the result.

### What changes are included in this PR?

- Reject unsupported keyword arguments with `TypeError` before processing the deprecated compatibility argument.
- Document that `promote` is the only accepted extra argument.
- Add a focused regression for the reported unknown-key behavior.

### Are these changes tested?

- Built and installed the current Arrow C++ minimal Python preset and an editable PyArrow from this branch.
- `python -m pytest -q python/pyarrow/tests/test_table.py -k 'concat_tables'`: 9 passed.
- `python -m pytest -q python/pyarrow/tests/test_table.py`: 181 passed, 33 skipped.
- Changed-file Python pre-commit hooks: format, flake8, and Cython lint passed.
- `git diff --check` passed.

### Are there any user-facing changes?

Yes. Unknown `concat_tables()` keyword arguments now raise `TypeError`, matching normal Python call behavior. The deprecated `promote=True` and `promote=False` compatibility path remains unchanged.

### AI assistance

I used an AI coding assistant to help investigate the root cause, draft the focused two-file patch, and run validation. I reviewed and understand every change and can own and debug it during review.

Closes #50957

* GitHub Issue: #50957