### PR TITLE
GH-50978: [C++] Enable MSVC's new preprocessor to handle C++20 grammar

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -218,22 +218,11 @@ if(WIN32)
       set(CXX_COMMON_FLAGS "/W3 /EHsc")
     endif()
 
-    # Disable C5105 (macro expansion producing 'defined' has undefined
-    # behavior) warning because there are codes that produce this
-    # warning in Windows Kits. e.g.:
-    #
-    #   #define _CRT_INTERNAL_NONSTDC_NAMES                                            \
-    #        (                                                                          \
-    #            ( defined _CRT_DECLARE_NONSTDC_NAMES && _CRT_DECLARE_NONSTDC_NAMES) || \
-    #            (!defined _CRT_DECLARE_NONSTDC_NAMES && !__STDC__                 )    \
-    #        )
+    # Enable the conforming preprocessor to support C++20 features.
     #
     # See also:
-    # * C5105: https://docs.microsoft.com/en-US/cpp/error-messages/compiler-warnings/c5105
-    # * Related reports:
-    #   * https://developercommunity.visualstudio.com/content/problem/387684/c5105-with-stdioh-and-experimentalpreprocessor.html
-    #   * https://developercommunity.visualstudio.com/content/problem/1249671/stdc17-generates-warning-compiling-windowsh.html
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /wd5105")
+    # * https://devblogs.microsoft.com/cppblog/announcing-full-support-for-a-c-c-conformant-preprocessor-in-msvc/
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /Zc:preprocessor")
 
     if(ARROW_USE_STATIC_CRT)
       foreach(c_flag


### PR DESCRIPTION
### Rationale for this change

Try to use MSVC's new preprocessor to handle C++20 grammar such as `__VA_OPT__`.

### What changes are included in this PR?

Change the common flag under MSVC.

### Are these changes tested?

Tested by existed tests.

### Are there any user-facing changes?

No.
* GitHub Issue: #50978