### PR TITLE
GH-51019: [Python] Raise IndexError for out-of-bounds KeyValueMetadata key/value

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -1193,6 +1193,34 @@ def test_key_value_metadata():
         ], b='BETA')
 
 
+def test_key_value_metadata_index_errors():
+    meta = pa.KeyValueMetadata({'a': 'A', 'b': 'B'})
+
+    # in-bounds accesses still work
+    assert meta.key(0) == b'a'
+    assert meta.key(1) == b'b'
+    assert meta.value(0) == b'A'
+    assert meta.value(1) == b'B'
+
+    # out-of-range indexes raise IndexError instead of segfaulting
+    with pytest.raises(IndexError):
+        meta.key(2)
+    with pytest.raises(IndexError):
+        meta.key(-1)
+    with pytest.raises(IndexError):
+        meta.value(2)
+    with pytest.raises(IndexError):
+        meta.value(-1)
+
+    # empty metadata: index 0 is out of bounds too
+    empty = pa.KeyValueMetadata()
+    assert len(empty) == 0
+    with pytest.raises(IndexError):
+        empty.key(0)
+    with pytest.raises(IndexError):
+        empty.value(0)
+
+
 def test_key_value_metadata_duplicates():
     meta = pa.KeyValueMetadata({'a': '1', 'b': '2'})
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2386,7 +2386,16 @@ cdef class KeyValueMetadata(_Metadata, Mapping):
         Returns
         -------
         byte
+
+        Raises
+        ------
+        IndexError
+            If `i` is negative or out of bounds.
         """
+        if i < 0 or i >= self.metadata.size():
+            raise IndexError(
+                f"key index {i} is out of bounds for metadata of size "
+                f"{self.metadata.size()}")
         return self.metadata.key(i)
 
     def value(self, i):
@@ -2398,7 +2407,16 @@ cdef class KeyValueMetadata(_Metadata, Mapping):
         Returns
         -------
         byte
+
+        Raises
+        ------
+        IndexError
+            If `i` is negative or out of bounds.
         """
+        if i < 0 or i >= self.metadata.size():
+            raise IndexError(
+                f"value index {i} is out of bounds for metadata of size "
+                f"{self.metadata.size()}")
         return self.metadata.value(i)
 
     def keys(self):


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

* Closes: #51019

### Rationale for this change

`KeyValueMetadata.key(i)` / `.value(i)` pass the index through to the C++
`KeyValueMetadata::key/value` accessors, whose `DCHECK` bounds checks are
compiled out in release builds. Any out-of-range or negative index — most
easily hit with `pa.KeyValueMetadata().key(0)` on an empty object — performs
an unchecked `std::vector::operator[]` access and **segfaults the Python
process** instead of raising an exception. Reproduced locally on pyarrow
25.0.1.

### What changes are included in this PR?

Bounds checks in the Python bindings (`types.pxi`) raise `IndexError` for
negative or out-of-range indexes, matching the behavior of other indexed
pyarrow containers.

### Are these changes tested?

Yes — added `test_key_value_metadata_index_errors` covering in-bounds
access, out-of-range/negative indexes, and empty-metadata access. The
segfault reproduces on pyarrow 25.0.1 (SIGSEGV); with the fix the same
calls raise `IndexError`.

* Closes: #51019
* GitHub Issue: #51019