### PR TITLE
GH-51111: [Dev] Group apache/infrastructure-actions/stash/{save,restore} Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
     commit-message:
       prefix: "MINOR: [CI] "
     open-pull-requests-limit: 10
+    groups:
+      apache-infrastructure-actions-stash:
+        patterns:
+          - "apache/infrastructure-actions/stash/save"
+          - "apache/infrastructure-actions/stash/restore"


### PR DESCRIPTION
### Rationale for this change

They exist in the same repository. We should update them at once.

### What changes are included in this PR?

Add a new group for them.

### Are these changes tested?

No. I want to try this in apache/arrow.

### Are there any user-facing changes?

No.
* GitHub Issue: #51111