### PR TITLE
GH-50985: [CI][Dev][Python] Update cython-lint and pin Cython to 3.2.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,6 +155,8 @@ repos:
           - "--no-pycodestyle"
         files: >-
           ^python/
+        additional_dependencies:
+        - Cython==3.2.9
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,6 +155,8 @@ repos:
           - "--no-pycodestyle"
         files: >-
           ^python/
+        # Pin Cython to 3.2.9 until cython-lint supports Cython 3.3:
+        # https://github.com/MarcoGorelli/cython-lint/issues/201
         additional_dependencies:
         - Cython==3.2.9
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,7 +146,7 @@ repos:
           ?^python/pyarrow/vendored/|
           )
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.16.2
+    rev: v0.21.0
     hooks:
       - id: cython-lint
         alias: python


### PR DESCRIPTION
### Rationale for this change

Cython 3.3.0 causes `cython-lint` to fail with the following error:
See also: https://github.com/MarcoGorelli/cython-lint/issues/201

```
Python (Cython) Lint.....................................................Failed
- hook id: cython-lint
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/bin/cython-lint", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 960, in main
    ret |= _main(
           ^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 837, in _main
    lines = run_ast_checks(code, filename, violations)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 751, in run_ast_checks
    names, imported_names, global_names, exported_imports = _traverse_file(
                                                            ^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 541, in _traverse_file
    expr = node.loop.body.value_expr
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DictComprehensionAppendNode' object has no attribute 'value_expr'
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/bin/cython-lint", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 960, in main
    ret |= _main(
           ^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 837, in _main
    lines = run_ast_checks(code, filename, violations)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 751, in run_ast_checks
    names, imported_names, global_names, exported_imports = _traverse_file(
                                                            ^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repoohugd5tn/py_env-python3/lib/python3.12/site-packages/cython_lint/cython_lint.py", line 541, in _traverse_file
    expr = node.loop.body.value_expr
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DictComprehensionAppendNode' object has no attribute 'value_expr'
```

### What changes are included in this PR?

* Pin Cython to 3.2.9 for cython-lint.
* Update `cython-lint` from 0.16.2 to 0.21.0, as it was using an older version.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50985