### PR TITLE
MINOR: [Docs] Fix reference to `int8` runs type in canonical extensions

### DIFF
--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -477,7 +477,7 @@ binary values look like.
 .. note::
 
    It is also *permissible* for the ``metadata`` field to be dictionary-encoded with a preferred (*but not required*) index type of ``int8``,
-   or run-end-encoded with a preferred (*but not required*) runs type of ``int8``.
+   or run-end-encoded with a preferred (*but not required*) runs type of ``int16``.
 
 .. note::
 


### PR DESCRIPTION
run types are 16, 32 & 64 bit only; looks to just be a typo from copying from dictionary above