### PR TITLE
GH-51095: [CI][C++] Fix core file detection in run-test.sh

### DIFF
--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -140,13 +140,7 @@ function print_coredumps() {
   FILENAME=$(basename "${TEST_EXECUTABLE}")
   FILENAME=$(echo "${FILENAME}" | cut -c-15)
 
-  COREFILES=(/tmp/"core.${FILENAME}"*)
-  # Clear the array if no core files match the pattern.
-  if [[ "${COREFILES[0]}" == *\* ]]; then
-    COREFILES=()
-  fi
-
-  for COREPATH in "${COREFILES[@]}"; do
+  for COREPATH in "/tmp/core.${FILENAME}"*; do
     if [ ! -e "${COREPATH}" ]; then
       echo "Core file '${COREPATH}' no longer exists. It may have been removed by another process."
       continue

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -140,13 +140,8 @@ function print_coredumps() {
   FILENAME=$(echo "${FILENAME}" | cut -c-15)
 
   for COREPATH in "/tmp/core.${FILENAME}"*; do
-    # Skip if the glob did not match any core files.
-    if [[ "${COREPATH}" == *\* ]]; then
-      continue
-    fi
-
+    # Skip if the glob did not match any core files or the core file has been removed by another process.
     if [ ! -e "${COREPATH}" ]; then
-      echo "Core file '${COREPATH}' no longer exists. It may have been removed by another process."
       continue
     fi
 

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -139,30 +139,19 @@ function print_coredumps() {
   FILENAME=$(basename "${TEST_EXECUTABLE}")
   FILENAME=$(echo "${FILENAME}" | cut -c-15)
 
-  # Use read instead of mapfile because macOS uses Bash 3.2.
-  # A trailing slash is required to follow the /tmp symbolic link on macOS.
-  COREFILES=()
-  while IFS= read -r COREFILE; do
-    COREFILES+=("$COREFILE")
-  done < <(
-    find /tmp/ -maxdepth 1 -type f -name "core.${FILENAME}*"
-  )
-
-  if [ "${#COREFILES[@]}" -gt 0 ]; then
-    for COREPATH in "${COREFILES[@]}"; do
+  COREFILES=$(find /tmp -maxdepth 1 -type f -name "core.${FILENAME}*" -exec basename {} \;)
+  if [ -n "$COREFILES" ]; then
+    for COREFILE in $COREFILES; do
+      COREPATH="/tmp/${COREFILE}"
       echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
       echo "Running '${TEST_EXECUTABLE}' produced core dump at '${COREPATH}', printing backtrace:"
-
       # Print backtrace
       if [ "$(uname)" == "Darwin" ]; then
         lldb -c "${COREPATH}" --batch --one-line "thread backtrace all -e true"
       else
-        gdb -c "${COREPATH}" "$TEST_EXECUTABLE" \
-          -ex "thread apply all bt" -ex "set pagination 0" -batch
+        gdb -c "${COREPATH}" "$TEST_EXECUTABLE" -ex "thread apply all bt" -ex "set pagination 0" -batch
       fi
-
       echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-
       # Remove the coredump, it can be regenerated via running the test case directly
       rm "${COREPATH}"
     done

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -142,7 +142,7 @@ function print_coredumps() {
 
   COREFILES=(/tmp/"core.${FILENAME}"*)
   # Clear the array if no core files match the pattern.
-  if [ ! -e "${COREFILES[0]}" ]; then
+  if [[ "${COREFILES[0]}" == *\* ]]; then
     COREFILES=()
   fi
 

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -139,19 +139,30 @@ function print_coredumps() {
   FILENAME=$(basename "${TEST_EXECUTABLE}")
   FILENAME=$(echo "${FILENAME}" | cut -c-15)
 
-  COREFILES=$(find /tmp -maxdepth 1 -type f -name "core.${FILENAME}*" -exec basename {} \;)
-  if [ -n "$COREFILES" ]; then
-    for COREFILE in $COREFILES; do
-      COREPATH="/tmp/${COREFILE}"
+  # Use read instead of mapfile because macOS uses Bash 3.2.
+  # A trailing slash is required to follow the /tmp symbolic link on macOS.
+  COREFILES=()
+  while IFS= read -r COREFILE; do
+    COREFILES+=("$COREFILE")
+  done < <(
+    find /tmp/ -maxdepth 1 -type f -name "core.${FILENAME}*"
+  )
+
+  if [ "${#COREFILES[@]}" -gt 0 ]; then
+    for COREPATH in "${COREFILES[@]}"; do
       echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
       echo "Running '${TEST_EXECUTABLE}' produced core dump at '${COREPATH}', printing backtrace:"
+
       # Print backtrace
       if [ "$(uname)" == "Darwin" ]; then
         lldb -c "${COREPATH}" --batch --one-line "thread backtrace all -e true"
       else
-        gdb -c "${COREPATH}" "$TEST_EXECUTABLE" -ex "thread apply all bt" -ex "set pagination 0" -batch
+        gdb -c "${COREPATH}" "$TEST_EXECUTABLE" \
+          -ex "thread apply all bt" -ex "set pagination 0" -batch
       fi
+
       echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+
       # Remove the coredump, it can be regenerated via running the test case directly
       rm "${COREPATH}"
     done

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -119,6 +119,7 @@ function run_test() {
 }
 
 function print_coredumps() {
+  STATUS=0
   # The script expects core files relative to the build directory with unique
   # names per test executable because of the parallel running. So the corefile
   # patterns must be set with prefix `core.{test-executable}*`:
@@ -139,23 +140,33 @@ function print_coredumps() {
   FILENAME=$(basename "${TEST_EXECUTABLE}")
   FILENAME=$(echo "${FILENAME}" | cut -c-15)
 
-  COREFILES=$(find /tmp -maxdepth 1 -type f -name "core.${FILENAME}*" -exec basename {} \;)
-  if [ -n "$COREFILES" ]; then
-    for COREFILE in $COREFILES; do
-      COREPATH="/tmp/${COREFILE}"
-      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      echo "Running '${TEST_EXECUTABLE}' produced core dump at '${COREPATH}', printing backtrace:"
-      # Print backtrace
-      if [ "$(uname)" == "Darwin" ]; then
-        lldb -c "${COREPATH}" --batch --one-line "thread backtrace all -e true"
-      else
-        gdb -c "${COREPATH}" "$TEST_EXECUTABLE" -ex "thread apply all bt" -ex "set pagination 0" -batch
-      fi
-      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      # Remove the coredump, it can be regenerated via running the test case directly
-      rm "${COREPATH}"
-    done
+  COREFILES=(/tmp/"core.${FILENAME}"*)
+  # Clear the array if no core files match the pattern.
+  if [ ! -e "${COREFILES[0]}" ]; then
+    COREFILES=()
   fi
+
+  for COREPATH in "${COREFILES[@]}"; do
+    if [ ! -e "${COREPATH}" ]; then
+      echo "Core file '${COREPATH}' no longer exists. It may have been removed by another process."
+      continue
+    fi
+
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo "Running '${TEST_EXECUTABLE}' produced core dump at '${COREPATH}', printing backtrace:"
+    # Print backtrace
+    if [ "$(uname)" == "Darwin" ]; then
+      lldb -c "${COREPATH}" --batch --one-line "thread backtrace all -e true"
+    else
+      gdb -c "${COREPATH}" "$TEST_EXECUTABLE" -ex "thread apply all bt" -ex "set pagination 0" -batch
+    fi
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    # Remove the coredump, it can be regenerated via running the test case directly
+    rm "${COREPATH}"
+
+    # Fail the CI if lldb or gdb was run.
+    STATUS=1
+  done
 }
 
 function post_process_tests() {

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -207,7 +207,7 @@ if [ "$RUN_TYPE" = "test" ]; then
   post_process_tests
 fi
 
-if [ "$STATUS" -ne 0 ] ; then
+if [ "$STATUS" -ne 0 ]; then
   print_coredumps
 fi
 

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -119,7 +119,6 @@ function run_test() {
 }
 
 function print_coredumps() {
-  STATUS=0
   # The script expects core files relative to the build directory with unique
   # names per test executable because of the parallel running. So the corefile
   # patterns must be set with prefix `core.{test-executable}*`:
@@ -141,6 +140,11 @@ function print_coredumps() {
   FILENAME=$(echo "${FILENAME}" | cut -c-15)
 
   for COREPATH in "/tmp/core.${FILENAME}"*; do
+    # Skip if the glob did not match any core files.
+    if [[ "${COREPATH}" == *\* ]]; then
+      continue
+    fi
+
     if [ ! -e "${COREPATH}" ]; then
       echo "Core file '${COREPATH}' no longer exists. It may have been removed by another process."
       continue
@@ -158,8 +162,6 @@ function print_coredumps() {
     # Remove the coredump, it can be regenerated via running the test case directly
     rm "${COREPATH}"
 
-    # Fail the CI if lldb or gdb was run.
-    STATUS=1
   done
 }
 
@@ -205,7 +207,9 @@ if [ "$RUN_TYPE" = "test" ]; then
   post_process_tests
 fi
 
-print_coredumps
+if [ "$STATUS" -ne 0 ] ; then
+  print_coredumps
+fi
 
 popd
 rm -Rf "$TEST_WORKDIR"


### PR DESCRIPTION
### Rationale for this change

In #50934, `find` was used instead of `(ls /tmp | grep $PATTERN)` to find core files in a ShellCheck-safe way, but using find can cause a race condition when files or directories under `/tmp` are removed by another process while find is scanning the directory.

### What changes are included in this PR?

This change uses shell globbing instead of find to avoid this issue.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #51095