### PR TITLE
GH-50988: [C++][Python] Substrait: add mappings for starts_with, ends_with and match_substring

### DIFF
--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -26,8 +26,10 @@
 
 #include "arrow/compute/api_scalar.h"
 #include "arrow/engine/substrait/options.h"
+#include "arrow/scalar.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hash_util.h"
 #include "arrow/util/hashing.h"
@@ -36,6 +38,7 @@
 
 namespace arrow {
 
+using internal::checked_cast;
 using internal::checked_pointer_cast;
 namespace engine {
 namespace {
@@ -757,6 +760,19 @@ static std::vector<std::string> kRoundModes = {
     "TIE_UP", "TIE_TOWARDS_ZERO", "TIE_AWAY_FROM_ZERO", "TIE_TO_EVEN",    "TIE_TO_ODD"};
 static EnumParser<compute::RoundMode> kRoundModeParser(kRoundModes);
 
+// The case_sensitivity option used by the Substrait string functions
+// (starts_with / ends_with / contains).  Arrow's MatchSubstringOptions only
+// distinguishes case sensitive from case insensitive, so CASE_INSENSITIVE_ASCII
+// is parsed but not implemented.
+enum class CaseSensitivity {
+  kCaseSensitive = 0,
+  kCaseInsensitive,
+  kCaseInsensitiveAscii
+};
+static std::vector<std::string> kCaseSensitivityOptions = {
+    "CASE_SENSITIVE", "CASE_INSENSITIVE", "CASE_INSENSITIVE_ASCII"};
+static EnumParser<CaseSensitivity> kCaseSensitivityParser(kCaseSensitivityOptions);
+
 template <typename Enum>
 Result<Enum> ParseOptionOrElse(const SubstraitCall& call, std::string_view option_name,
                                const EnumParser<Enum>& parser,
@@ -961,6 +977,71 @@ ExtensionIdRegistry::SubstraitCallToArrow DecodeConcatMapping() {
   };
 }
 
+// Substrait's starts_with / ends_with / contains take the pattern as a second
+// value argument.  The matching Arrow kernels (starts_with / ends_with /
+// match_substring) are unary and carry the pattern in MatchSubstringOptions, so
+// the second argument must be a string literal.
+ExtensionIdRegistry::SubstraitCallToArrow DecodeMatchSubstringMapping(
+    const std::string& function_name) {
+  return [function_name](const SubstraitCall& call) -> Result<compute::Expression> {
+    if (call.size() != 2) {
+      return Status::NotImplemented("Acero does not have a kernel for ", function_name,
+                                    " that receives ", call.size(), " arguments");
+    }
+    ARROW_ASSIGN_OR_RAISE(
+        CaseSensitivity case_sensitivity,
+        ParseOptionOrElse(
+            call, "case_sensitivity", kCaseSensitivityParser,
+            {CaseSensitivity::kCaseSensitive, CaseSensitivity::kCaseInsensitive},
+            CaseSensitivity::kCaseSensitive));
+    ARROW_ASSIGN_OR_RAISE(compute::Expression input, call.GetValueArg(0));
+    ARROW_ASSIGN_OR_RAISE(compute::Expression substring, call.GetValueArg(1));
+    const Datum* pattern = substring.literal();
+    if (pattern == nullptr || !pattern->is_scalar()) {
+      return Status::NotImplemented(
+          "The Arrow ", function_name,
+          " kernel requires the substring argument to be a literal");
+    }
+    const std::shared_ptr<Scalar>& pattern_scalar = pattern->scalar();
+    if (!pattern_scalar->is_valid || (!is_base_binary_like(pattern_scalar->type->id()) &&
+                                      !is_binary_view_like(pattern_scalar->type->id()))) {
+      return Status::NotImplemented(
+          "The Arrow ", function_name,
+          " kernel requires the substring argument to be a non-null string literal");
+    }
+    auto options = std::make_shared<compute::MatchSubstringOptions>(
+        std::string(checked_cast<const BaseBinaryScalar&>(*pattern_scalar).view()),
+        /*ignore_case=*/case_sensitivity == CaseSensitivity::kCaseInsensitive);
+    return compute::call(function_name, {std::move(input)}, std::move(options));
+  };
+}
+
+ExtensionIdRegistry::ArrowToSubstraitCall EncodeMatchSubstring(Id substrait_fn_id) {
+  return
+      [substrait_fn_id](const compute::Expression::Call& call) -> Result<SubstraitCall> {
+        if (call.arguments.size() != 1) {
+          return Status::Invalid("Expected the call to ", call.function_name,
+                                 " to have exactly one argument but it had ",
+                                 call.arguments.size());
+        }
+        if (call.options == nullptr) {
+          return Status::Invalid("The call to ", call.function_name,
+                                 " is missing its MatchSubstringOptions");
+        }
+        auto match_options =
+            checked_pointer_cast<compute::MatchSubstringOptions>(call.options);
+        // nullable=true errs on the side of caution
+        SubstraitCall substrait_call(substrait_fn_id, call.type.GetSharedPtr(),
+                                     /*nullable=*/true);
+        substrait_call.SetValueArg(0, call.arguments[0]);
+        substrait_call.SetValueArg(1, compute::literal(match_options->pattern));
+        substrait_call.SetOption(
+            "case_sensitivity",
+            {match_options->ignore_case ? "CASE_INSENSITIVE" : "CASE_SENSITIVE"});
+        return substrait_call;
+      };
+}
+
 ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
     const std::string& arrow_function_name) {
   return [arrow_function_name](const SubstraitCall& call) -> Result<compute::Aggregate> {
@@ -1147,6 +1228,13 @@ struct DefaultExtensionIdRegistry : ExtensionIdRegistryImpl {
                                       DecodeTemporalExtractionMapping()));
     DCHECK_OK(AddSubstraitCallToArrow({kSubstraitStringFunctionsUri, "concat"},
                                       DecodeConcatMapping()));
+    for (const auto& fn_pair : std::vector<std::pair<std::string_view, std::string>>{
+             {"starts_with", "starts_with"},
+             {"ends_with", "ends_with"},
+             {"contains", "match_substring"}}) {
+      DCHECK_OK(AddSubstraitCallToArrow({kSubstraitStringFunctionsUri, fn_pair.first},
+                                        DecodeMatchSubstringMapping(fn_pair.second)));
+    }
     DCHECK_OK(
         AddSubstraitCallToArrow({kSubstraitComparisonFunctionsUri, "is_null"},
                                 DecodeOptionlessBasicMapping("is_null", /*max_args=*/1)));
@@ -1239,6 +1327,15 @@ struct DefaultExtensionIdRegistry : ExtensionIdRegistryImpl {
 
     DCHECK_OK(AddArrowToSubstraitCall(
         "is_null", EncodeIsNull({kSubstraitComparisonFunctionsUri, "is_null"})));
+
+    for (const auto& fn_pair : std::vector<std::pair<std::string, std::string_view>>{
+             {"starts_with", "starts_with"},
+             {"ends_with", "ends_with"},
+             {"match_substring", "contains"}}) {
+      DCHECK_OK(AddArrowToSubstraitCall(
+          fn_pair.first,
+          EncodeMatchSubstring({kSubstraitStringFunctionsUri, fn_pair.second})));
+    }
   }
 };
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -6377,5 +6377,117 @@ TEST(Substrait, ExtendedExpressionInvalidPlans) {
               Raises(StatusCode::Invalid, testing::HasSubstr("Ambiguous plan")));
 }
 
+TEST(Substrait, StringMatchExpressionSerialization) {
+  std::shared_ptr<Schema> test_schema = schema({field("cat", utf8())});
+  for (const auto& fn_name : {"starts_with", "ends_with", "match_substring"}) {
+    for (bool ignore_case : {false, true}) {
+      CheckExpressionRoundTrip(
+          *test_schema, compute::call(fn_name, {compute::field_ref(0)},
+                                      compute::MatchSubstringOptions("al", ignore_case)));
+    }
+  }
+  // The pattern survives as a nested expression too
+  CheckExpressionRoundTrip(
+      *test_schema,
+      compute::call("invert", {compute::call("starts_with", {compute::field_ref(0)},
+                                             compute::MatchSubstringOptions("al"))}));
+}
+
+namespace {
+
+// An ExtendedExpression holding a single starts_with call over a utf8 column named
+// "cat".  `arguments` and `options` are spliced into the scalar function so that
+// individual tests can vary them.
+std::string StartsWithExpressionJSON(std::string_view arguments,
+                                     std::string_view options) {
+  return R"({
+      "extensionUris":[
+        {
+          "extensionUriAnchor":1,
+          "uri":")" +
+         std::string(kSubstraitStringFunctionsUri) + R"("
+        }
+      ],
+      "extensions":[
+        {
+          "extensionFunction":{
+            "extensionUriReference":1,
+            "functionAnchor":1,
+            "name":"starts_with"
+          }
+        }
+      ],
+      "referredExpr":[
+        {
+          "expression":{
+            "scalarFunction":{
+              "functionReference":1,
+              "outputType":{"bool":{"nullability":"NULLABILITY_NULLABLE"}},
+              "arguments":)" +
+         std::string(arguments) + R"(,
+              "options":)" +
+         std::string(options) + R"(
+            }
+          },
+          "outputNames":["out"]
+        }
+      ],
+      "baseSchema":{
+        "names":["cat"],
+        "struct":{
+          "types":[{"string":{"nullability":"NULLABILITY_NULLABLE"}}]
+        }
+      },
+      "version":{"majorNumber":9999}
+    })";
+}
+
+constexpr std::string_view kCatAndLiteralArgs = R"([
+  {"value":{"selection":{"directReference":{"structField":{"field":0}},
+                         "rootReference":{}}}},
+  {"value":{"literal":{"string":"al"}}}
+])";
+
+}  // namespace
+
+TEST(Substrait, StringMatchExpressionDeserialization) {
+  auto deserialize = [](const std::string& json) -> Result<BoundExpressions> {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> buf,
+                          internal::SubstraitFromJSON("ExtendedExpression", json));
+    return DeserializeExpressions(*buf);
+  };
+
+  std::shared_ptr<Schema> test_schema = schema({field("cat", utf8())});
+
+  // No case_sensitivity option means case sensitive
+  ASSERT_OK_AND_ASSIGN(BoundExpressions no_option,
+                       deserialize(StartsWithExpressionJSON(kCatAndLiteralArgs, "[]")));
+  ASSERT_OK_AND_ASSIGN(compute::Expression expected,
+                       compute::call("starts_with", {compute::field_ref(0)},
+                                     compute::MatchSubstringOptions("al"))
+                           .Bind(*test_schema));
+  ASSERT_EQ(1, no_option.named_expressions.size());
+  ASSERT_EQ(expected, no_option.named_expressions[0].expression);
+
+  // CASE_INSENSITIVE_ASCII has no Arrow equivalent
+  ASSERT_THAT(
+      deserialize(StartsWithExpressionJSON(
+          kCatAndLiteralArgs,
+          R"([{"name":"case_sensitivity","preference":["CASE_INSENSITIVE_ASCII"]}])")),
+      Raises(StatusCode::NotImplemented,
+             testing::HasSubstr("the only supported options are")));
+
+  // The pattern has to be a literal because the Arrow kernel takes it as an option
+  constexpr std::string_view kTwoFieldArgs = R"([
+    {"value":{"selection":{"directReference":{"structField":{"field":0}},
+                           "rootReference":{}}}},
+    {"value":{"selection":{"directReference":{"structField":{"field":0}},
+                           "rootReference":{}}}}
+  ])";
+  ASSERT_THAT(deserialize(StartsWithExpressionJSON(kTwoFieldArgs, "[]")),
+              Raises(StatusCode::NotImplemented,
+                     testing::HasSubstr("substring argument to be a literal")));
+}
+
 }  // namespace engine
 }  // namespace arrow

--- a/docs/source/cpp/acero/substrait.rst
+++ b/docs/source/cpp/acero/substrait.rst
@@ -227,6 +227,11 @@ Functions
   * Acero does not support the SATURATE option for overflow
   * Acero does not support kernels that take more than two arguments
     for the functions ``and``, ``or``, ``xor``
+  * The functions ``starts_with``, ``ends_with``, and ``contains`` map onto Acero
+    kernels that take the substring as a function option.  The second argument
+    must therefore be a non-null string literal.  The ``case_sensitivity`` option
+    supports ``CASE_SENSITIVE`` and ``CASE_INSENSITIVE`` but not
+    ``CASE_INSENSITIVE_ASCII``
 
 * Substrait has not yet clearly identified the form that URIs should take for
   standard functions.  Acero will look for the URIs to the ``main`` GitHub branch.

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -946,6 +946,29 @@ def test_serializing_expressions(expr):
     assert "test_expr" in returned.expressions
 
 
+@pytest.mark.parametrize("make_expr", [
+    lambda f: pc.starts_with(f, "pre"),
+    lambda f: pc.ends_with(f, "post"),
+    lambda f: pc.match_substring(f, "mid"),
+    lambda f: pc.starts_with(f, "pre", ignore_case=True),
+    lambda f: pc.ends_with(f, "post", ignore_case=True),
+    lambda f: pc.match_substring(f, "mid", ignore_case=True),
+    lambda f: ~pc.starts_with(f, "pre"),
+])
+def test_serializing_string_match_expressions(make_expr):
+    # GH-50988: starts_with / ends_with / match_substring map onto the Substrait
+    # starts_with / ends_with / contains functions
+    schema = pa.schema([pa.field("s", pa.string())])
+
+    buf = pa.substrait.serialize_expressions(
+        [make_expr(pc.field("s"))], ["test_expr"], schema)
+    returned = pa.substrait.deserialize_expressions(buf)
+    assert schema == returned.schema
+    assert len(returned.expressions) == 1
+    # Substrait refers to fields by index, so compare against the normalized form
+    assert str(returned.expressions["test_expr"]) == str(make_expr(pc.field(0)))
+
+
 def test_arrow_specific_types():
     fields = {
         "time_seconds": (pa.time32("s"), 0),


### PR DESCRIPTION
### Rationale for this change

`starts_with`, `ends_with` and `match_substring` have no Substrait mapping, so any expression using them fails to serialize:

```python
import pyarrow as pa
import pyarrow.compute as pc
from pyarrow.substrait import serialize_expressions

schema = pa.schema([pa.field("cat", pa.string())])
serialize_expressions([pc.starts_with(pc.field("cat"), "al")], ["f"], schema)
# ArrowNotImplementedError: No conversion function exists to convert the
# Arrow function starts_with to a Substrait call
```

Comparisons, `isin` and arithmetic serialize fine, so this is a per-function gap. It matters for engines that ingest a PyArrow filter through Substrait, where an unmappable function becomes a hard failure rather than a fallback.

See #50988.

### What changes are included in this PR?

Map the three kernels onto `starts_with`, `ends_with` and `contains` from Substrait's `functions_string.yaml`, in both directions.

The signatures do not line up. Substrait passes the pattern as a second argument, while the Arrow kernels are unary and carry it in `MatchSubstringOptions`. So:

* encoding lifts `MatchSubstringOptions::pattern` out into a literal argument
* decoding requires that argument to be a non-null string literal, and returns `NotImplemented` otherwise

Substrait's `case_sensitivity` option maps onto `ignore_case`. `CASE_INSENSITIVE_ASCII` has no Arrow equivalent and returns `NotImplemented`.

Both caveats are documented in `docs/source/cpp/acero/substrait.rst`.

### Are these changes tested?

Yes.

`Substrait.StringMatchExpressionSerialization` round-trips all three functions with and without `ignore_case`, plus a nested `invert(starts_with(...))`. `Substrait.StringMatchExpressionDeserialization` drives hand-written Substrait JSON to cover the default (no option) case and the two rejection paths.

### Are there any user-facing changes?

Yes. `pc.starts_with`, `pc.ends_with` and `pc.match_substring` can now be serialized to Substrait and consumed back, and Acero can consume plans using Substrait's `starts_with`, `ends_with` and `contains`. No existing behaviour changes: these previously raised.

* GitHub Issue: #50988