### PR TITLE
GH-51101: [C++][Emscripten] Increase test stack size

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -740,14 +740,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
       "-sSIDE_MODULE=1 ${ARROW_EMSCRIPTEN_LINKER_FLAGS}")
   set(CMAKE_SHARED_LINKER_FLAGS "-sSIDE_MODULE=1 ${ARROW_EMSCRIPTEN_LINKER_FLAGS}")
   if(ARROW_TESTING)
+    # Deeply nested tests need a larger stack (1 MiB).
+    set(ARROW_EMSCRIPTEN_TEST_STACK_SIZE 1048576)
     # flags for building test executables for use in node
     if("${UPPERCASE_BUILD_TYPE}" STREQUAL "RELEASE")
       set(CMAKE_EXE_LINKER_FLAGS
-          "${ARROW_EMSCRIPTEN_LINKER_FLAGS} -sALLOW_MEMORY_GROWTH -lnodefs.js -lnoderawfs.js --pre-js ${BUILD_SUPPORT_DIR}/emscripten-test-init.js"
+          "${ARROW_EMSCRIPTEN_LINKER_FLAGS} -sSTACK_SIZE=${ARROW_EMSCRIPTEN_TEST_STACK_SIZE} -sALLOW_MEMORY_GROWTH -lnodefs.js -lnoderawfs.js --pre-js ${BUILD_SUPPORT_DIR}/emscripten-test-init.js"
       )
     else()
       set(CMAKE_EXE_LINKER_FLAGS
-          "${ARROW_EMSCRIPTEN_LINKER_FLAGS} -sERROR_ON_WASM_CHANGES_AFTER_LINK=1 -sALLOW_MEMORY_GROWTH -lnodefs.js -lnoderawfs.js --pre-js ${BUILD_SUPPORT_DIR}/emscripten-test-init.js"
+          "${ARROW_EMSCRIPTEN_LINKER_FLAGS} -sERROR_ON_WASM_CHANGES_AFTER_LINK=1 -sSTACK_SIZE=${ARROW_EMSCRIPTEN_TEST_STACK_SIZE} -sALLOW_MEMORY_GROWTH -lnodefs.js -lnoderawfs.js --pre-js ${BUILD_SUPPORT_DIR}/emscripten-test-init.js"
       )
     endif()
   else()


### PR DESCRIPTION
### Rationale for this change

JSON integration tests fail on deeply nested lists we want to fix that.

### What changes are included in this PR?

We give Emscripten test executable a bigger stack size (1 MiB) and hope it's enough.

### Are these changes tested?

By CI.

### Are there any user-facing changes?

No, integration testing only change.
* GitHub Issue: #51101