### PR TITLE
MINOR: [CI] Document Crossbow GitHub token maintenance

### DIFF
--- a/docs/source/developers/continuous_integration/overview.rst
+++ b/docs/source/developers/continuous_integration/overview.rst
@@ -55,6 +55,22 @@ The ``.yml`` files in ``.github/workflows`` are workflows which are run on GitHu
 - ``dev.yml`` - runs any time there is activity on a PR, or a PR is merged; it runs the linter and tests that the PR can be merged
 - ``dev_pr.yml`` - runs any time a PR is opened or updated; checks the formatting of the PR title, adds assignee to the appropriate GitHub issue if needed (or adds a comment requesting the user to include the issue id in the title), and adds any relevant GitHub labels
 
+Maintaining the Crossbow GitHub token
+-------------------------------------
+
+The ``comment_bot.yml`` workflow uses ``CROSSBOW_GITHUB_TOKEN`` when it
+submits Crossbow jobs from pull-request comments.  The token must have the
+following GitHub scopes:
+
+- ``contents:write``
+- ``actions:write``
+- ``workflows:write``
+
+When the token-expiration notification is received, generate a replacement
+token with these scopes and send it to Apache INFRA.  INFRA updates the
+``CROSSBOW_GITHUB_TOKEN`` Actions secret.  The replacement also needs to be
+updated in the Crossbow repository and in the Azure Pipelines configuration.
+
 Extended builds
 -----------------------
 


### PR DESCRIPTION
Issue: #51001

Documented the required scopes and replacement process for CROSSBOW_GITHUB_TOKEN used by the Crossbow comment bot.

The documentation explains:
- required GitHub token scopes;
- when to rotate the token;
- that Apache INFRA updates the GitHub Actions secret;
- the additional Crossbow repository and Azure Pipelines updates.

Validation:
- git diff --check

AI assistance was used for repository search and drafting. I reviewed the change against the existing workflow and token-expiration template.