### PR TITLE
GH-50314: [C++][Parquet] Reject invalid DELTA_BINARY_PACKED headers

### DIFF
--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -1561,6 +1561,20 @@ class DeltaBitPackDecoder : public TypedDecoderImpl<DType> {
     }
 
     total_values_remaining_ = total_value_count_;
+    // GH-50314: mini_blocks_per_block_ comes from the page header and sizes the
+    // allocation below, while InitBlock() reads one bit-width byte per miniblock.
+    // A count larger than the bytes left can never decode, so we reject it here
+    // instead of allowing it to drive a large allocation. A page holding a single
+    // value keeps that value in the header and never calls InitBlock(), so this
+    // check skips it.
+    if (total_value_count_ > 1 &&
+        static_cast<int64_t>(mini_blocks_per_block_) > decoder_->bytes_left()) {
+      throw ParquetException(
+          "the number of miniblocks per block (" +
+          std::to_string(mini_blocks_per_block_) +
+          ") is larger than the number of bytes remaining in the page (" +
+          std::to_string(decoder_->bytes_left()) + ")");
+    }
     if (delta_bit_widths_ == nullptr) {
       delta_bit_widths_ = AllocateBuffer(pool_, mini_blocks_per_block_);
     } else {

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -1561,25 +1561,22 @@ class DeltaBitPackDecoder : public TypedDecoderImpl<DType> {
     }
 
     total_values_remaining_ = total_value_count_;
-    // GH-50314: mini_blocks_per_block_ comes from the page header and sizes the
-    // allocation below, while InitBlock() reads one bit-width byte per miniblock.
-    // A count larger than the bytes left can never decode, so we reject it here
-    // instead of allowing it to drive a large allocation. A page holding a single
-    // value keeps that value in the header and never calls InitBlock(), so this
-    // check skips it.
-    if (total_value_count_ > 1 &&
-        static_cast<int64_t>(mini_blocks_per_block_) > decoder_->bytes_left()) {
-      throw ParquetException(
-          "the number of miniblocks per block (" +
-          std::to_string(mini_blocks_per_block_) +
-          ") is larger than the number of bytes remaining in the page (" +
-          std::to_string(decoder_->bytes_left()) + ")");
-    }
-    if (delta_bit_widths_ == nullptr) {
-      delta_bit_widths_ = AllocateBuffer(pool_, mini_blocks_per_block_);
-    } else {
-      PARQUET_THROW_NOT_OK(
-          delta_bit_widths_->Resize(mini_blocks_per_block_, /*shrink_to_fit*/ false));
+    if (total_value_count_ > 1) {
+      const int64_t bytes_left = decoder_->bytes_left();
+      const int64_t bit_width_bytes_left = std::max<int64_t>(0, bytes_left - 1);
+      if (static_cast<int64_t>(mini_blocks_per_block_) > bit_width_bytes_left) {
+        throw ParquetException(
+            "the number of miniblocks per block (" +
+            std::to_string(mini_blocks_per_block_) +
+            ") is larger than the number of bytes available for miniblock bit widths (" +
+            std::to_string(bit_width_bytes_left) + ")");
+      }
+      if (delta_bit_widths_ == nullptr) {
+        delta_bit_widths_ = AllocateBuffer(pool_, mini_blocks_per_block_);
+      } else {
+        PARQUET_THROW_NOT_OK(
+            delta_bit_widths_->Resize(mini_blocks_per_block_, /*shrink_to_fit*/ false));
+      }
     }
     first_block_initialized_ = false;
     values_remaining_current_mini_block_ = 0;

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -31,6 +32,7 @@
 #include "arrow/array/builder_dict.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/compute/cast.h"
+#include "arrow/memory_pool.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
@@ -1900,6 +1902,36 @@ TYPED_TEST(TestDeltaBitPackEncoding, BasicRoundTrip) {
         /*null_probability*/ 0.1,
         /*half_range*/ half_range));
   }
+}
+
+TYPED_TEST(TestDeltaBitPackEncoding, SingleValueRoundTrip) {
+  ASSERT_NO_FATAL_FAILURE(this->Execute(1, 1));
+}
+
+TYPED_TEST(TestDeltaBitPackEncoding, RejectsMiniblockWidthsLargerThanInput) {
+  using T = typename TypeParam::c_type;
+
+  // Header: 2^25 values per block, 2^20 miniblocks, 2 values, and first value 0,
+  // followed by min delta 0 and no miniblock bit widths.
+  const std::vector<uint8_t> encoded = {0x80, 0x80, 0x80, 0x10, 0x80,
+                                        0x80, 0x40, 0x02, 0x00, 0x00};
+  ::arrow::ProxyMemoryPool pool(default_memory_pool());
+  auto decoder = MakeTypedDecoder<TypeParam>(Encoding::DELTA_BINARY_PACKED,
+                                             this->descr_.get(), &pool);
+  std::vector<T> decoded(2);
+
+  EXPECT_THROW_THAT(
+      [&] {
+        decoder->SetData(2, encoded.data(), static_cast<int>(encoded.size()));
+        decoder->Decode(decoded.data(), static_cast<int>(decoded.size()));
+      },
+      ParquetException,
+      ::testing::Property(
+          &ParquetException::what,
+          ::testing::HasSubstr(
+              "the number of miniblocks per block (1048576) is larger than the "
+              "number of bytes remaining in the page (1)")));
+  EXPECT_EQ(pool.bytes_allocated(), 0);
 }
 
 TYPED_TEST(TestDeltaBitPackEncoding, NonZeroPaddedMiniblockBitWidth) {

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1904,8 +1904,21 @@ TYPED_TEST(TestDeltaBitPackEncoding, BasicRoundTrip) {
   }
 }
 
-TYPED_TEST(TestDeltaBitPackEncoding, SingleValueRoundTrip) {
-  ASSERT_NO_FATAL_FAILURE(this->Execute(1, 1));
+TYPED_TEST(TestDeltaBitPackEncoding, SingleValueSkipsMiniblockAllocation) {
+  using T = typename TypeParam::c_type;
+
+  // Header: 2^25 values per block, 2^20 miniblocks, 1 value, and first value 0.
+  const std::vector<uint8_t> encoded = {0x80, 0x80, 0x80, 0x10, 0x80,
+                                        0x80, 0x40, 0x01, 0x00};
+  ::arrow::ProxyMemoryPool pool(default_memory_pool());
+  auto decoder = MakeTypedDecoder<TypeParam>(Encoding::DELTA_BINARY_PACKED,
+                                             this->descr_.get(), &pool);
+  T decoded = 1;
+
+  decoder->SetData(1, encoded.data(), static_cast<int>(encoded.size()));
+  ASSERT_EQ(decoder->Decode(&decoded, 1), 1);
+  EXPECT_EQ(decoded, 0);
+  EXPECT_EQ(pool.total_bytes_allocated(), 0);
 }
 
 TYPED_TEST(TestDeltaBitPackEncoding, RejectsMiniblockWidthsLargerThanInput) {
@@ -1930,8 +1943,33 @@ TYPED_TEST(TestDeltaBitPackEncoding, RejectsMiniblockWidthsLargerThanInput) {
           &ParquetException::what,
           ::testing::HasSubstr(
               "the number of miniblocks per block (1048576) is larger than the "
-              "number of bytes remaining in the page (1)")));
-  EXPECT_EQ(pool.bytes_allocated(), 0);
+              "number of bytes available for miniblock bit widths (0)")));
+  EXPECT_EQ(pool.total_bytes_allocated(), 0);
+}
+
+TYPED_TEST(TestDeltaBitPackEncoding, RejectsMiniblockWidthsWithoutMinDelta) {
+  using T = typename TypeParam::c_type;
+
+  // Header: 128 values per block, 1 miniblock, 2 values, and first value 0,
+  // followed by only one byte for the min delta and miniblock bit width.
+  const std::vector<uint8_t> encoded = {0x80, 0x01, 0x01, 0x02, 0x00, 0x00};
+  ::arrow::ProxyMemoryPool pool(default_memory_pool());
+  auto decoder = MakeTypedDecoder<TypeParam>(Encoding::DELTA_BINARY_PACKED,
+                                             this->descr_.get(), &pool);
+  std::vector<T> decoded(2);
+
+  EXPECT_THROW_THAT(
+      [&] {
+        decoder->SetData(2, encoded.data(), static_cast<int>(encoded.size()));
+        decoder->Decode(decoded.data(), static_cast<int>(decoded.size()));
+      },
+      ParquetException,
+      ::testing::Property(
+          &ParquetException::what,
+          ::testing::HasSubstr(
+              "the number of miniblocks per block (1) is larger than the number "
+              "of bytes available for miniblock bit widths (0)")));
+  EXPECT_EQ(pool.total_bytes_allocated(), 0);
 }
 
 TYPED_TEST(TestDeltaBitPackEncoding, NonZeroPaddedMiniblockBitWidth) {


### PR DESCRIPTION
### Rationale for this change

A corrupt DELTA_BINARY_PACKED page can request a miniblock buffer much larger than the page. A single-value page never needs that buffer but still allocated it from the untrusted count.

Fixes https://github.com/apache/arrow/issues/50314.

### What changes are included in this PR?

Skip the buffer for single-value pages and reject impossible miniblock counts before allocation. The size check reserves the required min-delta byte.

### Are these changes tested?

#### Testing Done

This native decoder probe covers a single-value page with an oversized miniblock count and a truncated two-value page. The logging pool exposes allocations made before the decoder rejects the truncated header. Save it as arrow-delta-probe.cc:

```cpp
#include <iostream>
#include <memory_pool.h>
#include <encoding.h>

using arrow::default_memory_pool;

int main(int argc, char**) {
  const uint8_t single[] = {0x80, 0x80, 0x80, 0x10, 0x80, 0x80, 0x40, 0x01, 0x00};
  const uint8_t truncated[] = {0x80, 0x01, 0x01, 0x02, 0x00, 0x00};
  const bool malformed = argc > 1;
  arrow::LoggingMemoryPool pool(default_memory_pool());
  auto decoder = parquet::MakeTypedDecoder<parquet::Int32Type>(
      parquet::Encoding::DELTA_BINARY_PACKED, nullptr, &pool);
  const int expected = malformed ? 2 : 1;
  try {
    decoder->SetData(expected, malformed ? truncated : single,
                     malformed ? sizeof(truncated) : sizeof(single));
    int32_t values[2] = {-1, -1};
    const int count = decoder->Decode(values, expected);
    std::cout << "decoded=" << values[0] << " count=" << count << '\n';
    return malformed || values[0] != 0 || count != expected;
  } catch (const parquet::ParquetException&) {
    std::cout << "ParquetException" << '\n';
    return malformed ? 0 : 1;
  }
}
```

Using a shared Arrow/Parquet build with headers installed under `install`:

```bash
g++ -std=c++20 -I install/include -I install/include/arrow -I install/include/parquet -L build/release arrow-delta-probe.cc -lparquet -larrow -o arrow-delta-probe
export LD_LIBRARY_PATH="$PWD/build/release"
./arrow-delta-probe
./arrow-delta-probe truncated
```

Before:

```text
Allocate: size = 1048576, alignment = 64
decoded=0 count=1
Free: size = 1048576, alignment = 64
Allocate: size = 64, alignment = 64
ParquetException
Free: size = 64, alignment = 64
```

After:

```text
decoded=0 count=1
ParquetException
```

The single value is unchanged, and the malformed header is rejected without allocating its miniblock buffer. The original truncated-page error was `Unexpected end of stream: Decode bit-width EOF`; the new validation identifies the impossible miniblock count and the zero available bit-width bytes.

### Are there any user-facing changes?

Invalid headers fail before allocation. Valid single-value pages decode without allocating a miniblock buffer.

[New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request) |
[Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html) |
[AI-generated Code Guidance](https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code)

### Was AI used for this PR?

AI assisted with the code, regression tests, and description.

**PR code and description written by:**

- [ ] Human
- [x] AI

**Reviewed before submission by:**

- [ ] Human
- [x] AI
- [ ] Not reviewed

* GitHub Issue: #50314