### PR TITLE
MINOR: [Integration][CI] Remove Python pinning in integration build

### DIFF
--- a/ci/conda_env_archery.txt
+++ b/ci/conda_env_archery.txt
@@ -20,12 +20,9 @@ click
 
 # bot, crossbow
 jinja2
-jira
 pygit2
 pygithub
 ruamel.yaml
-setuptools_scm
-toolz
 
 # benchmark
 pandas

--- a/ci/conda_env_gandiva.txt
+++ b/ci/conda_env_gandiva.txt
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-clang>=11
-llvmdev>=11
+clang
+llvmdev<23

--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -23,8 +23,6 @@ FROM --platform=linux/${arch} ${repo}:${arch_short}-conda
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts
 RUN /arrow/ci/scripts/install_minio.sh latest /opt/conda
 
-ARG python=3.11
-
 # install the required conda packages into the test environment
 # use `mold` to work around issues with GNU `ld` (GH-47015).
 COPY ci/conda_env_cpp.txt \
@@ -37,7 +35,6 @@ RUN mamba install -q -y \
         doxygen \
         libnuma \
         mold \
-        python=${python} \
         valgrind && \
     mamba clean --all --yes
 

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -30,11 +30,8 @@ ARG jdk=17
 # Install Archery and integration dependencies
 COPY ci/conda_env_archery.txt /arrow/ci/
 
-# Pin Python until pythonnet is made compatible with 3.12
-# (https://github.com/pythonnet/pythonnet/pull/2249)
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_archery.txt \
-        "python < 3.12" \
         numpy \
         compilers \
         go \

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -21,7 +21,7 @@ ARG arch_short
 FROM --platform=linux/${arch} ${repo}:${arch_short}-conda-cpp
 
 # install python specific packages
-ARG python=3.11
+ARG python=3.14
 COPY ci/conda_env_python.txt \
      /arrow/ci/
 # If the Python version being tested is the same as the Python used by the system gdb,

--- a/compose.yaml
+++ b/compose.yaml
@@ -1869,7 +1869,10 @@ services:
     volumes: *conda-volumes
     environment:
       <<: [*common, *ccache, *sccache]
+      ARCHERY_INTEGRATION_WITH_DOTNET: 0
       ARCHERY_INTEGRATION_WITH_GO: 0
+      ARCHERY_INTEGRATION_WITH_JAVA: 0
+      ARCHERY_INTEGRATION_WITH_JS: 0
       ARCHERY_INTEGRATION_WITH_NANOARROW: 0
       ARCHERY_INTEGRATION_WITH_RUST: 0
       # Tell Archery where Arrow binaries are located


### PR DESCRIPTION
### Rationale for this change

Pythonnet now seems to be compatible with Python versions up to 3.15:
https://github.com/pythonnet/pythonnet/blob/d2d27164cdcb62ea022a51ffc3ed78f338f01803/.github/workflows/main.yml#L49

### Are these changes tested?

Yes, by corresponding CI job.

### Are there any user-facing changes?

No.