### PR TITLE
GH-51011: [C++][CI] Poll for GCS testbench readiness instead of one 10s attempt

### DIFF
--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -77,7 +77,9 @@ class GcsTestbench : public ::testing::Environment {
     }
 
     server_process->SetArgs({"--port", port_});
-    server_process->IgnoreStderr();
+    // Do not discard stderr: the testbench, and Werkzeug underneath it, report
+    // startup progress and failures there, and without it a startup failure in
+    // CI cannot be diagnosed.
     status = server_process->Execute();
     if (!status.ok()) {
       error += ": " + status.ToString();
@@ -85,8 +87,16 @@ class GcsTestbench : public ::testing::Environment {
       return;
     }
 
+    // The testbench is a Python application importing grpcio, protobuf and
+    // flask, and it serves through Werkzeug's reloader, which pays that import
+    // cost twice: the parent process binds the listening socket immediately
+    // and only the reloader child answers requests.  Connecting therefore
+    // succeeds well before the first response arrives.  Keep the per-attempt
+    // retry budget well below the overall one, otherwise a single slow request
+    // consumes all of it and this loop only ever runs once.
     auto testbench_is_running = [&server_process, this]() {
-      auto ready_timeout = std::chrono::seconds(10);
+      auto ready_timeout = std::chrono::seconds(60);
+      auto attempt_timeout = std::chrono::seconds(5);
       std::chrono::time_point<std::chrono::steady_clock> end =
           std::chrono::steady_clock::now() + ready_timeout;
       while (server_process->IsRunning() && std::chrono::steady_clock::now() < end) {
@@ -95,7 +105,7 @@ class GcsTestbench : public ::testing::Environment {
                 .set<gcs::RestEndpointOption>("http://127.0.0.1:" + port_)
                 .set<gc::UnifiedCredentialsOption>(gc::MakeInsecureCredentials())
                 .set<gcs::RetryPolicyOption>(
-                    gcs::LimitedTimeRetryPolicy(ready_timeout).clone()));
+                    gcs::LimitedTimeRetryPolicy(attempt_timeout).clone()));
         auto metadata = client.GetBucketMetadata("nonexistent");
         if (metadata.status().code() == google::cloud::StatusCode::kNotFound) {
           return true;
@@ -105,7 +115,7 @@ class GcsTestbench : public ::testing::Environment {
     };
 
     if (!testbench_is_running()) {
-      error += " (failed to listen)";
+      error += " (timed out waiting for it to become ready)";
       error_ = std::move(error);
       return;
     }


### PR DESCRIPTION
### Rationale for this change

`arrow-gcsfs-test` fails on CI with `Could not start GCS emulator 'storage-testbench' (failed to listen)` when the testbench is only slow to start. The message is wrong: the testbench listens immediately.

`GcsTestbench` gives startup 10 seconds and hands that same duration to `LimitedTimeRetryPolicy`, so the loop makes one attempt rather than polling.

That budget is tight because of how the testbench serves. Its entry point calls `run_simple(..., use_reloader=True)`, and Werkzeug binds the listening socket in the parent, then spawns a reloader child that re-imports grpcio, protobuf and
flask before answering anything. Measured with werkzeug 3.0.4 and a 2.0s stand-in for those imports:

```
use_reloader=1:  TCP accept at 2.10s   first HTTP response at 4.17s
use_reloader=0:  TCP accept at 2.07s   first HTTP response at 2.07s
```

`IgnoreStderr()` then discards Werkzeug's output, so the CI log cannot distinguish a slow start from a crash.

See #51011.

### What changes are included in this PR?

In `cpp/src/arrow/filesystem/gcsfs_test.cc`:

* per-attempt retry budget of 5s, overall wait of 60s, so the loop polls
* drop `IgnoreStderr()`, keeping the testbench's startup output in the test log
* replace `(failed to listen)` with `(timed out waiting for it to become ready)`

`util::Process::IgnoreStderr` now has no callers. Left in place to keep the diff small; happy to remove it if preferred.

### Are these changes tested?

Covered by `arrow-gcsfs-test` itself, which is the thing that was failing.

I have not reproduced the CI failure on demand. It is a timing threshold, so this widens the margin and makes the next occurrence diagnosable rather than proving it gone.

### Are there any user-facing changes?

No. Test-only.

* GitHub Issue: #51011