### PR TITLE
GH-47576: [C++][Acero] Fix C++23 build

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -509,18 +509,7 @@ class InputState : public util::SerialSequencingQueue::Processor {
       KeyHasher* key_hasher, ExecNode* asof_input, AsofJoinNode* asof_node,
       std::atomic<int32_t>& backpressure_counter,
       const std::shared_ptr<arrow::Schema>& schema, const col_index_t time_col_index,
-      const std::vector<col_index_t>& key_col_index) {
-    constexpr size_t low_threshold = 4, high_threshold = 8;
-    std::unique_ptr<BackpressureControl> backpressure_control =
-        std::make_unique<BackpressureController>(
-            /*node=*/asof_input, /*output=*/asof_node, backpressure_counter);
-    ARROW_ASSIGN_OR_RAISE(auto handler,
-                          BackpressureHandler::Make(low_threshold, high_threshold,
-                                                    std::move(backpressure_control)));
-    return std::make_unique<InputState>(index, tolerance, must_hash, may_rehash,
-                                        key_hasher, asof_node, std::move(handler), schema,
-                                        time_col_index, key_col_index);
-  }
+      const std::vector<col_index_t>& key_col_index);
 
   col_index_t InitSrcToDstMapping(col_index_t dst_offset, bool skip_time_and_key_fields) {
     src_to_dst_.resize(schema_->num_fields());
@@ -1573,6 +1562,24 @@ class AsofJoinNode : public ExecNode {
   // In-progress batches produced
   int batches_produced_ = 0;
 };
+
+Result<std::unique_ptr<InputState>> InputState::Make(
+    size_t index, TolType tolerance, bool must_hash, bool may_rehash,
+    KeyHasher* key_hasher, ExecNode* asof_input, AsofJoinNode* asof_node,
+    std::atomic<int32_t>& backpressure_counter,
+    const std::shared_ptr<arrow::Schema>& schema, const col_index_t time_col_index,
+    const std::vector<col_index_t>& key_col_index) {
+  constexpr size_t low_threshold = 4, high_threshold = 8;
+  std::unique_ptr<BackpressureControl> backpressure_control =
+      std::make_unique<BackpressureController>(
+          /*node=*/asof_input, /*output=*/asof_node, backpressure_counter);
+  ARROW_ASSIGN_OR_RAISE(auto handler,
+                        BackpressureHandler::Make(low_threshold, high_threshold,
+                                                  std::move(backpressure_control)));
+  return std::make_unique<InputState>(index, tolerance, must_hash, may_rehash, key_hasher,
+                                      asof_node, std::move(handler), schema,
+                                      time_col_index, key_col_index);
+}
 
 AsofJoinNode::AsofJoinNode(ExecPlan* plan, NodeVector inputs,
                            std::vector<std::string> input_labels,


### PR DESCRIPTION
### Rationale for this change

Related to #47576.

In `C++23`, `Clang` diagnoses the conversion from `AsofJoinNode*` to `ExecNode*`
while instantiating `std::make_unique<BackpressureController>`. At the current
definition site, `AsofJoinNode` is still incomplete, causing the `Acero` build to
fail.

### What changes are included in this PR?

Declare `InputState::Make` in `InputState` and define it after `AsofJoinNode` is
complete. This makes the derived-to-base conversion valid without changing runtime
behavior.

AI assistance: Codex drafted and evaluated this source-ordering change. The
automated checks below were run before opening the PR.

### Are these changes tested?

- `cmake --build cpp/build-clang22-cxx23-release --target arrow_acero_static --parallel 2`
  (`Clang 22.1.8`, `Release`, `C++23`)
- `ctest -j 16 --output-on-failure` in
  `cpp/build-clang22-cxx23-release-tests/src/arrow/acero`: 14/14 tests passed
- `clang-format --dry-run --Werror cpp/src/arrow/acero/asof_join_node.cc`
- `git diff --check`

<details>
<summary>Original `Clang 22` `C++23` diagnostic</summary>

~~~text
In file included from /arrow/src/arrow/acero/asof_join_node.cc:18:
In file included from /arrow/src/arrow/acero/asof_join_node.h:20:
In file included from /arrow/src/arrow/acero/options.h:21:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16/../../../../include/c++/16/memory:80:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16/../../../../include/c++/16/bits/unique_ptr.h:1105:34: error: no matching constructor for initialization of 'arrow::acero::BackpressureController'
 1105 |     { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
      |                                  ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/arrow/src/arrow/acero/asof_join_node.cc:515:14: note: in instantiation of function template specialization 'std::make_unique<arrow::acero::BackpressureController, arrow::acero::ExecNode *&, arrow::acero::AsofJoinNode *&, std::atomic<int> &>' requested here
  515 |         std::make_unique<BackpressureController>(
      |              ^
/arrow/src/arrow/acero/asof_join_node.cc:464:3: note: candidate constructor not viable: cannot convert argument of incomplete type 'arrow::acero::AsofJoinNode *' to 'ExecNode *' for 2nd argument
  464 |   BackpressureController(ExecNode* node, ExecNode* output,
      |   ^                                      ~~~~~~~~~~~~~~~~
/arrow/src/arrow/acero/asof_join_node.cc:462:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 3 were provided
  462 | class BackpressureController : public BackpressureControl {
      |       ^~~~~~~~~~~~~~~~~~~~~~
/arrow/src/arrow/acero/asof_join_node.cc:462:7: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 3 were provided
  462 | class BackpressureController : public BackpressureControl {
      |       ^~~~~~~~~~~~~~~~~~~~~~
/arrow/src/arrow/acero/asof_join_node.cc:794:17: warning: private field 'node_' is not used [-Wunused-private-field]
  794 |   AsofJoinNode* node_;
      |                 ^
/arrow/src/arrow/acero/asof_join_node.cc:796:10: warning: private field 'index_' is not used [-Wunused-private-field]
  796 |   size_t index_;
      |          ^
2 warnings and 1 error generated.
~~~

</details>

### Are there any user-facing changes?

No public API changes. This restores the ability to compile the `Acero` component
with the affected `Clang 22`/`C++23` configuration.

* GitHub Issue: #47576