### PR TITLE
GH-51025: [CI] Use GNU mirror to download Bison

### DIFF
--- a/ci/scripts/install_bison.sh
+++ b/ci/scripts/install_bison.sh
@@ -28,7 +28,7 @@ version=$1
 prefix=$2
 
 mkdir -p /tmp/bison
-url="https://ftp.gnu.org/gnu/bison/bison-${version}.tar.gz"
+url="https://ftpmirror.gnu.org/bison/bison-${version}.tar.gz"
 
 wget -q "${url}" -O - | tar -xzf - --directory /tmp/bison --strip-components=1
 


### PR DESCRIPTION
### Rationale for this change

Bison downloads from ftp.gnu.org fail on JNI linux jobs due to unreliable connectivity. Let's use GNU mirror redirector instead.

### What changes are included in this PR?

Switch from `ftp.gnu.org` to `ftpmirror.gnu.org ` to avoid download timeouts in Linux JNI jobs.

### Are these changes tested?

By CI.

### Are there any user-facing changes?

No, this is a CI only change.
* GitHub Issue: #51025