### PR TITLE
GH-50967: [C++] Allow CSV reader to ignore extra columns in rows with more columns

### DIFF
--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -35,6 +35,25 @@ class SpecializedOptions {
   static constexpr bool escaping = Escaping;
 };
 
+template <typename... CompiledBools, typename Fn, typename... Rest>
+  requires std::invocable<Fn, CompiledBools...,
+                          std::conditional_t<true, std::true_type, Rest>...>
+decltype(auto) DispatchBool(Fn&& fn, Rest... rest) {
+  if constexpr (sizeof...(Rest) == 0) {
+    return std::forward<Fn>(fn)(CompiledBools{}...);
+  } else {
+    return [&](bool head, auto... tail) -> decltype(auto) {
+      if (head) {
+        return DispatchBool<CompiledBools..., std::true_type>(std::forward<Fn>(fn),
+                                                              tail...);
+      } else {
+        return DispatchBool<CompiledBools..., std::false_type>(std::forward<Fn>(fn),
+                                                               tail...);
+      }
+    }(rest...);
+  }
+}
+
 //
 // Bulk filters for packed character matching.
 // These filters allow checking multiple CSV bytes at once for specific

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -37,6 +37,7 @@ class SpecializedOptions {
   static constexpr bool escaping = Escaping;
 };
 
+/// Convert runtime boolean options into template arguments for a callable.
 template <bool... CompiledBools, typename Fn, typename... Rest>
 decltype(auto) DispatchBool(Fn&& fn, Rest... rest)
   requires requires {
@@ -45,8 +46,11 @@ decltype(auto) DispatchBool(Fn&& fn, Rest... rest)
   }
 {
   if constexpr (sizeof...(Rest) == 0) {
+    // All runtime booleans have been appended to the compile-time pack.
     return std::forward<Fn>(fn).template operator()<CompiledBools...>();
   } else {
+    // Split off the next runtime boolean, append its value to the compile-time pack,
+    // and recursively dispatch the remaining booleans.
     return [&](bool head, auto... tail) -> decltype(auto) {
       if (head) {
         return DispatchBool<CompiledBools..., true>(std::forward<Fn>(fn), tail...);

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <cstring>
 #include <string_view>
+#include <type_traits>
 
 #include "arrow/csv/options.h"
 #include "arrow/util/simd.h"

--- a/cpp/src/arrow/csv/lexing_internal.h
+++ b/cpp/src/arrow/csv/lexing_internal.h
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include <concepts>
 #include <cstdint>
 #include <cstring>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 #include "arrow/csv/options.h"
 #include "arrow/util/simd.h"
@@ -37,20 +37,21 @@ class SpecializedOptions {
   static constexpr bool escaping = Escaping;
 };
 
-template <typename... CompiledBools, typename Fn, typename... Rest>
-  requires std::invocable<Fn, CompiledBools...,
-                          std::conditional_t<true, std::true_type, Rest>...>
-decltype(auto) DispatchBool(Fn&& fn, Rest... rest) {
+template <bool... CompiledBools, typename Fn, typename... Rest>
+decltype(auto) DispatchBool(Fn&& fn, Rest... rest)
+  requires requires {
+    std::forward<Fn>(fn)
+        .template operator()<CompiledBools..., std::is_convertible_v<Rest, bool>...>();
+  }
+{
   if constexpr (sizeof...(Rest) == 0) {
-    return std::forward<Fn>(fn)(CompiledBools{}...);
+    return std::forward<Fn>(fn).template operator()<CompiledBools...>();
   } else {
     return [&](bool head, auto... tail) -> decltype(auto) {
       if (head) {
-        return DispatchBool<CompiledBools..., std::true_type>(std::forward<Fn>(fn),
-                                                              tail...);
+        return DispatchBool<CompiledBools..., true>(std::forward<Fn>(fn), tail...);
       } else {
-        return DispatchBool<CompiledBools..., std::false_type>(std::forward<Fn>(fn),
-                                                               tail...);
+        return DispatchBool<CompiledBools..., false>(std::forward<Fn>(fn), tail...);
       }
     }(rest...);
   }

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -63,6 +63,8 @@ struct ARROW_EXPORT ParseOptions {
   InvalidRowHandler invalid_row_handler;
   /// Whether rows with fewer columns than expected are padded with nulls.
   bool pad_short_rows = false;
+  /// Whether rows with more columns than expected should ignore the extra columns.
+  bool ignore_extra_columns = false;
 
   /// Create parsing options with default values
   static ParseOptions Defaults();

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -287,7 +287,23 @@ class BlockParserImpl {
 
     DCHECK_GT(data_end, data);
 
-    auto FinishField = [&]() { values_writer->FinishField(parsed_writer); };
+    bool ignoring_extra_field = false;
+
+    auto IsExtraField = [&]() {
+      return batch_.num_cols_ >= 0 && options_.ignore_extra_columns &&
+             num_cols >= batch_.num_cols_;
+    };
+    auto StartField = [&](bool quoted) {
+      ignoring_extra_field = IsExtraField();
+      if (!ignoring_extra_field) {
+        values_writer->StartField(quoted);
+      }
+    };
+    auto FinishField = [&]() {
+      if (!IsExtraField()) {
+        values_writer->FinishField(parsed_writer);
+      }
+    };
 
     values_writer->BeginLine();
     parsed_writer->BeginLine();
@@ -314,7 +330,7 @@ class BlockParserImpl {
     // At the start of a field
     if (*data == options_.delimiter) {
       // Empty cells are very common in some files, shortcut them
-      values_writer->StartField(false /* quoted */);
+      StartField(false /* quoted */);
       FinishField();
       ++data;
       ++num_cols;
@@ -328,17 +344,18 @@ class BlockParserImpl {
     if (SpecializedOptions::quoting &&
         ARROW_PREDICT_FALSE(*data == options_.quote_char)) {
       ++data;
-      values_writer->StartField(true /* quoted */);
+      StartField(true /* quoted */);
       goto InQuotedField;
     } else {
-      values_writer->StartField(false /* quoted */);
+      StartField(false /* quoted */);
       goto InField;
     }
 
   InField:
     // Inside a non-quoted part of a field
     if (UseBulkFilter) {
-      const char* bulk_end = RunBulkFilter(parsed_writer, data, data_end, bulk_filter);
+      const char* bulk_end =
+          RunBulkFilter(parsed_writer, data, data_end, bulk_filter, ignoring_extra_field);
       if (ARROW_PREDICT_FALSE(bulk_end == nullptr)) {
         if (is_final) {
           data = data_end;
@@ -358,7 +375,9 @@ class BlockParserImpl {
         goto AbortLine;
       }
       c = *data++;
-      parsed_writer->PushFieldChar(c);
+      if (!ignoring_extra_field) {
+        parsed_writer->PushFieldChar(c);
+      }
       goto InField;
     }
     if (ARROW_PREDICT_FALSE(c == options_.delimiter)) {
@@ -376,13 +395,16 @@ class BlockParserImpl {
         goto LineEnd;
       }
     }
-    parsed_writer->PushFieldChar(c);
+    if (!ignoring_extra_field) {
+      parsed_writer->PushFieldChar(c);
+    }
     goto InField;
 
   InQuotedField:
     // Inside a quoted part of a field
     if (UseBulkFilter) {
-      const char* bulk_end = RunBulkFilter(parsed_writer, data, data_end, bulk_filter);
+      const char* bulk_end =
+          RunBulkFilter(parsed_writer, data, data_end, bulk_filter, ignoring_extra_field);
       if (ARROW_PREDICT_FALSE(bulk_end == nullptr)) {
         if (is_final) {
           data = data_end;
@@ -401,7 +423,9 @@ class BlockParserImpl {
         goto AbortLine;
       }
       c = *data++;
-      parsed_writer->PushFieldChar(c);
+      if (!ignoring_extra_field) {
+        parsed_writer->PushFieldChar(c);
+      }
       goto InQuotedField;
     }
     if (ARROW_PREDICT_FALSE(c == options_.quote_char)) {
@@ -414,7 +438,9 @@ class BlockParserImpl {
         goto InField;
       }
     }
-    parsed_writer->PushFieldChar(c);
+    if (!ignoring_extra_field) {
+      parsed_writer->PushFieldChar(c);
+    }
     goto InQuotedField;
 
   FieldEnd:
@@ -436,11 +462,11 @@ class BlockParserImpl {
       } else if (options_.pad_short_rows && num_cols < batch_.num_cols_) {
         batch_.missing_fields_.push_back({batch_.num_rows_, num_cols});
         while (num_cols < batch_.num_cols_) {
-          values_writer->StartField(false /* quoted */);
+          StartField(false /* quoted */);
           FinishField();
           ++num_cols;
         }
-      } else {
+      } else if (!options_.ignore_extra_columns || num_cols < batch_.num_cols_) {
         return HandleInvalidRow(values_writer, parsed_writer, start, data, num_cols,
                                 out_data);
       }
@@ -466,9 +492,10 @@ class BlockParserImpl {
         batch_.num_cols_ = 1;
       }
       // Record as row of empty (null?) values
-      while (num_cols++ < batch_.num_cols_) {
-        values_writer->StartField(false /* quoted */);
+      while (num_cols < batch_.num_cols_) {
+        StartField(false /* quoted */);
         FinishField();
+        ++num_cols;
       }
       ++batch_.num_rows_;
     }
@@ -479,7 +506,8 @@ class BlockParserImpl {
   template <typename DataWriter, typename SpecializedBulkFilter>
   const char* RunBulkFilter(DataWriter* data_writer, const char* data,
                             const char* data_end,
-                            const SpecializedBulkFilter& bulk_filter) {
+                            const SpecializedBulkFilter& bulk_filter,
+                            bool ignoring_extra_field) {
     while (true) {
       using WordType = typename SpecializedBulkFilter::WordType;
 
@@ -495,7 +523,9 @@ class BlockParserImpl {
         return data;
       }
       // No special chars
-      data_writer->PushFieldWord(word);
+      if (!ignoring_extra_field) {
+        data_writer->PushFieldWord(word);
+      }
       data += sizeof(WordType);
     }
   }

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -18,8 +18,10 @@
 #include "arrow/csv/parser.h"
 
 #include <algorithm>
+#include <concepts>
 #include <cstdio>
 #include <limits>
+#include <type_traits>
 #include <utility>
 
 #include "arrow/csv/lexing_internal.h"
@@ -58,6 +60,14 @@ Status MismatchingColumns(const InvalidRow& row) {
 }
 
 inline bool IsControlChar(uint8_t c) { return c < ' '; }
+
+template <bool IgnoreExtraColumns>
+constexpr bool ShouldWrite(bool ignoring_extra_field) {
+  if constexpr (IgnoreExtraColumns) {
+    return !ignoring_extra_field;
+  }
+  return true;
+}
 
 // A helper class allocating the buffer for parsed values and writing into it
 // without any further resizes, except at the end.
@@ -276,8 +286,8 @@ class BlockParserImpl {
     return MismatchingColumns(row);
   }
 
-  template <typename SpecializedOptions, bool UseBulkFilter, typename ValueDescWriter,
-            typename DataWriter, typename BulkFilter>
+  template <typename SpecializedOptions, bool UseBulkFilter, bool IgnoreExtraColumns,
+            typename ValueDescWriter, typename DataWriter, typename BulkFilter>
   Status ParseLine(ValueDescWriter* values_writer, DataWriter* parsed_writer,
                    const char* data, const char* data_end, bool is_final,
                    const char** out_data, const BulkFilter& bulk_filter) {
@@ -290,17 +300,22 @@ class BlockParserImpl {
     bool ignoring_extra_field = false;
 
     auto IsExtraField = [&]() {
-      return batch_.num_cols_ >= 0 && options_.ignore_extra_columns &&
-             num_cols >= batch_.num_cols_;
+      if constexpr (!IgnoreExtraColumns) {
+        return false;
+      }
+      return batch_.num_cols_ >= 0 && num_cols >= batch_.num_cols_;
     };
     auto StartField = [&](bool quoted) {
-      ignoring_extra_field = IsExtraField();
-      if (!ignoring_extra_field) {
-        values_writer->StartField(quoted);
+      if (ARROW_PREDICT_TRUE(ShouldWrite<IgnoreExtraColumns>(ignoring_extra_field))) {
+        if (ARROW_PREDICT_FALSE(IsExtraField())) {
+          ignoring_extra_field = true;
+        } else {
+          values_writer->StartField(quoted);
+        }
       }
     };
     auto FinishField = [&]() {
-      if (!IsExtraField()) {
+      if (ARROW_PREDICT_TRUE(ShouldWrite<IgnoreExtraColumns>(ignoring_extra_field))) {
         values_writer->FinishField(parsed_writer);
       }
     };
@@ -354,8 +369,8 @@ class BlockParserImpl {
   InField:
     // Inside a non-quoted part of a field
     if (UseBulkFilter) {
-      const char* bulk_end =
-          RunBulkFilter(parsed_writer, data, data_end, bulk_filter, ignoring_extra_field);
+      const char* bulk_end = RunBulkFilter<IgnoreExtraColumns>(
+          parsed_writer, data, data_end, bulk_filter, ignoring_extra_field);
       if (ARROW_PREDICT_FALSE(bulk_end == nullptr)) {
         if (is_final) {
           data = data_end;
@@ -375,7 +390,7 @@ class BlockParserImpl {
         goto AbortLine;
       }
       c = *data++;
-      if (!ignoring_extra_field) {
+      if (ARROW_PREDICT_TRUE(ShouldWrite<IgnoreExtraColumns>(ignoring_extra_field))) {
         parsed_writer->PushFieldChar(c);
       }
       goto InField;
@@ -395,7 +410,7 @@ class BlockParserImpl {
         goto LineEnd;
       }
     }
-    if (!ignoring_extra_field) {
+    if (ARROW_PREDICT_TRUE(ShouldWrite<IgnoreExtraColumns>(ignoring_extra_field))) {
       parsed_writer->PushFieldChar(c);
     }
     goto InField;
@@ -403,8 +418,8 @@ class BlockParserImpl {
   InQuotedField:
     // Inside a quoted part of a field
     if (UseBulkFilter) {
-      const char* bulk_end =
-          RunBulkFilter(parsed_writer, data, data_end, bulk_filter, ignoring_extra_field);
+      const char* bulk_end = RunBulkFilter<IgnoreExtraColumns>(
+          parsed_writer, data, data_end, bulk_filter, ignoring_extra_field);
       if (ARROW_PREDICT_FALSE(bulk_end == nullptr)) {
         if (is_final) {
           data = data_end;
@@ -423,7 +438,7 @@ class BlockParserImpl {
         goto AbortLine;
       }
       c = *data++;
-      if (!ignoring_extra_field) {
+      if (ARROW_PREDICT_TRUE(ShouldWrite<IgnoreExtraColumns>(ignoring_extra_field))) {
         parsed_writer->PushFieldChar(c);
       }
       goto InQuotedField;
@@ -438,7 +453,7 @@ class BlockParserImpl {
         goto InField;
       }
     }
-    if (!ignoring_extra_field) {
+    if (ARROW_PREDICT_TRUE(ShouldWrite<IgnoreExtraColumns>(ignoring_extra_field))) {
       parsed_writer->PushFieldChar(c);
     }
     goto InQuotedField;
@@ -466,7 +481,7 @@ class BlockParserImpl {
           FinishField();
           ++num_cols;
         }
-      } else if (!options_.ignore_extra_columns || num_cols < batch_.num_cols_) {
+      } else if (!IgnoreExtraColumns || num_cols < batch_.num_cols_) {
         return HandleInvalidRow(values_writer, parsed_writer, start, data, num_cols,
                                 out_data);
       }
@@ -478,6 +493,10 @@ class BlockParserImpl {
   AbortLine:
     // Not a full line except perhaps if in final block
     if (is_final) {
+      if constexpr (IgnoreExtraColumns) {
+        // Handle an implicit trailing empty field after a delimiter.
+        ignoring_extra_field = IsExtraField();
+      }
       goto LineEnd;
     }
     // Truncated line at end of block, rewind parsed state
@@ -503,7 +522,7 @@ class BlockParserImpl {
     return Status::OK();
   }
 
-  template <typename DataWriter, typename SpecializedBulkFilter>
+  template <bool IgnoreExtraColumns, typename DataWriter, typename SpecializedBulkFilter>
   const char* RunBulkFilter(DataWriter* data_writer, const char* data,
                             const char* data_end,
                             const SpecializedBulkFilter& bulk_filter,
@@ -523,15 +542,15 @@ class BlockParserImpl {
         return data;
       }
       // No special chars
-      if (!ignoring_extra_field) {
+      if (ARROW_PREDICT_TRUE(ShouldWrite<IgnoreExtraColumns>(ignoring_extra_field))) {
         data_writer->PushFieldWord(word);
       }
       data += sizeof(WordType);
     }
   }
 
-  template <typename SpecializedOptions, typename ValueDescWriter, typename DataWriter,
-            typename BulkFilter>
+  template <typename SpecializedOptions, bool IgnoreExtraColumns,
+            typename ValueDescWriter, typename DataWriter, typename BulkFilter>
   Status ParseChunk(ValueDescWriter* values_writer, DataWriter* parsed_writer,
                     const char* data, const char* data_end, bool is_final,
                     int32_t rows_in_chunk, const char** out_data, bool* finished_parsing,
@@ -542,9 +561,9 @@ class BlockParserImpl {
     if (use_bulk_filter_) {
       while (data < data_end && batch_.num_rows_ < num_rows_deadline) {
         const char* line_end = data;
-        RETURN_NOT_OK((ParseLine<SpecializedOptions, true>(values_writer, parsed_writer,
-                                                           data, data_end, is_final,
-                                                           &line_end, bulk_filter)));
+        RETURN_NOT_OK((ParseLine<SpecializedOptions, true, IgnoreExtraColumns>(
+            values_writer, parsed_writer, data, data_end, is_final, &line_end,
+            bulk_filter)));
         RETURN_NOT_OK(values_writer->status());
         if (line_end == data) {
           // Cannot parse any further
@@ -556,9 +575,9 @@ class BlockParserImpl {
     } else {
       while (data < data_end && batch_.num_rows_ < num_rows_deadline) {
         const char* line_end = data;
-        RETURN_NOT_OK((ParseLine<SpecializedOptions, false>(values_writer, parsed_writer,
-                                                            data, data_end, is_final,
-                                                            &line_end, bulk_filter)));
+        RETURN_NOT_OK((ParseLine<SpecializedOptions, false, IgnoreExtraColumns>(
+            values_writer, parsed_writer, data, data_end, is_final, &line_end,
+            bulk_filter)));
         RETURN_NOT_OK(values_writer->status());
         if (line_end == data) {
           // Cannot parse any further
@@ -589,7 +608,7 @@ class BlockParserImpl {
     return Status::OK();
   }
 
-  template <typename SpecializedOptions>
+  template <typename SpecializedOptions, bool IgnoreExtraColumns>
   Status ParseSpecialized(const std::vector<std::string_view>& views, bool is_final,
                           uint32_t* out_size) {
     internal::PreferredBulkFilterType<SpecializedOptions> bulk_filter(options_);
@@ -628,9 +647,9 @@ class BlockParserImpl {
         ARROW_ASSIGN_OR_RAISE(auto values_writer, ResizableValueDescWriter::Make(pool_));
         values_writer.Start(parsed_writer);
 
-        RETURN_NOT_OK(ParseChunk<SpecializedOptions>(
+        RETURN_NOT_OK((ParseChunk<SpecializedOptions, IgnoreExtraColumns>(
             &values_writer, &parsed_writer, data, data_end, is_final, rows_in_chunk,
-            &data, &finished_parsing, bulk_filter));
+            &data, &finished_parsing, bulk_filter)));
         if (batch_.num_cols_ == -1) {
           return ParseError("Empty CSV file or block: cannot infer number of columns");
         }
@@ -666,9 +685,9 @@ class BlockParserImpl {
             PresizedValueDescWriter::Make(pool_, rows_in_chunk, batch_.num_cols_));
         values_writer.Start(parsed_writer);
 
-        RETURN_NOT_OK(ParseChunk<SpecializedOptions>(
+        RETURN_NOT_OK((ParseChunk<SpecializedOptions, IgnoreExtraColumns>(
             &values_writer, &parsed_writer, data, data_end, is_final, rows_in_chunk,
-            &data, &finished_parsing, bulk_filter));
+            &data, &finished_parsing, bulk_filter)));
       }
       DCHECK_GE(data, view.data());
       DCHECK_LE(data, data_end);
@@ -709,23 +728,14 @@ class BlockParserImpl {
 
   Status Parse(const std::vector<std::string_view>& data, bool is_final,
                uint32_t* out_size) {
-    if (options_.quoting) {
-      if (options_.escaping) {
-        return ParseSpecialized<internal::SpecializedOptions<true, true>>(data, is_final,
-                                                                          out_size);
-      } else {
-        return ParseSpecialized<internal::SpecializedOptions<true, false>>(data, is_final,
-                                                                           out_size);
-      }
-    } else {
-      if (options_.escaping) {
-        return ParseSpecialized<internal::SpecializedOptions<false, true>>(data, is_final,
-                                                                           out_size);
-      } else {
-        return ParseSpecialized<internal::SpecializedOptions<false, false>>(
-            data, is_final, out_size);
-      }
-    }
+    return internal::DispatchBool(
+        [&](auto quoting, auto escaping, auto ignore_extra_columns) {
+          using SpecializedOptions =
+              internal::SpecializedOptions<quoting.value, escaping.value>;
+          return ParseSpecialized<SpecializedOptions, ignore_extra_columns.value>(
+              data, is_final, out_size);
+        },
+        options_.quoting, options_.escaping, options_.ignore_extra_columns);
   }
 
  protected:

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -727,11 +727,10 @@ class BlockParserImpl {
   Status Parse(const std::vector<std::string_view>& data, bool is_final,
                uint32_t* out_size) {
     return internal::DispatchBool(
-        [&](auto quoting, auto escaping, auto ignore_extra_columns) {
-          using SpecializedOptions =
-              internal::SpecializedOptions<quoting.value, escaping.value>;
-          return ParseSpecialized<SpecializedOptions, ignore_extra_columns.value>(
-              data, is_final, out_size);
+        [&]<bool Quoting, bool Escaping, bool IgnoreExtraColumns>() {
+          using SpecializedOptions = internal::SpecializedOptions<Quoting, Escaping>;
+          return ParseSpecialized<SpecializedOptions, IgnoreExtraColumns>(data, is_final,
+                                                                          out_size);
         },
         options_.quoting, options_.escaping, options_.ignore_extra_columns);
   }

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -18,10 +18,8 @@
 #include "arrow/csv/parser.h"
 
 #include <algorithm>
-#include <concepts>
 #include <cstdio>
 #include <limits>
-#include <type_traits>
 #include <utility>
 
 #include "arrow/csv/lexing_internal.h"
@@ -62,7 +60,7 @@ Status MismatchingColumns(const InvalidRow& row) {
 inline bool IsControlChar(uint8_t c) { return c < ' '; }
 
 template <bool IgnoreExtraColumns>
-constexpr bool ShouldWrite(bool ignoring_extra_field) {
+constexpr bool ShouldWrite([[maybe_unused]] bool ignoring_extra_field) {
   if constexpr (IgnoreExtraColumns) {
     return !ignoring_extra_field;
   }

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -298,6 +298,19 @@ TEST(BlockParser, PadShortRows) {
   ASSERT_EQ(last_row_missing, std::vector<bool>({false, false, true}));
 }
 
+TEST(BlockParser, IgnoreExtraColumns) {
+  auto options = ParseOptions::Defaults();
+  options.ignore_extra_columns = true;
+
+  BlockParser parser(options, /*num_cols=*/2);
+  AssertParseOk(parser, "a,\"b\",c,\nd,e\n");
+  AssertColumnsEq(parser, {{"a", "d"}, {"b", "e"}}, {{false, false}, {true, false}});
+
+  BlockParser final_parser(options, /*num_cols=*/2);
+  AssertParseFinal(final_parser, "a,b,");
+  AssertColumnsEq(final_parser, {{"a"}, {"b"}});
+}
+
 TEST(BlockParser, EmptyHeader) {
   // Cannot infer number of columns
   uint32_t out_size;

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -311,6 +311,26 @@ TEST(BlockParser, IgnoreExtraColumns) {
   AssertColumnsEq(final_parser, {{"a"}, {"b"}});
 }
 
+TEST(BlockParser, PadAndIgnore) {
+  auto options = ParseOptions::Defaults();
+  options.pad_short_rows = true;
+  options.ignore_extra_columns = true;
+
+  BlockParser parser(options, /*num_cols=*/2);
+  AssertParseFinal(parser, "a,b,c\nd");
+  AssertColumnEq(parser, 0, {"a", "d"});
+  std::vector<std::string> values;
+  std::vector<bool> missing;
+  ASSERT_OK(parser.VisitColumn(
+      1, [&](const uint8_t* data, uint32_t size, bool, bool is_missing) -> Status {
+        values.emplace_back(reinterpret_cast<const char*>(data), size);
+        missing.push_back(is_missing);
+        return Status::OK();
+      }));
+  ASSERT_EQ(values, std::vector<std::string>({"b", ""}));
+  ASSERT_EQ(missing, std::vector<bool>({false, true}));
+}
+
 TEST(BlockParser, EmptyHeader) {
   // Cannot infer number of columns
   uint32_t out_size;

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -644,6 +644,27 @@ TEST(ReaderTests, ShortRows) {
   ASSERT_TRUE(table->Equals(*expected_table));
 }
 
+TEST(ReaderTests, IgnoreExtraColumns) {
+  auto input =
+      std::make_shared<io::BufferReader>(std::make_shared<Buffer>("a,b\n1,2,3\n4,5\n"));
+  auto parse_options = ParseOptions::Defaults();
+  parse_options.ignore_extra_columns = true;
+  auto convert_options = ConvertOptions::Defaults();
+  convert_options.default_column_type = int64();
+
+  ASSERT_OK_AND_ASSIGN(auto reader, TableReader::Make(io::default_io_context(), input,
+                                                      ReadOptions::Defaults(),
+                                                      parse_options, convert_options));
+  ASSERT_OK_AND_ASSIGN(auto table, reader->Read());
+
+  auto expected_schema = schema({field("a", int64()), field("b", int64())});
+  auto expected_table = TableFromJSON(expected_schema, {R"([
+    {"a":1, "b":2},
+    {"a":4, "b":5}
+  ])"});
+  ASSERT_TRUE(table->Equals(*expected_table));
+}
+
 TEST(ReaderTests, ShortRowsTypedConverters) {
   auto input = std::make_shared<io::BufferReader>(std::make_shared<Buffer>("1,10\n2\n"));
   auto read_options = ReadOptions::Defaults();

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -164,11 +164,12 @@ Result<std::vector<std::string>> GetOrderedColumnNames(
   int32_t max_num_rows = read_options.skip_rows + 1;
   std::optional<csv::ParseOptions> inspection_parse_options;
   const auto* parser_options = &parse_options;
-  if (parse_options.pad_short_rows) {
-    // Do not pad short rows while determining column names, since padding cannot
-    // synthesize missing names. Copy the parse options only when needed.
+  if (parse_options.pad_short_rows || parse_options.ignore_extra_columns) {
+    // Do not adjust row widths while determining column names: padding cannot
+    // synthesize missing names, and ignoring extra columns may discard columns.
     inspection_parse_options.emplace(parse_options);
     inspection_parse_options->pad_short_rows = false;
+    inspection_parse_options->ignore_extra_columns = false;
     parser_options = &*inspection_parse_options;
   }
   csv::BlockParser parser(pool, *parser_options, /*num_cols=*/-1, /*first_row=*/1,
@@ -379,7 +380,8 @@ bool CsvFileFormat::Equals(const FileFormat& format) const {
          parse_options.escape_char == other_parse_options.escape_char &&
          parse_options.newlines_in_values == other_parse_options.newlines_in_values &&
          parse_options.ignore_empty_lines == other_parse_options.ignore_empty_lines &&
-         parse_options.pad_short_rows == other_parse_options.pad_short_rows;
+         parse_options.pad_short_rows == other_parse_options.pad_short_rows &&
+         parse_options.ignore_extra_columns == other_parse_options.ignore_extra_columns;
 }
 
 Result<bool> CsvFileFormat::IsSupported(const FileSource& source) const {


### PR DESCRIPTION
### Rationale for this change

Currently, the C++ CSV reader rejects rows with more columns than expected. We can allow users to ignore the extra values instead of throwing exception.

### What changes are included in this PR?

Add an option `ignore_extra_columns` in CSV `struct ParseOptions` that ignores extra columns.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Add an option `ignore_extra_columns` in CSV `struct ParseOptions`.
* GitHub Issue: #50967