### PR TITLE
GH-51090: [CI][C++] Fix shellcheck errors in cpp/build-support/fuzzing/generate_corpuses.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -288,13 +288,7 @@ repos:
           (
           ?^c_glib/.*\.sh$|
           ?^ci/.*\.sh$|
-          ?^cpp/build-support/build-lz4-lib\.sh$|
-          ?^cpp/build-support/build-zstd-lib\.sh$|
-          ?^cpp/build-support/get-upstream-commit\.sh$|
-          ?^cpp/build-support/run-test\.sh$|
-          ?^cpp/build-support/update-flatbuffers\.sh$|
-          ?^cpp/build-support/update-thrift\.sh$|
-          ?^cpp/build-support/vendor-flatbuffers\.sh$|
+          ?^cpp/build-support/.*\.sh$|
           ?^cpp/examples/minimal_build/run\.sh$|
           ?^cpp/examples/tutorial_examples/run\.sh$|
           ?^cpp/src/arrow/flight/sql/odbc/install/mac/postinstall$|

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -42,18 +42,24 @@ OUT=$1
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -stream "${CORPUS_DIR}"
 # Add "golden" IPC integration files
-IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" -name "*.stream")
-[ -z "${IPC_INTEGRATION_FILES}" ] && exit 1
+mapfile -d '' IPC_INTEGRATION_FILES < <(
+  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+    -name "*.stream" -print0
+)
+[ -z "${IPC_INTEGRATION_FILES[@]}" ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
-cp --backup=numbered "${IPC_INTEGRATION_FILES}" "${CORPUS_DIR}"
+cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-stream-fuzz_seed_corpus.zip
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
-IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}"/testing/data/arrow-ipc-stream/integration -name "*.arrow_file")
-[ -z "${IPC_INTEGRATION_FILES}" ] && exit 1
-cp --backup=numbered "${IPC_INTEGRATION_FILES}" "${CORPUS_DIR}"
+mapfile -d '' IPC_INTEGRATION_FILES < <(
+  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+    -name "*.arrow_file" -print0
+)
+[ -z "${IPC_INTEGRATION_FILES[@]}" ] && exit 1
+cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-file-fuzz_seed_corpus.zip
 
 rm -rf "${CORPUS_DIR}"

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -42,10 +42,12 @@ OUT=$1
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -stream "${CORPUS_DIR}"
 # Add "golden" IPC integration files
+# Store the files found by the find command in an array.
 mapfile -d '' IPC_INTEGRATION_FILES < <(
   find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.stream" -print0
 )
+# Exit with an error if find returns no files.
 [ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
@@ -54,10 +56,12 @@ cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
+# Store the files found by the find command in an array.
 mapfile -d '' IPC_INTEGRATION_FILES < <(
   find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.arrow_file" -print0
 )
+# Exit with an error if find returns no files.
 [ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-file-fuzz_seed_corpus.zip

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -63,7 +63,7 @@ cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-file-fuzz_seed_corpus.zip
 
 rm -rf "${CORPUS_DIR}"
-"${OUT}/arrow-ipc-generate-tensor-fuzz-corpus -stream" "${CORPUS_DIR}"
+"${OUT}/arrow-ipc-generate-tensor-fuzz-corpus" -stream "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-tensor-stream-fuzz_seed_corpus.zip"
 
 # Parquet file-level fuzzer

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -52,7 +52,7 @@ mapfile -d '' IPC_INTEGRATION_FILES < <(
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
 cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
-"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-stream-fuzz_seed_corpus.zip
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-stream-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
@@ -64,7 +64,7 @@ mapfile -d '' IPC_INTEGRATION_FILES < <(
 # Exit with an error if find returns no files.
 [ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
-"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-file-fuzz_seed_corpus.zip
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-tensor-fuzz-corpus" -stream "${CORPUS_DIR}"

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -46,7 +46,7 @@ mapfile -d '' IPC_INTEGRATION_FILES < <(
   find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.stream" -print0
 )
-[ -z "${IPC_INTEGRATION_FILES[@]}" ] && exit 1
+[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
 cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
@@ -58,7 +58,7 @@ mapfile -d '' IPC_INTEGRATION_FILES < <(
   find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.arrow_file" -print0
 )
-[ -z "${IPC_INTEGRATION_FILES[@]}" ] && exit 1
+[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-file-fuzz_seed_corpus.zip
 

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -39,17 +39,17 @@ OUT=$1
 
 # Arrow IPC
 
-rm -rf ${CORPUS_DIR}
-${OUT}/arrow-ipc-generate-fuzz-corpus -stream ${CORPUS_DIR}
+rm -rf "${CORPUS_DIR}"
+"${OUT}/arrow-ipc-generate-fuzz-corpus" -stream "${CORPUS_DIR}"
 # Add "golden" IPC integration files
 IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" -name "*.stream")
 [ -z "${IPC_INTEGRATION_FILES}" ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
-cp --backup=numbered "${IPC_INTEGRATION_FILES}" ${CORPUS_DIR}
-"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" ${CORPUS_DIR} "${OUT}"/arrow-ipc-stream-fuzz_seed_corpus.zip
+cp --backup=numbered "${IPC_INTEGRATION_FILES}" "${CORPUS_DIR}"
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-stream-fuzz_seed_corpus.zip
 
-rm -rf ${CORPUS_DIR}
+rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
 IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}"/testing/data/arrow-ipc-stream/integration -name "*.arrow_file")
 [ -z "${IPC_INTEGRATION_FILES}" ] && exit 1
@@ -62,11 +62,11 @@ rm -rf "${CORPUS_DIR}"
 
 # Parquet file-level fuzzer
 
-rm -rf ${CORPUS_DIR}
+rm -rf "${CORPUS_DIR}"
 "${OUT}/parquet-arrow-generate-fuzz-corpus" "${CORPUS_DIR}"
 # Add Parquet testing examples
-cp "${ARROW_CPP}/submodules/parquet-testing/data/*.parquet" "${CORPUS_DIR}"
-cp "${ARROW_CPP}/submodules/parquet-testing/bad_data/*.parquet" "${CORPUS_DIR}"
+cp "${ARROW_CPP}"/submodules/parquet-testing/data/*.parquet "${CORPUS_DIR}"
+cp "${ARROW_CPP}"/submodules/parquet-testing/bad_data/*.parquet "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/parquet-arrow-fuzz_seed_corpus.zip"
 
 # Parquet encoding fuzzer

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -29,7 +29,7 @@ set -ex
 CORPUS_DIR=/tmp/corpus
 PANDAS_DIR=/tmp/pandas
 
-ARROW_ROOT=$(cd $(dirname "$BASH_SOURCE")/../../..; pwd)
+ARROW_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 ARROW_CPP=$ARROW_ROOT/cpp
 OUT=$1
 
@@ -42,48 +42,48 @@ OUT=$1
 rm -rf ${CORPUS_DIR}
 ${OUT}/arrow-ipc-generate-fuzz-corpus -stream ${CORPUS_DIR}
 # Add "golden" IPC integration files
-IPC_INTEGRATION_FILES=$(find ${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration -name "*.stream")
+IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" -name "*.stream")
 [ -z "${IPC_INTEGRATION_FILES}" ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
-cp --backup=numbered ${IPC_INTEGRATION_FILES} ${CORPUS_DIR}
-${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-stream-fuzz_seed_corpus.zip
+cp --backup=numbered "${IPC_INTEGRATION_FILES}" ${CORPUS_DIR}
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" ${CORPUS_DIR} "${OUT}"/arrow-ipc-stream-fuzz_seed_corpus.zip
 
 rm -rf ${CORPUS_DIR}
-${OUT}/arrow-ipc-generate-fuzz-corpus -file ${CORPUS_DIR}
-IPC_INTEGRATION_FILES=$(find ${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration -name "*.arrow_file")
+"${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
+IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}"/testing/data/arrow-ipc-stream/integration -name "*.arrow_file")
 [ -z "${IPC_INTEGRATION_FILES}" ] && exit 1
-cp --backup=numbered ${IPC_INTEGRATION_FILES} ${CORPUS_DIR}
-${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip
+cp --backup=numbered "${IPC_INTEGRATION_FILES}" "${CORPUS_DIR}"
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}"/arrow-ipc-file-fuzz_seed_corpus.zip
 
-rm -rf ${CORPUS_DIR}
-${OUT}/arrow-ipc-generate-tensor-fuzz-corpus -stream ${CORPUS_DIR}
-${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-tensor-stream-fuzz_seed_corpus.zip
+rm -rf "${CORPUS_DIR}"
+"${OUT}/arrow-ipc-generate-tensor-fuzz-corpus -stream" "${CORPUS_DIR}"
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-tensor-stream-fuzz_seed_corpus.zip"
 
 # Parquet file-level fuzzer
 
 rm -rf ${CORPUS_DIR}
-${OUT}/parquet-arrow-generate-fuzz-corpus ${CORPUS_DIR}
+"${OUT}/parquet-arrow-generate-fuzz-corpus" "${CORPUS_DIR}"
 # Add Parquet testing examples
-cp ${ARROW_CPP}/submodules/parquet-testing/data/*.parquet ${CORPUS_DIR}
-cp ${ARROW_CPP}/submodules/parquet-testing/bad_data/*.parquet ${CORPUS_DIR}
-${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/parquet-arrow-fuzz_seed_corpus.zip
+cp "${ARROW_CPP}/submodules/parquet-testing/data/*.parquet" "${CORPUS_DIR}"
+cp "${ARROW_CPP}/submodules/parquet-testing/bad_data/*.parquet" "${CORPUS_DIR}"
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/parquet-arrow-fuzz_seed_corpus.zip"
 
 # Parquet encoding fuzzer
 
 rm -rf ${CORPUS_DIR}
-${OUT}/parquet-generate-encoding-fuzz-corpus ${CORPUS_DIR}
-${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/parquet-encoding-fuzz_seed_corpus.zip
+"${OUT}/parquet-generate-encoding-fuzz-corpus" "${CORPUS_DIR}"
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/parquet-encoding-fuzz_seed_corpus.zip"
 
 # CSV
 
-rm -rf ${PANDAS_DIR}
-git clone --depth=1 https://github.com/pandas-dev/pandas ${PANDAS_DIR}
+rm -rf "${PANDAS_DIR}"
+git clone --depth=1 https://github.com/pandas-dev/pandas "${PANDAS_DIR}"
 
-rm -rf ${CORPUS_DIR}
-${OUT}/arrow-csv-generate-fuzz-corpus ${CORPUS_DIR}
+rm -rf "${CORPUS_DIR}"
+"${OUT}/arrow-csv-generate-fuzz-corpus" "${CORPUS_DIR}"
 # Add examples from arrow-testing repo
-cp ${ARROW_ROOT}/testing/data/csv/*.csv ${CORPUS_DIR}
+cp "${ARROW_ROOT}"/testing/data/csv/*.csv "${CORPUS_DIR}"
 # Add examples from Pandas test suite
-find ${PANDAS_DIR}/ -name "*.csv" -exec cp --backup=numbered '{}' ${CORPUS_DIR} \;
-${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-csv-fuzz_seed_corpus.zip
+find "${PANDAS_DIR}/" -name "*.csv" -exec cp --backup=numbered '{}' "${CORPUS_DIR}" \;
+"${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-csv-fuzz_seed_corpus.zip"

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -42,9 +42,12 @@ OUT=$1
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -stream "${CORPUS_DIR}"
 # Add "golden" IPC integration files
-# Store the files found by the find command in an array.
-mapfile -d '' IPC_INTEGRATION_FILES < <(
-  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+# Use read instead of mapfile to keep this compatible with Bash 3.2 on macOS.
+IPC_INTEGRATION_FILES=()
+while IFS= read -r -d '' IPC_INTEGRATION_FILE; do
+  IPC_INTEGRATION_FILES+=("${IPC_INTEGRATION_FILE}")
+done < <(
+  find "${IPC_INTEGRATION_DIR}" \
     -name "*.stream" -print0
 )
 # Exit with an error if find returns no files.
@@ -56,9 +59,12 @@ cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
-# Store the files found by the find command in an array.
-mapfile -d '' IPC_INTEGRATION_FILES < <(
-  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+
+IPC_INTEGRATION_FILES=()
+while IFS= read -r -d '' IPC_INTEGRATION_FILE; do
+  IPC_INTEGRATION_FILES+=("${IPC_INTEGRATION_FILE}")
+done < <(
+  find "${IPC_INTEGRATION_DIR}" \
     -name "*.arrow_file" -print0
 )
 # Exit with an error if find returns no files.

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -41,29 +41,27 @@ OUT=$1
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -stream "${CORPUS_DIR}"
+
+IPC_INTEGRATION_DIR="${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration"
+
 # Add "golden" IPC integration files
-# Store the files found by the find command in an array.
-mapfile -d '' IPC_INTEGRATION_FILES < <(
-  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
-    -name "*.stream" -print0
-)
-# Exit with an error if find returns no files.
-[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
-cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
+# Use shell globbing to keep this ShellCheck-safe and compatible with Bash 3.2 on macOS.
+# IPC integration files are expected to be directly under each subdirectory.
+cp --backup=numbered \
+  "${IPC_INTEGRATION_DIR}"/*/*.stream \
+  "${CORPUS_DIR}"
+
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-stream-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
-# Store the files found by the find command in an array.
-mapfile -d '' IPC_INTEGRATION_FILES < <(
-  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
-    -name "*.arrow_file" -print0
-)
-# Exit with an error if find returns no files.
-[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
-cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
+
+cp --backup=numbered \
+  "${IPC_INTEGRATION_DIR}"/*/*.arrow_file \
+  "${CORPUS_DIR}"
+
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -50,8 +50,6 @@ done < <(
   find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.stream" -print0
 )
-# Exit with an error if find returns no files.
-[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
 cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
@@ -67,8 +65,6 @@ done < <(
   find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.arrow_file" -print0
 )
-# Exit with an error if find returns no files.
-[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip"
 

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -41,27 +41,29 @@ OUT=$1
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -stream "${CORPUS_DIR}"
-
-IPC_INTEGRATION_DIR="${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration"
-
 # Add "golden" IPC integration files
+# Store the files found by the find command in an array.
+mapfile -d '' IPC_INTEGRATION_FILES < <(
+  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+    -name "*.stream" -print0
+)
+# Exit with an error if find returns no files.
+[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
-# Use shell globbing to keep this ShellCheck-safe and compatible with Bash 3.2 on macOS.
-# IPC integration files are expected to be directly under each subdirectory.
-cp --backup=numbered \
-  "${IPC_INTEGRATION_DIR}"/*/*.stream \
-  "${CORPUS_DIR}"
-
+cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-stream-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
-
-cp --backup=numbered \
-  "${IPC_INTEGRATION_DIR}"/*/*.arrow_file \
-  "${CORPUS_DIR}"
-
+# Store the files found by the find command in an array.
+mapfile -d '' IPC_INTEGRATION_FILES < <(
+  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+    -name "*.arrow_file" -print0
+)
+# Exit with an error if find returns no files.
+[ "${#IPC_INTEGRATION_FILES[@]}" -eq 0 ] && exit 1
+cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -42,30 +42,21 @@ OUT=$1
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -stream "${CORPUS_DIR}"
 # Add "golden" IPC integration files
-# Use read instead of mapfile to keep this compatible with Bash 3.2 on macOS.
-IPC_INTEGRATION_FILES=()
-while IFS= read -r -d '' IPC_INTEGRATION_FILE; do
-  IPC_INTEGRATION_FILES+=("${IPC_INTEGRATION_FILE}")
-done < <(
-  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
-    -name "*.stream" -print0
-)
 # Several IPC integration files can have the same name, make sure
 # they all appear in the corpus by numbering the duplicates.
-cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
+find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+  -name "*.stream" \
+  -exec cp --backup=numbered '{}' "${CORPUS_DIR}" \;
+
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-stream-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"
 "${OUT}/arrow-ipc-generate-fuzz-corpus" -file "${CORPUS_DIR}"
 
-IPC_INTEGRATION_FILES=()
-while IFS= read -r -d '' IPC_INTEGRATION_FILE; do
-  IPC_INTEGRATION_FILES+=("${IPC_INTEGRATION_FILE}")
-done < <(
-  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
-    -name "*.arrow_file" -print0
-)
-cp --backup=numbered "${IPC_INTEGRATION_FILES[@]}" "${CORPUS_DIR}"
+find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
+  -name "*.arrow_file" \
+  -exec cp --backup=numbered '{}' "${CORPUS_DIR}" \;
+
 "${ARROW_CPP}/build-support/fuzzing/pack_corpus.py" "${CORPUS_DIR}" "${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip"
 
 rm -rf "${CORPUS_DIR}"

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -47,7 +47,7 @@ IPC_INTEGRATION_FILES=()
 while IFS= read -r -d '' IPC_INTEGRATION_FILE; do
   IPC_INTEGRATION_FILES+=("${IPC_INTEGRATION_FILE}")
 done < <(
-  find "${IPC_INTEGRATION_DIR}" \
+  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.stream" -print0
 )
 # Exit with an error if find returns no files.
@@ -64,7 +64,7 @@ IPC_INTEGRATION_FILES=()
 while IFS= read -r -d '' IPC_INTEGRATION_FILE; do
   IPC_INTEGRATION_FILES+=("${IPC_INTEGRATION_FILE}")
 done < <(
-  find "${IPC_INTEGRATION_DIR}" \
+  find "${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration" \
     -name "*.arrow_file" -print0
 )
 # Exit with an error if find returns no files.


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2046: Quote this to prevent word splitting.
* SC2128: Expanding an array without an index only gives the element in the index 0.
* SC2086: Double quote to prevent globbing and word splitting.

```

In generate_corpuses.sh line 32:
ARROW_ROOT=$(cd $(dirname "$BASH_SOURCE")/../../..; pwd)
                ^-----------------------^ SC2046 (warning): Quote this to prevent word splitting.
                           ^----------^ SC2128 (warning): Expanding an array without an index only gives the first element.


In generate_corpuses.sh line 43:
${OUT}/arrow-ipc-generate-fuzz-corpus -stream ${CORPUS_DIR}
^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${OUT}"/arrow-ipc-generate-fuzz-corpus -stream ${CORPUS_DIR}


In generate_corpuses.sh line 45:
IPC_INTEGRATION_FILES=$(find ${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration -name "*.stream")
                             ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}"/testing/data/arrow-ipc-stream/integration -name "*.stream")


In generate_corpuses.sh line 49:
cp --backup=numbered ${IPC_INTEGRATION_FILES} ${CORPUS_DIR}
                     ^----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp --backup=numbered "${IPC_INTEGRATION_FILES}" ${CORPUS_DIR}


In generate_corpuses.sh line 50:
${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-stream-fuzz_seed_corpus.zip
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${ARROW_CPP}"/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} "${OUT}"/arrow-ipc-stream-fuzz_seed_corpus.zip


In generate_corpuses.sh line 53:
${OUT}/arrow-ipc-generate-fuzz-corpus -file ${CORPUS_DIR}
^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${OUT}"/arrow-ipc-generate-fuzz-corpus -file ${CORPUS_DIR}


In generate_corpuses.sh line 54:
IPC_INTEGRATION_FILES=$(find ${ARROW_ROOT}/testing/data/arrow-ipc-stream/integration -name "*.arrow_file")
                             ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
IPC_INTEGRATION_FILES=$(find "${ARROW_ROOT}"/testing/data/arrow-ipc-stream/integration -name "*.arrow_file")


In generate_corpuses.sh line 56:
cp --backup=numbered ${IPC_INTEGRATION_FILES} ${CORPUS_DIR}
                     ^----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp --backup=numbered "${IPC_INTEGRATION_FILES}" ${CORPUS_DIR}


In generate_corpuses.sh line 57:
${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${ARROW_CPP}"/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} "${OUT}"/arrow-ipc-file-fuzz_seed_corpus.zip


In generate_corpuses.sh line 60:
${OUT}/arrow-ipc-generate-tensor-fuzz-corpus -stream ${CORPUS_DIR}
^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${OUT}"/arrow-ipc-generate-tensor-fuzz-corpus -stream ${CORPUS_DIR}


In generate_corpuses.sh line 61:
${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-tensor-stream-fuzz_seed_corpus.zip
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${ARROW_CPP}"/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} "${OUT}"/arrow-ipc-tensor-stream-fuzz_seed_corpus.zip


In generate_corpuses.sh line 66:
${OUT}/parquet-arrow-generate-fuzz-corpus ${CORPUS_DIR}
^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${OUT}"/parquet-arrow-generate-fuzz-corpus ${CORPUS_DIR}


In generate_corpuses.sh line 68:
cp ${ARROW_CPP}/submodules/parquet-testing/data/*.parquet ${CORPUS_DIR}
   ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "${ARROW_CPP}"/submodules/parquet-testing/data/*.parquet ${CORPUS_DIR}


In generate_corpuses.sh line 69:
cp ${ARROW_CPP}/submodules/parquet-testing/bad_data/*.parquet ${CORPUS_DIR}
   ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "${ARROW_CPP}"/submodules/parquet-testing/bad_data/*.parquet ${CORPUS_DIR}


In generate_corpuses.sh line 70:
${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/parquet-arrow-fuzz_seed_corpus.zip
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${ARROW_CPP}"/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} "${OUT}"/parquet-arrow-fuzz_seed_corpus.zip


In generate_corpuses.sh line 75:
${OUT}/parquet-generate-encoding-fuzz-corpus ${CORPUS_DIR}
^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${OUT}"/parquet-generate-encoding-fuzz-corpus ${CORPUS_DIR}


In generate_corpuses.sh line 76:
${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/parquet-encoding-fuzz_seed_corpus.zip
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${ARROW_CPP}"/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} "${OUT}"/parquet-encoding-fuzz_seed_corpus.zip


In generate_corpuses.sh line 84:
${OUT}/arrow-csv-generate-fuzz-corpus ${CORPUS_DIR}
^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${OUT}"/arrow-csv-generate-fuzz-corpus ${CORPUS_DIR}


In generate_corpuses.sh line 86:
cp ${ARROW_ROOT}/testing/data/csv/*.csv ${CORPUS_DIR}
   ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "${ARROW_ROOT}"/testing/data/csv/*.csv ${CORPUS_DIR}


In generate_corpuses.sh line 89:
${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-csv-fuzz_seed_corpus.zip
^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"${ARROW_CPP}"/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} "${OUT}"/arrow-csv-fuzz_seed_corpus.zip

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2128 -- Expanding an array without an ind...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC2046: Quote command substitutions to prevent word splitting.
* SC2128: Specify an array index explicitly.
* SC2086: Quote variables to prevent globbing and word splitting.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #51090