### PR TITLE
GH-47369: [Python][Parquet] Fix wrong variable in the invalid operator error message

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -181,7 +181,7 @@ def filters_to_expression(filters):
         elif op == 'not in':
             return ~field.isin(val)
         else:
-            raise ValueError(f'"{col}" is not a valid operator in predicates.')
+            raise ValueError(f'"{op}" is not a valid operator in predicates.')
 
     disjunction_members = []
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -369,7 +369,7 @@ def test_filters_invalid_pred_op(tempdir):
                           filesystem=local,
                           filters=[('integers', 'in', 3), ])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='"=<" is not a valid operator'):
         pq.ParquetDataset(base_path,
                           filesystem=local,
                           filters=[('integers', '=<', 3), ])


### PR DESCRIPTION
### Rationale for this change

The invalid-operator error prints the column name instead of the operator:

```
>>> pq.filters_to_expression([[('a', '=!', 1)]])
ValueError: "a" is not a valid operator in predicates.
```

The message means `op`, the value that failed to match; `col` was already consumed by `ds.field(col)` above. The mixup came in 992bee2c8, when a `.format()` over the whole `(col, op, val)` tuple was converted to an f-string. First shipped in 21.0.0.

### What changes are included in this PR?

The message interpolates `op`. The existing test already passes an invalid operator and only checked the exception type, so it gains a `match=`.

### Are these changes tested?

The `match=` fails on unpatched main:

```
E   AssertionError: Regex pattern did not match.
E     Expected regex: '"=<" is not a valid operator'
E     Actual message: '"integers" is not a valid operator in predicates.'
```

`pyarrow/tests/parquet/` passes 316 either way.

### Are there any user-facing changes?

Only the message text. Same exception, same trigger.

* GitHub Issue: #47369