### PR TITLE
GH-47417: [C++] Fix JSON parser losing nulls in a null-typed list

### DIFF
--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -529,50 +529,51 @@ class RawBuilderSet {
 
   /// Appending null is slightly tricky since null count is stored inline
   /// for builders of Kind::kNull. Append nulls using this helper
-  Status AppendNull(BuilderPtr parent, int field_index, BuilderPtr builder) {
-    if (ARROW_PREDICT_FALSE(!builder.nullable)) {
+  Status AppendNull(BuilderPtr parent, int field_index, BuilderPtr* builder) {
+    if (ARROW_PREDICT_FALSE(!builder->nullable)) {
       return ParseError("a required field was null");
     }
-    switch (builder.kind) {
+    switch (builder->kind) {
       case Kind::kNull: {
-        DCHECK_EQ(builder, parent.kind == Kind::kArray
-                               ? Cast<Kind::kArray>(parent)->value_builder()
-                               : Cast<Kind::kObject>(parent)->field_builder(field_index));
+        DCHECK_EQ(*builder,
+                  parent.kind == Kind::kArray
+                      ? Cast<Kind::kArray>(parent)->value_builder()
+                      : Cast<Kind::kObject>(parent)->field_builder(field_index));
 
         // increment null count stored inline
-        builder.index += 1;
+        builder->index += 1;
 
         // update the parent, since changing builder doesn't affect parent
         if (parent.kind == Kind::kArray) {
-          Cast<Kind::kArray>(parent)->value_builder(builder);
+          Cast<Kind::kArray>(parent)->value_builder(*builder);
         } else {
-          Cast<Kind::kObject>(parent)->field_builder(field_index, builder);
+          Cast<Kind::kObject>(parent)->field_builder(field_index, *builder);
         }
         return Status::OK();
       }
       case Kind::kBoolean:
-        return Cast<Kind::kBoolean>(builder)->AppendNull();
+        return Cast<Kind::kBoolean>(*builder)->AppendNull();
 
       case Kind::kNumber:
-        return Cast<Kind::kNumber>(builder)->AppendNull();
+        return Cast<Kind::kNumber>(*builder)->AppendNull();
 
       case Kind::kString:
-        return Cast<Kind::kString>(builder)->AppendNull();
+        return Cast<Kind::kString>(*builder)->AppendNull();
 
       case Kind::kNumberOrString: {
-        return Cast<Kind::kNumberOrString>(builder)->AppendNull();
+        return Cast<Kind::kNumberOrString>(*builder)->AppendNull();
       }
 
       case Kind::kArray:
-        return Cast<Kind::kArray>(builder)->AppendNull();
+        return Cast<Kind::kArray>(*builder)->AppendNull();
 
       case Kind::kObject: {
-        auto struct_builder = Cast<Kind::kObject>(builder);
+        auto struct_builder = Cast<Kind::kObject>(*builder);
         RETURN_NOT_OK(struct_builder->AppendNull());
 
         for (int i = 0; i < struct_builder->num_fields(); ++i) {
           auto field_builder = struct_builder->field_builder(i);
-          RETURN_NOT_OK(AppendNull(builder, i, field_builder));
+          RETURN_NOT_OK(AppendNull(*builder, i, &field_builder));
         }
         return Status::OK();
       }
@@ -672,7 +673,7 @@ class HandlerBase : public BlockParser,
   ///
   /// @{
   bool Null() {
-    status_ = builder_set_.AppendNull(builder_stack_.back(), field_index_, builder_);
+    status_ = builder_set_.AppendNull(builder_stack_.back(), field_index_, &builder_);
     return status_.ok();
   }
 
@@ -869,7 +870,7 @@ class HandlerBase : public BlockParser,
       if (ARROW_PREDICT_FALSE(!field_builder.nullable)) {
         return ParseError("a required field was absent");
       }
-      RETURN_NOT_OK(builder_set_.AppendNull(parent, i, field_builder));
+      RETURN_NOT_OK(builder_set_.AppendNull(parent, i, &field_builder));
     }
     absent_fields_stack_.Pop();
     EndNested();

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -235,6 +235,17 @@ TEST(BlockParserWithSchema, FailOnIncompleteJson) {
   ASSERT_RAISES(Invalid, ParseFromString(options, "{\"a\":0, \"b\"", &parsed));
 }
 
+TEST(BlockParserWithSchema, NullsInList) {
+  auto options = ParseOptions::Defaults();
+  options.explicit_schema = schema({field("a", list(null()))});
+  for (auto behavior :
+       {UnexpectedFieldBehavior::Error, UnexpectedFieldBehavior::Ignore}) {
+    options.unexpected_field_behavior = behavior;
+    AssertParseColumns(options, R"({"a": [null, null]})", {field("a", list(null()))},
+                       {"[[null, null]]"});
+  }
+}
+
 TEST(BlockParser, Basics) {
   auto options = ParseOptions::Defaults();
   options.unexpected_field_behavior = UnexpectedFieldBehavior::InferType;

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -267,6 +267,14 @@ TEST(BlockParser, Null) {
        R"([{"plain": null}, {"plain": null}])"});
 }
 
+TEST(BlockParser, NullsInList) {
+  auto options = ParseOptions::Defaults();
+  options.unexpected_field_behavior = UnexpectedFieldBehavior::InferType;
+  AssertParseColumns(options, R"({"a": [null, null], "b": [null, "hi", null]})",
+                     {field("a", list(null())), field("b", list(utf8()))},
+                     {"[[null, null]]", R"([[null, "hi", null]])"});
+}
+
 TEST(BlockParser, InferNewFields) {
   std::string src = R"(
     {}


### PR DESCRIPTION
### Rationale for this change

`{"a": [null, 1]}` parses to `[[1]]`. Nothing raises, and `validate(full=True)` is the only thing
that notices:

```
Offset invariant failure: offset for slot 1 out of bounds: 2 > 1
```

Debug builds abort on a DCHECK instead, at `parser.cc:540` if the second element is null and
`parser.cc:1151` if it is typed.

### What changes are included in this PR?

`RawBuilderSet::AppendNull` takes the child builder by value. Builders of `Kind::kNull` have no
arena, their null count is packed into `BuilderPtr::index`, so the increment updates the parent
but is lost to the caller. The next null then re-increments the same stale value, which leaves an
all-null list as `NullArray(1)` and a promoted list with its leading nulls missing.

It now takes a `BuilderPtr*`, matching `MakeBuilder` in the same class. The regression came in
with `b7054c21aab` and has shipped since 0.14.0.

### Are these changes tested?

`BlockParser.NullsInList` covers both arms, and `BlockParserWithSchema.NullsInList` runs an
explicit `list(null())` schema under `Error` and `Ignore`. `arrow-json-test` passes 262/262 in
Debug and Release. Reverting `parser.cc` with the tests in place aborts both in Debug and fails
both on null count in Release.

### Are there any user-facing changes?

Those inputs parse correctly now. This is not inference-only: an explicit `list(null())` schema
reaches the same arm under both `Error` and `Ignore`.

**This PR contains a "Critical Fix".** Well-formed JSON silently loses list elements in release
builds and aborts on a DCHECK in debug builds.

* GitHub Issue: #47417
