### PR TITLE
GH-51039: [CI][GLib][Ruby] Re-enable Arrow Flight tests for GLib and Ruby on macOS

### DIFF
--- a/c_glib/test/flight-sql/test-client.rb
+++ b/c_glib/test/flight-sql/test-client.rb
@@ -23,7 +23,6 @@ class TestFlightSQLClient < Test::Unit::TestCase
     @server = nil
     omit("Arrow Flight SQL is required") unless defined?(ArrowFlightSQL)
     omit("Unstable on Windows") if Gem.win_platform?
-    omit("Unstable on macOS") if /darwin/.match?(RUBY_PLATFORM)
     @server = Helper::FlightSQLServer.new
     host = "127.0.0.1"
     location = ArrowFlight::Location.new("grpc://#{host}:0")

--- a/ruby/red-arrow-flight/test/test-client.rb
+++ b/ruby/red-arrow-flight/test/test-client.rb
@@ -19,7 +19,6 @@ class TestClient < Test::Unit::TestCase
   def setup
     @server = nil
     omit("Unstable on Windows") if Gem.win_platform?
-    omit("Unstable on x86_64 macOS") if /x86_64-darwin/.match?(RUBY_PLATFORM)
     @server = Helper::Server.new
     @server.listen("grpc://127.0.0.1:0")
     @location = "grpc://127.0.0.1:#{@server.port}"

--- a/ruby/red-arrow-flight/test/test-record-batch-reader.rb
+++ b/ruby/red-arrow-flight/test/test-record-batch-reader.rb
@@ -19,6 +19,7 @@ class TestRecordBatchReader < Test::Unit::TestCase
   def setup
     @server = nil
     omit("Unstable on Windows") if Gem.win_platform?
+
     @server = Helper::Server.new
     @server.listen("grpc://127.0.0.1:0")
     @location = "grpc://127.0.0.1:#{@server.port}"

--- a/ruby/red-arrow-flight/test/test-record-batch-reader.rb
+++ b/ruby/red-arrow-flight/test/test-record-batch-reader.rb
@@ -19,7 +19,6 @@ class TestRecordBatchReader < Test::Unit::TestCase
   def setup
     @server = nil
     omit("Unstable on Windows") if Gem.win_platform?
-    omit("Unstable on macOS") if /darwin/.match?(RUBY_PLATFORM)
     @server = Helper::Server.new
     @server.listen("grpc://127.0.0.1:0")
     @location = "grpc://127.0.0.1:#{@server.port}"

--- a/ruby/red-arrow-flight/test/test-record-batch-reader.rb
+++ b/ruby/red-arrow-flight/test/test-record-batch-reader.rb
@@ -19,7 +19,6 @@ class TestRecordBatchReader < Test::Unit::TestCase
   def setup
     @server = nil
     omit("Unstable on Windows") if Gem.win_platform?
-
     @server = Helper::Server.new
     @server.listen("grpc://127.0.0.1:0")
     @location = "grpc://127.0.0.1:#{@server.port}"


### PR DESCRIPTION
### Rationale for this change

It looks like [this change](https://github.com/ruby-gnome/ruby-gnome/pull/1743) has fixed issue #50919.
#50868 disabled Arrow Flight test for GLib on macOS.

### What changes are included in this PR?

Re-enable Arrow Flight tests for GLib and Ruby on macOS.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #51039