### PR TITLE
GH-51046: [Python][Interchange] Preserve the categorical ordered flag in from_dataframe

### DIFF
--- a/python/pyarrow/interchange/from_dataframe.py
+++ b/python/pyarrow/interchange/from_dataframe.py
@@ -276,7 +276,8 @@ def categorical_column_to_dictionary(
                                col.offset)
 
     # Constructing a pa.DictionaryArray
-    dict_array = pa.DictionaryArray.from_arrays(indices, dictionary)
+    dict_array = pa.DictionaryArray.from_arrays(indices, dictionary,
+                                                ordered=categorical["is_ordered"])
 
     return dict_array
 

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -258,7 +258,7 @@ def test_pandas_roundtrip_categorical():
     assert col_result.size() == col_table.size()
     assert col_result.offset == col_table.offset
 
-    desc_cat_table = col_result.describe_categorical
+    desc_cat_table = col_table.describe_categorical
     desc_cat_result = col_result.describe_categorical
 
     assert desc_cat_table["is_ordered"] == desc_cat_result["is_ordered"]
@@ -380,10 +380,12 @@ def test_pyarrow_roundtrip(uint, int, float, np_float_str,
 
 
 @pytest.mark.parametrize("offset, length", [(0, 10), (0, 2), (7, 3), (2, 1)])
-def test_pyarrow_roundtrip_categorical(offset, length):
+@pytest.mark.parametrize("ordered", [False, True])
+def test_pyarrow_roundtrip_categorical(offset, length, ordered):
     arr = ["Mon", "Tue", "Mon", "Wed", "Mon", "Thu", "Fri", None, "Sun"]
+    dict_type = pa.dictionary(pa.int32(), pa.string(), ordered=ordered)
     table = pa.table(
-        {"weekday": pa.array(arr).dictionary_encode()}
+        {"weekday": pa.array(arr).dictionary_encode().cast(dict_type)}
     )
     table = table.slice(offset, length)
     result = _from_dataframe(table.__dataframe__())


### PR DESCRIPTION
### Rationale for this change

`from_dataframe` builds the dictionary array without the `is_ordered` flag the producer reports, so an ordered categorical column comes back unordered. A pyarrow table with `dictionary(int32, string, ordered=True)` does not survive its own round trip, and an ordered pandas `Categorical` loses its ordering on the way in. The pandas consumer passes the flag through (`pd.Categorical(values, categories=categories, ordered=categorical["is_ordered"])`), and our own producer reports it, so pyarrow is the only side dropping it.

### What changes are included in this PR?

`categorical_column_to_dictionary` passes `ordered=categorical["is_ordered"]` to `DictionaryArray.from_arrays`. Indices, dictionary and null handling are untouched.

### Are these changes tested?

Yes. `test_pyarrow_roundtrip_categorical` is now parametrized over ordered True and False, and the ordered cases fail without the change: `assert table.equals(result)` sees `ordered=1` going in and `ordered=0` coming out. I also fixed a copy-paste in `test_pandas_roundtrip_categorical`, which read `describe_categorical` from the result column twice, so its `is_ordered` assertion compared the result with itself and could never fail.

### Are there any user-facing changes?

An ordered dictionary column stays ordered through `from_dataframe`. No API change.

I used an AI assistant while finding and writing this. I checked the behavior and the tests myself before opening the PR.
* GitHub Issue: #51046