### PR TITLE
GH-50999: [CI][Python] Fix NuGet based vcpkg cache failures on musllinux

### DIFF
--- a/ci/docker/python-wheel-musllinux.dockerfile
+++ b/ci/docker/python-wheel-musllinux.dockerfile
@@ -33,14 +33,13 @@ RUN apk add --no-cache \
     curl \
     flex \
     git \
+    mono \
     ninja \
     sccache \
     unzip \
     wget \
-    zip
-# Add mono from community repo because it's not in the main repo.
-# We will be able to use the main repo once we move to alpine 3.22 or later.
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community mono
+    zip && \
+    cert-sync /etc/ssl/certs/ca-certificates.crt
 
 # The linker shipped in Alpine (ld 2.44) causes issue with the generated wheel
 # on x86_64 which makes "import pyarrow" abort at startup with:


### PR DESCRIPTION
### Rationale for this change

We need to synchronize certificates used by Mono manually on Alpine Linux.

### What changes are included in this PR?

Run `cert-sync` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #50999