### PR TITLE
GH-48137: [C++] Restore ThreadPool state when a worker fails to start

### DIFF
--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -23,6 +23,7 @@
 #include <list>
 #include <mutex>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -580,7 +581,7 @@ Status ThreadPool::SetCapacity(int threads) {
                                 threads - static_cast<int>(state_->workers_.size()));
   if (required > 0) {
     // Some tasks are pending, spawn the number of needed threads immediately
-    LaunchWorkersUnlocked(required);
+    RETURN_NOT_OK(LaunchWorkersUnlocked(required));
   } else if (required < 0) {
     // Excess threads are running, wake them so that they stop
     state_->cv_.notify_all();
@@ -692,7 +693,7 @@ static void SetCurrentThreadPool(ThreadPool* pool) { current_thread_pool_ = pool
 
 bool ThreadPool::OwnsThisThread() { return GetCurrentThreadPool() == this; }
 
-void ThreadPool::LaunchWorkersUnlocked(int threads) {
+Status ThreadPool::LaunchWorkersUnlocked(int threads) {
   std::shared_ptr<State> state = sp_state_;
 
   for (int i = 0; i < threads; i++) {
@@ -703,11 +704,12 @@ void ThreadPool::LaunchWorkersUnlocked(int threads) {
         SetCurrentThreadPool(this);
         WorkerLoop(state, it);
       });
-    } catch (...) {
+    } catch (const std::exception& e) {
       state_->workers_.erase(it);
-      throw;
+      return Status::UnknownError("Failed to launch worker thread: ", e.what());
     }
   }
+  return Status::OK();
 }
 
 Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken stop_token,
@@ -737,7 +739,7 @@ Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken sto
     if (static_cast<int>(state_->workers_.size()) <= state_->tasks_queued_or_running_ &&
         state_->desired_capacity_ > static_cast<int>(state_->workers_.size())) {
       // We can still spin up more workers so spin up a new worker
-      LaunchWorkersUnlocked(/*threads=*/1);
+      RETURN_NOT_OK(LaunchWorkersUnlocked(/*threads=*/1));
     }
     state_->tasks_queued_or_running_++;
     state_->pending_tasks_.push(

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -698,10 +698,15 @@ void ThreadPool::LaunchWorkersUnlocked(int threads) {
   for (int i = 0; i < threads; i++) {
     state_->workers_.emplace_back();
     auto it = --(state_->workers_.end());
-    *it = std::thread([this, state, it] {
-      SetCurrentThreadPool(this);
-      WorkerLoop(state, it);
-    });
+    try {
+      *it = std::thread([this, state, it] {
+        SetCurrentThreadPool(this);
+        WorkerLoop(state, it);
+      });
+    } catch (...) {
+      state_->workers_.erase(it);
+      throw;
+    }
   }
 }
 
@@ -729,12 +734,12 @@ Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken sto
       return Status::Invalid("operation forbidden during or after shutdown");
     }
     CollectFinishedWorkersUnlocked();
-    state_->tasks_queued_or_running_++;
-    if (static_cast<int>(state_->workers_.size()) < state_->tasks_queued_or_running_ &&
+    if (static_cast<int>(state_->workers_.size()) <= state_->tasks_queued_or_running_ &&
         state_->desired_capacity_ > static_cast<int>(state_->workers_.size())) {
       // We can still spin up more workers so spin up a new worker
       LaunchWorkersUnlocked(/*threads=*/1);
     }
+    state_->tasks_queued_or_running_++;
     state_->pending_tasks_.push(
         QueuedTask{{std::move(task), std::move(stop_token), std::move(stop_callback)},
                    hints.priority,

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -496,6 +496,7 @@ class ARROW_EXPORT ThreadPool : public Executor {
 
  protected:
   FRIEND_TEST(TestThreadPool, SetCapacity);
+  FRIEND_TEST(TestThreadPoolForkSafety, FailedWorkerLaunch);
   FRIEND_TEST(TestGlobalThreadPool, Capacity);
   ARROW_FRIEND_EXPORT friend ThreadPool* GetCpuThreadPool();
 

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -496,7 +496,7 @@ class ARROW_EXPORT ThreadPool : public Executor {
 
  protected:
   FRIEND_TEST(TestThreadPool, SetCapacity);
-  FRIEND_TEST(TestThreadPoolForkSafety, FailedWorkerLaunch);
+  FRIEND_TEST(TestThreadPool, FailedWorkerLaunch);
   FRIEND_TEST(TestGlobalThreadPool, Capacity);
   ARROW_FRIEND_EXPORT friend ThreadPool* GetCpuThreadPool();
 
@@ -508,7 +508,7 @@ class ARROW_EXPORT ThreadPool : public Executor {
   // Collect finished worker threads, making sure the OS threads have exited
   void CollectFinishedWorkersUnlocked();
   // Launch a given number of additional workers
-  void LaunchWorkersUnlocked(int threads);
+  Status LaunchWorkersUnlocked(int threads);
   // Get the current actual capacity
   int GetActualCapacity();
 

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -16,8 +16,15 @@
 // under the License.
 
 #ifndef _WIN32
+#  include <sys/resource.h>
 #  include <sys/types.h>
+#  include <sys/wait.h>
 #  include <unistd.h>
+#endif
+
+#ifdef __APPLE__
+#  include <pthread.h>
+#  include <sys/sysctl.h>
 #endif
 
 #include <algorithm>
@@ -28,6 +35,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -1047,6 +1055,103 @@ TEST_F(TestThreadPoolForkSafety, NestedChild) {
       ASSERT_OK(pool->Shutdown());
     }
   }
+}
+
+namespace {
+
+constexpr int kChildOk = 0;
+constexpr int kLaunchDidNotFail = 1;
+constexpr int kStateNotRestored = 2;
+constexpr int kShutdownFailed = 3;
+constexpr int kCouldNotForceFailure = 42;
+
+#  ifdef __APPLE__
+
+void* ParkUntilExit(void*) {
+  SleepFor(3600);
+  return nullptr;
+}
+
+bool ExhaustTaskThreads() {
+  int max_threads = 0;
+  size_t size = sizeof(max_threads);
+  if (sysctlbyname("kern.num_taskthreads", &max_threads, &size, nullptr, 0) != 0) {
+    return false;
+  }
+  pthread_attr_t attr;
+  if (pthread_attr_init(&attr) != 0) {
+    return false;
+  }
+  bool creation_failed = false;
+  if (pthread_attr_setstacksize(&attr, 32 * 1024) == 0 &&
+      pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) == 0) {
+    for (int i = 0; i < max_threads && !creation_failed; ++i) {
+      pthread_t thread;
+      creation_failed = pthread_create(&thread, &attr, ParkUntilExit, nullptr) != 0;
+    }
+  }
+  pthread_attr_destroy(&attr);
+  return creation_failed;
+}
+
+#  endif
+
+bool ForceThreadCreationFailure() {
+  if (geteuid() == 0) {
+    return false;
+  }
+  struct rlimit limit;
+  if (getrlimit(RLIMIT_NPROC, &limit) != 0) {
+    return false;
+  }
+  limit.rlim_cur = 1;
+  if (setrlimit(RLIMIT_NPROC, &limit) != 0) {
+    return false;
+  }
+  try {
+    std::thread([] { SleepFor(3600); }).detach();
+  } catch (const std::system_error&) {
+    return true;
+  }
+#  ifdef __APPLE__
+  return ExhaustTaskThreads();
+#  else
+  return false;
+#  endif
+}
+
+}  // namespace
+
+TEST_F(TestThreadPoolForkSafety, FailedWorkerLaunch) {
+#  ifndef ARROW_ENABLE_THREADING
+  GTEST_SKIP() << "Test requires threading support";
+#  endif
+  auto child_pid = fork();
+  if (child_pid == 0) {
+    alarm(60);
+    auto pool = this->MakeThreadPool(4);
+    if (!ForceThreadCreationFailure()) {
+      std::exit(kCouldNotForceFailure);
+    }
+    try {
+      ARROW_UNUSED(pool->Spawn([] {}));
+      std::exit(kLaunchDidNotFail);
+    } catch (const std::system_error&) {
+    }
+    if (pool->GetActualCapacity() != 0 || pool->GetNumTasks() != 0) {
+      std::exit(kStateNotRestored);
+    }
+    std::exit(pool->Shutdown().ok() ? kChildOk : kShutdownFailed);
+  }
+
+  ASSERT_GT(child_pid, 0);
+  int child_status = 0;
+  ASSERT_EQ(waitpid(child_pid, &child_status, 0), child_pid);
+  ASSERT_TRUE(WIFEXITED(child_status)) << "Child status = " << child_status;
+  if (WEXITSTATUS(child_status) == kCouldNotForceFailure) {
+    GTEST_SKIP() << "Could not make thread creation fail";
+  }
+  ASSERT_EQ(WEXITSTATUS(child_status), kChildOk);
 }
 
 #endif

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -18,13 +18,7 @@
 #ifndef _WIN32
 #  include <sys/resource.h>
 #  include <sys/types.h>
-#  include <sys/wait.h>
 #  include <unistd.h>
-#endif
-
-#ifdef __APPLE__
-#  include <pthread.h>
-#  include <sys/sysctl.h>
 #endif
 
 #include <algorithm>
@@ -35,7 +29,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -840,6 +833,36 @@ TEST_F(TestThreadPool, SetCapacity) {
   ASSERT_EQ(pool->GetCapacity(), 7);
 }
 #endif
+
+#if defined(ARROW_ENABLE_THREADING) && !defined(_WIN32)
+TEST_F(TestThreadPool, FailedWorkerLaunch) {
+#  ifdef __APPLE__
+  GTEST_SKIP() << "RLIMIT_NPROC does not limit thread creation on macOS";
+#  else
+  auto pool = this->MakeThreadPool(4);
+
+  struct rlimit limit;
+  ASSERT_EQ(getrlimit(RLIMIT_NPROC, &limit), 0);
+  const rlim_t soft_limit = limit.rlim_cur;
+  limit.rlim_cur = 1;
+  if (setrlimit(RLIMIT_NPROC, &limit) != 0) {
+    GTEST_SKIP() << "Could not lower RLIMIT_NPROC";
+  }
+  const Status st = pool->Spawn([] {});
+  limit.rlim_cur = soft_limit;
+  ASSERT_EQ(setrlimit(RLIMIT_NPROC, &limit), 0);
+
+  if (st.ok()) {
+    GTEST_SKIP() << "Lowering RLIMIT_NPROC did not prevent thread creation";
+  }
+  ASSERT_RAISES(UnknownError, st);
+  ASSERT_EQ(pool->GetActualCapacity(), 0);
+  ASSERT_EQ(pool->GetNumTasks(), 0);
+  ASSERT_OK(pool->Shutdown());
+#  endif
+}
+#endif
+
 // Test Submit() functionality
 
 TEST_F(TestThreadPool, Submit) {
@@ -1055,103 +1078,6 @@ TEST_F(TestThreadPoolForkSafety, NestedChild) {
       ASSERT_OK(pool->Shutdown());
     }
   }
-}
-
-namespace {
-
-constexpr int kChildOk = 0;
-constexpr int kLaunchDidNotFail = 1;
-constexpr int kStateNotRestored = 2;
-constexpr int kShutdownFailed = 3;
-constexpr int kCouldNotForceFailure = 42;
-
-#  ifdef __APPLE__
-
-void* ParkUntilExit(void*) {
-  SleepFor(3600);
-  return nullptr;
-}
-
-bool ExhaustTaskThreads() {
-  int max_threads = 0;
-  size_t size = sizeof(max_threads);
-  if (sysctlbyname("kern.num_taskthreads", &max_threads, &size, nullptr, 0) != 0) {
-    return false;
-  }
-  pthread_attr_t attr;
-  if (pthread_attr_init(&attr) != 0) {
-    return false;
-  }
-  bool creation_failed = false;
-  if (pthread_attr_setstacksize(&attr, 32 * 1024) == 0 &&
-      pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) == 0) {
-    for (int i = 0; i < max_threads && !creation_failed; ++i) {
-      pthread_t thread;
-      creation_failed = pthread_create(&thread, &attr, ParkUntilExit, nullptr) != 0;
-    }
-  }
-  pthread_attr_destroy(&attr);
-  return creation_failed;
-}
-
-#  endif
-
-bool ForceThreadCreationFailure() {
-  if (geteuid() == 0) {
-    return false;
-  }
-  struct rlimit limit;
-  if (getrlimit(RLIMIT_NPROC, &limit) != 0) {
-    return false;
-  }
-  limit.rlim_cur = 1;
-  if (setrlimit(RLIMIT_NPROC, &limit) != 0) {
-    return false;
-  }
-  try {
-    std::thread([] { SleepFor(3600); }).detach();
-  } catch (const std::system_error&) {
-    return true;
-  }
-#  ifdef __APPLE__
-  return ExhaustTaskThreads();
-#  else
-  return false;
-#  endif
-}
-
-}  // namespace
-
-TEST_F(TestThreadPoolForkSafety, FailedWorkerLaunch) {
-#  ifndef ARROW_ENABLE_THREADING
-  GTEST_SKIP() << "Test requires threading support";
-#  endif
-  auto child_pid = fork();
-  if (child_pid == 0) {
-    alarm(60);
-    auto pool = this->MakeThreadPool(4);
-    if (!ForceThreadCreationFailure()) {
-      std::exit(kCouldNotForceFailure);
-    }
-    try {
-      ARROW_UNUSED(pool->Spawn([] {}));
-      std::exit(kLaunchDidNotFail);
-    } catch (const std::system_error&) {
-    }
-    if (pool->GetActualCapacity() != 0 || pool->GetNumTasks() != 0) {
-      std::exit(kStateNotRestored);
-    }
-    std::exit(pool->Shutdown().ok() ? kChildOk : kShutdownFailed);
-  }
-
-  ASSERT_GT(child_pid, 0);
-  int child_status = 0;
-  ASSERT_EQ(waitpid(child_pid, &child_status, 0), child_pid);
-  ASSERT_TRUE(WIFEXITED(child_status)) << "Child status = " << child_status;
-  if (WEXITSTATUS(child_status) == kCouldNotForceFailure) {
-    GTEST_SKIP() << "Could not make thread creation fail";
-  }
-  ASSERT_EQ(WEXITSTATUS(child_status), kChildOk);
 }
 
 #endif


### PR DESCRIPTION
### Rationale for this change

`LaunchWorkersUnlocked` appends an entry to `state_->workers_` before constructing the thread
that owns it, and only the worker itself erases that entry. If the `std::thread` constructor
fails, the entry stays behind with nothing left to remove it, so `Shutdown` waits forever on
`workers_.empty()`. The destructor takes the same path. The failure also escaped `SpawnReal`
after `tasks_queued_or_running_` had been incremented, so `WaitForIdle` never returned either,
and once stale entries filled `workers_` to capacity the pool stopped launching workers while
`Spawn` still returned OK for tasks nothing would run.

### What changes are included in this PR?

`LaunchWorkersUnlocked` returns a `Status`. A failed thread construction erases the entry it had
reserved and returns an error, which `SpawnReal` and `SetCapacity` propagate. The task counter is
incremented after the launch rather than before, so a failed launch cannot leak a count.

### Are these changes tested?

`TestThreadPool.FailedWorkerLaunch` lowers `RLIMIT_NPROC` to 1, spawns a task, restores the soft
limit, and then checks the pool reports no workers and no tasks and still shuts down. It skips on
macOS, where `RLIMIT_NPROC` counts processes rather than threads, and skips anywhere else the
lowered limit does not stop thread creation, such as under root.

### Are there any user-facing changes?

Yes. `Spawn`, `Submit` and `SetCapacity` used to let a `std::system_error` escape when the OS
refused a new thread. They return an error `Status` now. `ThreadPool::Make` is unaffected, since
worker threads are only started on demand and a new pool starts none.

* GitHub Issue: #48137
