### PR TITLE
GH-50964: [C++] fix out-of-bounds read in DecimalRescale for out-of-range scale

### DIFF
--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -1061,6 +1061,16 @@ DecimalStatus DecimalRescale(const DecimalClass& value, int32_t original_scale,
   }
 
   const int32_t delta_scale = new_scale - original_scale;
+
+  // GetScaleMultiplier only covers scales in [0, kMaxScale]; a larger delta would
+  // index the scale-multiplier table out of bounds. A rescale that big can never be
+  // represented without overflow or truncation, so reject it here instead of reading
+  // past the table. Testing delta_scale before std::abs also avoids abs(INT32_MIN).
+  if (ARROW_PREDICT_FALSE(delta_scale > DecimalClass::kMaxScale ||
+                          delta_scale < -DecimalClass::kMaxScale)) {
+    return DecimalStatus::kRescaleDataLoss;
+  }
+
   const int32_t abs_delta_scale = std::abs(delta_scale);
 
   DecimalClass multiplier = DecimalClass::GetScaleMultiplier(abs_delta_scale);

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -478,6 +478,20 @@ TEST(Decimal128Test, FromStringLimits) {
                           38, 38);
 }
 
+TEST(Decimal128Test, RescaleScaleParsedFromStringOutOfRange) {
+  // A negative exponent with few significant digits parses to a small precision but
+  // a scale far beyond kMaxScale. Rescaling that value to the target scale (as the
+  // CSV decimal converter does) used to index the scale-multiplier table out of
+  // bounds; it now fails cleanly.
+  Decimal128 value;
+  int32_t precision = 0;
+  int32_t scale = 0;
+  ASSERT_OK(Decimal128::FromString("1E-100", &value, &precision, &scale));
+  ASSERT_EQ(precision, 1);
+  ASSERT_EQ(scale, 100);
+  ASSERT_RAISES(Invalid, value.Rescale(scale, 0));
+}
+
 TEST(Decimal256Test, FromStringLimits) {
   // Positive / zero exponent
   AssertDecimalFromString(
@@ -1599,6 +1613,13 @@ TYPED_TEST(TestBasicDecimalFunctionality, Rescale) {
       ASSERT_OK_AND_EQ(TypeParam(-1), negative_value.Rescale(new_scale, original_scale));
     }
   }
+
+  // A scale change larger than kMaxScale used to index the scale-multiplier table
+  // out of bounds (an out-of-bounds read caught by ASAN). It now reports data loss
+  // for both the multiply and divide directions. A delta of exactly kMaxScale is the
+  // largest valid multiplier and is exercised by the loops above.
+  ASSERT_RAISES(Invalid, TypeParam(1).Rescale(0, TypeParam::kMaxScale + 1));
+  ASSERT_RAISES(Invalid, TypeParam(1).Rescale(TypeParam::kMaxScale + 1, 0));
 }
 
 TYPED_TEST(TestBasicDecimalFunctionality, Mod) {


### PR DESCRIPTION
### Rationale for this change

`DecimalRescale` indexes the scale-multiplier table through `GetScaleMultiplier(abs_delta_scale)`, but that table only holds `kMaxScale + 1` entries and is guarded by a `DCHECK` that disappears under `NDEBUG`. `Decimal::FromString` clamps a negative parsed scale but leaves a positive one unbounded, so a literal like `1E-100` parses to precision 1 and scale 100. In the CSV decimal converter that passes the precision check and then calls `Rescale(100, 0)`, reading `kDecimal128PowersOfTen[100]` well past the end of the 39-entry table. The same path is reachable from the public `Decimal32/64/128/256::FromString` and `Rescale` APIs. UBSan flags it as `index 100 out of bounds for type 'const BasicDecimal128[39]'`.

### What changes are included in this PR?

Reject a scale delta whose magnitude exceeds `kMaxScale` in `DecimalRescale` before the lookup, returning `kRescaleDataLoss`. A change that large can never be represented without overflow or truncation anyway. The check lives in the one templated function so it covers all four decimal widths, and testing the delta before `std::abs` also keeps `std::abs(INT32_MIN)` out of reach.

### Are these changes tested?

Yes. The typed `Rescale` test now asserts a delta past `kMaxScale` fails in both directions (a delta of exactly `kMaxScale` is still exercised by the existing loops). A new `Decimal128` case parses `1E-100`, confirms scale 100, and checks the following `Rescale` returns Invalid instead of reading past the table. Built with `-fsanitize=bounds`, the prior code aborts at `GetScaleMultiplier`; with the fix it returns cleanly.

### Are there any user-facing changes?

A decimal string whose scale exceeds the type maximum now returns an Invalid status from `Rescale` rather than reading out of bounds. Valid inputs are unchanged.

**This PR contains a "Critical Fix".** An out-of-bounds read of a static table, reachable from untrusted decimal strings (for example CSV values), that the `DCHECK` bound does not catch in release builds.

* GitHub Issue: #50964
