### PR TITLE
GH-51018: [C++] Fix indices_nonzero segfault on chunkless ChunkedArray

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -264,8 +264,10 @@ Status DoNonZero(const std::vector<ArraySpan>& arrays, int64_t total_length,
   UInt64Builder builder;
   RETURN_NOT_OK(builder.Reserve(total_length));
 
-  NonZeroVisitor visitor(&builder, arrays);
-  RETURN_NOT_OK(VisitTypeInline(*arrays[0].type, &visitor));
+  if (!arrays.empty()) {
+    NonZeroVisitor visitor(&builder, arrays);
+    RETURN_NOT_OK(VisitTypeInline(*arrays[0].type, &visitor));
+  }
   return builder.FinishInternal(out);
 }
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2920,6 +2920,14 @@ TEST(TestIndicesNonZero, IndicesNonZero) {
         actual, CallFunction("indices_nonzero", {static_cast<Datum>(chunked_arr_empty)}));
     AssertArraysEqual(*ArrayFromJSON(uint64(), "[0, 2, 3, 5]"), *actual.make_array(),
                       /*verbose*/ true);
+
+    // chunked with zero chunks (GH-51018)
+    ChunkedArray chunked_arr_no_chunks({}, type);
+    ASSERT_OK_AND_ASSIGN(
+        actual,
+        CallFunction("indices_nonzero", {static_cast<Datum>(chunked_arr_no_chunks)}));
+    AssertArraysEqual(*ArrayFromJSON(uint64(), "[]"), *actual.make_array(),
+                      /*verbose*/ true);
   }
 }
 


### PR DESCRIPTION
### Rationale for this change

`pyarrow.compute.indices_nonzero()` segfaults (SIGSEGV) on a `ChunkedArray` with zero chunks. A zero-length `Array` and a `ChunkedArray` holding one empty chunk both work; only the chunkless case crashes.

### Are these changes tested?

Yes, by new test case.

### Are there any user-facing changes?

Only a bugfix.

* GitHub Issue: #51018