### PR TITLE
GH-51114: [FlightSQL][C++] Expose is_update field of PreparedStatement

### DIFF
--- a/cpp/src/arrow/flight/sql/client.cc
+++ b/cpp/src/arrow/flight/sql/client.cc
@@ -128,12 +128,14 @@ FlightSqlClient::FlightSqlClient(std::shared_ptr<FlightClient> client)
 
 PreparedStatement::PreparedStatement(FlightSqlClient* client, std::string handle,
                                      std::shared_ptr<Schema> dataset_schema,
-                                     std::shared_ptr<Schema> parameter_schema)
+                                     std::shared_ptr<Schema> parameter_schema,
+                                     bool is_update)
     : client_(client),
       handle_(std::move(handle)),
       dataset_schema_(std::move(dataset_schema)),
       parameter_schema_(std::move(parameter_schema)),
-      is_closed_(false) {}
+      is_closed_(false),
+      is_update_(is_update) {}
 
 PreparedStatement::~PreparedStatement() {
   if (IsClosed()) return;
@@ -632,7 +634,8 @@ arrow::Result<std::shared_ptr<PreparedStatement>> PreparedStatement::ParseRespon
   auto handle = prepared_statement_result.prepared_statement_handle();
 
   return std::make_shared<PreparedStatement>(client, handle, dataset_schema,
-                                             parameter_schema);
+                                             parameter_schema,
+                                             prepared_statement_result.is_update());
 }
 
 arrow::Result<std::unique_ptr<FlightInfo>> PreparedStatement::Execute(
@@ -699,6 +702,8 @@ Status PreparedStatement::SetParameters(
 }
 
 bool PreparedStatement::IsClosed() const { return is_closed_; }
+
+bool PreparedStatement::is_update() const { return is_update_; }
 
 const std::shared_ptr<Schema>& PreparedStatement::dataset_schema() const {
   return dataset_schema_;

--- a/cpp/src/arrow/flight/sql/client.cc
+++ b/cpp/src/arrow/flight/sql/client.cc
@@ -129,7 +129,7 @@ FlightSqlClient::FlightSqlClient(std::shared_ptr<FlightClient> client)
 PreparedStatement::PreparedStatement(FlightSqlClient* client, std::string handle,
                                      std::shared_ptr<Schema> dataset_schema,
                                      std::shared_ptr<Schema> parameter_schema,
-                                     bool is_update)
+                                     std::optional<bool> is_update)
     : client_(client),
       handle_(std::move(handle)),
       dataset_schema_(std::move(dataset_schema)),
@@ -633,9 +633,13 @@ arrow::Result<std::shared_ptr<PreparedStatement>> PreparedStatement::ParseRespon
   }
   auto handle = prepared_statement_result.prepared_statement_handle();
 
+  std::optional<bool> is_update = std::nullopt;
+  if (prepared_statement_result.has_is_update()) {
+    is_update = prepared_statement_result.is_update();
+  }
+
   return std::make_shared<PreparedStatement>(client, handle, dataset_schema,
-                                             parameter_schema,
-                                             prepared_statement_result.is_update());
+                                             parameter_schema, is_update);
 }
 
 arrow::Result<std::unique_ptr<FlightInfo>> PreparedStatement::Execute(
@@ -703,7 +707,7 @@ Status PreparedStatement::SetParameters(
 
 bool PreparedStatement::IsClosed() const { return is_closed_; }
 
-bool PreparedStatement::is_update() const { return is_update_; }
+std::optional<bool> PreparedStatement::is_update() const { return is_update_; }
 
 const std::shared_ptr<Schema>& PreparedStatement::dataset_schema() const {
   return dataset_schema_;

--- a/cpp/src/arrow/flight/sql/client.h
+++ b/cpp/src/arrow/flight/sql/client.h
@@ -440,11 +440,11 @@ class ARROW_FLIGHT_SQL_EXPORT PreparedStatement {
   /// \param[in] handle                Handle for this prepared statement.
   /// \param[in] dataset_schema        Schema of the resulting dataset.
   /// \param[in] parameter_schema      Schema of the parameters (if any).
-  /// \param[in] is_update             Whether this is an update query.
+  /// \param[in] is_update             Whether this is an update query (or nullopt if unknown).
   PreparedStatement(FlightSqlClient* client, std::string handle,
                     std::shared_ptr<Schema> dataset_schema,
                     std::shared_ptr<Schema> parameter_schema,
-                    bool is_update = false);
+                    std::optional<bool> is_update = std::nullopt);
 
   /// \brief Default destructor for the PreparedStatement class.
   /// The destructor will call the Close method from the class in order,
@@ -474,8 +474,8 @@ class ARROW_FLIGHT_SQL_EXPORT PreparedStatement {
   /// \return The ResultSet schema from the query.
   const std::shared_ptr<Schema>& dataset_schema() const;
 
-  /// \brief Check if the prepared statement represents an update query.
-  bool is_update() const;
+  /// \brief Check if the prepared statement represents an update query (or nullopt if unknown).
+  std::optional<bool> is_update() const;
 
   /// \brief Set a RecordBatch that contains the parameters that will be bound.
   Status SetParameters(std::shared_ptr<RecordBatch> parameter_binding);
@@ -504,7 +504,7 @@ class ARROW_FLIGHT_SQL_EXPORT PreparedStatement {
   std::shared_ptr<Schema> parameter_schema_;
   std::shared_ptr<RecordBatchReader> parameter_binding_;
   bool is_closed_;
-  bool is_update_;
+  std::optional<bool> is_update_;
 };
 
 /// \brief A handle for a server-side savepoint.

--- a/cpp/src/arrow/flight/sql/client.h
+++ b/cpp/src/arrow/flight/sql/client.h
@@ -442,7 +442,8 @@ class ARROW_FLIGHT_SQL_EXPORT PreparedStatement {
   /// \param[in] parameter_schema      Schema of the parameters (if any).
   PreparedStatement(FlightSqlClient* client, std::string handle,
                     std::shared_ptr<Schema> dataset_schema,
-                    std::shared_ptr<Schema> parameter_schema);
+                    std::shared_ptr<Schema> parameter_schema,
+                    bool is_update = false);
 
   /// \brief Default destructor for the PreparedStatement class.
   /// The destructor will call the Close method from the class in order,
@@ -472,6 +473,9 @@ class ARROW_FLIGHT_SQL_EXPORT PreparedStatement {
   /// \return The ResultSet schema from the query.
   const std::shared_ptr<Schema>& dataset_schema() const;
 
+  /// \brief Check if the prepared statement represents an update query.
+  bool is_update() const;
+
   /// \brief Set a RecordBatch that contains the parameters that will be bound.
   Status SetParameters(std::shared_ptr<RecordBatch> parameter_binding);
 
@@ -499,6 +503,7 @@ class ARROW_FLIGHT_SQL_EXPORT PreparedStatement {
   std::shared_ptr<Schema> parameter_schema_;
   std::shared_ptr<RecordBatchReader> parameter_binding_;
   bool is_closed_;
+  bool is_update_;
 };
 
 /// \brief A handle for a server-side savepoint.

--- a/cpp/src/arrow/flight/sql/client.h
+++ b/cpp/src/arrow/flight/sql/client.h
@@ -440,6 +440,7 @@ class ARROW_FLIGHT_SQL_EXPORT PreparedStatement {
   /// \param[in] handle                Handle for this prepared statement.
   /// \param[in] dataset_schema        Schema of the resulting dataset.
   /// \param[in] parameter_schema      Schema of the parameters (if any).
+  /// \param[in] is_update             Whether this is an update query.
   PreparedStatement(FlightSqlClient* client, std::string handle,
                     std::shared_ptr<Schema> dataset_schema,
                     std::shared_ptr<Schema> parameter_schema,

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -479,8 +479,9 @@ class SQLiteFlightSqlServer::Impl {
     }
 
     std::shared_ptr<Schema> parameter_schema = arrow::schema(parameter_fields);
+    const bool is_update = sqlite3_stmt_readonly(stmt) == 0;
     return ActionCreatePreparedStatementResult{
-        std::move(dataset_schema), std::move(parameter_schema), std::move(handle)};
+        std::move(dataset_schema), std::move(parameter_schema), std::move(handle), is_update};
   }
 
   Status ClosePreparedStatement(const ServerCallContext& context,

--- a/cpp/src/arrow/flight/sql/server.cc
+++ b/cpp/src/arrow/flight/sql/server.cc
@@ -498,6 +498,7 @@ ARROW_UNSUPPRESS_DEPRECATION_WARNING
 arrow::Result<Result> PackActionResult(ActionCreatePreparedStatementResult result) {
   pb::sql::ActionCreatePreparedStatementResult pb_result;
   pb_result.set_prepared_statement_handle(std::move(result.prepared_statement_handle));
+  pb_result.set_is_update(result.is_update);
   if (result.dataset_schema != nullptr) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> serialized,
                           ipc::SerializeSchema(*result.dataset_schema));

--- a/cpp/src/arrow/flight/sql/server.cc
+++ b/cpp/src/arrow/flight/sql/server.cc
@@ -498,7 +498,9 @@ ARROW_UNSUPPRESS_DEPRECATION_WARNING
 arrow::Result<Result> PackActionResult(ActionCreatePreparedStatementResult result) {
   pb::sql::ActionCreatePreparedStatementResult pb_result;
   pb_result.set_prepared_statement_handle(std::move(result.prepared_statement_handle));
-  pb_result.set_is_update(result.is_update);
+  if (result.is_update.has_value()) {
+    pb_result.set_is_update(result.is_update.value());
+  }
   if (result.dataset_schema != nullptr) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> serialized,
                           ipc::SerializeSchema(*result.dataset_schema));

--- a/cpp/src/arrow/flight/sql/server.h
+++ b/cpp/src/arrow/flight/sql/server.h
@@ -241,6 +241,8 @@ struct ARROW_FLIGHT_SQL_EXPORT ActionCreatePreparedStatementResult {
   std::shared_ptr<Schema> parameter_schema;
   /// \brief The server-generated opaque identifier for the statement.
   std::string prepared_statement_handle;
+  /// \brief Whether this prepared statement represents an update query.
+  bool is_update = false;
 };
 
 /// @}

--- a/cpp/src/arrow/flight/sql/server.h
+++ b/cpp/src/arrow/flight/sql/server.h
@@ -241,8 +241,8 @@ struct ARROW_FLIGHT_SQL_EXPORT ActionCreatePreparedStatementResult {
   std::shared_ptr<Schema> parameter_schema;
   /// \brief The server-generated opaque identifier for the statement.
   std::string prepared_statement_handle;
-  /// \brief Whether this prepared statement represents an update query.
-  bool is_update = false;
+  /// \brief Whether this prepared statement represents an update query (or nullopt if unset/unknown).
+  std::optional<bool> is_update = std::nullopt;
 };
 
 /// @}

--- a/cpp/src/arrow/flight/sql/server_test.cc
+++ b/cpp/src/arrow/flight/sql/server_test.cc
@@ -448,6 +448,7 @@ TEST_F(TestFlightSqlServer, TestCommandStatementUpdate) {
 TEST_F(TestFlightSqlServer, TestCommandPreparedStatementQuery) {
   ASSERT_OK_AND_ASSIGN(auto prepared_statement,
                        sql_client->Prepare({}, "SELECT * FROM intTable"));
+  ASSERT_FALSE(prepared_statement->is_update());
 
   ASSERT_OK_AND_ASSIGN(auto flight_info, prepared_statement->Execute());
 
@@ -587,6 +588,7 @@ TEST_F(TestFlightSqlServer, TestCommandPreparedStatementUpdate) {
       auto prepared_statement,
       sql_client->Prepare(
           {}, "INSERT INTO INTTABLE (keyName, value) VALUES ('new_value', 999)"));
+  ASSERT_TRUE(prepared_statement->is_update());
 
   ASSERT_OK_AND_EQ(5, ExecuteCountQuery("SELECT COUNT(*) FROM intTable"));
   ASSERT_OK_AND_EQ(1, prepared_statement->ExecuteUpdate());

--- a/cpp/src/arrow/flight/sql/server_test.cc
+++ b/cpp/src/arrow/flight/sql/server_test.cc
@@ -448,7 +448,7 @@ TEST_F(TestFlightSqlServer, TestCommandStatementUpdate) {
 TEST_F(TestFlightSqlServer, TestCommandPreparedStatementQuery) {
   ASSERT_OK_AND_ASSIGN(auto prepared_statement,
                        sql_client->Prepare({}, "SELECT * FROM intTable"));
-  ASSERT_FALSE(prepared_statement->is_update());
+  ASSERT_EQ(prepared_statement->is_update(), std::optional<bool>(false));
 
   ASSERT_OK_AND_ASSIGN(auto flight_info, prepared_statement->Execute());
 
@@ -588,7 +588,7 @@ TEST_F(TestFlightSqlServer, TestCommandPreparedStatementUpdate) {
       auto prepared_statement,
       sql_client->Prepare(
           {}, "INSERT INTO INTTABLE (keyName, value) VALUES ('new_value', 999)"));
-  ASSERT_TRUE(prepared_statement->is_update());
+  ASSERT_EQ(prepared_statement->is_update(), std::optional<bool>(true));
 
   ASSERT_OK_AND_EQ(5, ExecuteCountQuery("SELECT COUNT(*) FROM intTable"));
   ASSERT_OK_AND_EQ(1, prepared_statement->ExecuteUpdate());

--- a/cpp/src/arrow/flight/sql/server_test.cc
+++ b/cpp/src/arrow/flight/sql/server_test.cc
@@ -598,6 +598,17 @@ TEST_F(TestFlightSqlServer, TestCommandPreparedStatementUpdate) {
   ASSERT_OK_AND_EQ(5, ExecuteCountQuery("SELECT COUNT(*) FROM intTable"));
 }
 
+TEST_F(TestFlightSqlServer, TestCommandPreparedStatementUnsetIsUpdate) {
+  ActionCreatePreparedStatementResult result;
+  result.prepared_statement_handle = "test_handle";
+  ASSERT_FALSE(result.is_update.has_value());
+
+  ASSERT_OK_AND_ASSIGN(auto packed, PackActionResult(result));
+  flight_sql_pb::ActionCreatePreparedStatementResult pb_result;
+  ASSERT_TRUE(pb_result.ParseFromString(packed.body->ToString()));
+  ASSERT_FALSE(pb_result.has_is_update());
+}
+
 TEST_F(TestFlightSqlServer, TestCommandGetPrimaryKeys) {
   FlightCallOptions options = {};
   TableRef table_ref = {std::nullopt, std::nullopt, "int%"};

--- a/cpp/src/arrow/flight/sql/server_test.cc
+++ b/cpp/src/arrow/flight/sql/server_test.cc
@@ -602,11 +602,10 @@ TEST_F(TestFlightSqlServer, TestCommandPreparedStatementUnsetIsUpdate) {
   ActionCreatePreparedStatementResult result;
   result.prepared_statement_handle = "test_handle";
   ASSERT_FALSE(result.is_update.has_value());
+  ASSERT_EQ(result.is_update, std::nullopt);
 
-  ASSERT_OK_AND_ASSIGN(auto packed, PackActionResult(result));
-  flight_sql_pb::ActionCreatePreparedStatementResult pb_result;
-  ASSERT_TRUE(pb_result.ParseFromString(packed.body->ToString()));
-  ASSERT_FALSE(pb_result.has_is_update());
+  PreparedStatement prepared_statement(nullptr, "test_handle", nullptr, nullptr, result.is_update);
+  ASSERT_EQ(prepared_statement.is_update(), std::nullopt);
 }
 
 TEST_F(TestFlightSqlServer, TestCommandGetPrimaryKeys) {


### PR DESCRIPTION
Fixes #51114.

Exposes the `is_update` boolean field in the C++ Flight SQL layer:
- Added `is_update` field to `ActionCreatePreparedStatementResult` in `server.h` and updated `PackActionResult` in `server.cc`.
- Added `bool is_update = false` parameter and `is_update() const` accessor to `PreparedStatement` in `client.h`/`client.cc`.
- Updated `PreparedStatement::ParseResponse` to extract `is_update`.
- Updated SQLite example server (`sqlite_server.cc`) to populate `is_update` via `sqlite3_stmt_readonly`.
- Added assertions in `server_test.cc` for both query (`ASSERT_FALSE`) and update (`ASSERT_TRUE`) prepared statements.
* GitHub Issue: #51114