### PR TITLE
GH-35815: [C++] Provided dictionary support for utf8_trim

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -166,11 +166,11 @@ void MakeUnaryStringBatchKernel(
   ARROW_DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 
-template <template <typename> class ExecFunctor>
+template <template <typename> class ExecFunctor, typename FunctionType = ScalarFunction>
 void MakeUnaryStringBatchKernelWithState(
     std::string name, FunctionRegistry* registry, FunctionDoc doc,
     MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE) {
-  auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), std::move(doc));
+  auto func = std::make_shared<FunctionType>(name, Arity::Unary(), std::move(doc));
   {
     using t32 = ExecFunctor<StringType>;
     ScalarKernel kernel{{utf8()}, utf8(), t32::Exec, t32::State::Init};

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -2471,6 +2471,10 @@ TYPED_TEST(TestStringKernels, TrimUTF8) {
                    "[\"zȺz矢ba\", null, \"\", \"zȺz\"]", &options);
   this->CheckUnary("utf8_rtrim", "[\"azȺz矢ba\", null, \"bab\", \"zȺz\"]", this->type(),
                    "[\"azȺz矢\", null, \"\", \"zȺz\"]", &options);
+  this->CheckUnary("utf8_trim",
+                   ArrayFromJSON(dictionary(int32(), this->type()),
+                                 R"(["azȺz矢ba", null, "bab", "zȺz"])"),
+                   this->type(), R"(["zȺz矢", null, "", "zȺz"])", &options);
 
   options = TrimOptions{"ȺA"};
   this->CheckUnary("utf8_trim", "[\"ȺȺfoo矢ȺAȺ\", null, \"barȺAȺ\", \"ȺAȺfooȺAȺ矢barA\"]",

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -2472,9 +2472,17 @@ TYPED_TEST(TestStringKernels, TrimUTF8) {
   this->CheckUnary("utf8_rtrim", "[\"azȺz矢ba\", null, \"bab\", \"zȺz\"]", this->type(),
                    "[\"azȺz矢\", null, \"\", \"zȺz\"]", &options);
   this->CheckUnary("utf8_trim",
-                   ArrayFromJSON(dictionary(int32(), this->type()),
+                   ArrayFromJSON(dictionary(int64(), this->type()),
                                  R"(["azȺz矢ba", null, "bab", "zȺz"])"),
                    this->type(), R"(["zȺz矢", null, "", "zȺz"])", &options);
+  this->CheckUnary("utf8_ltrim",
+                   ArrayFromJSON(dictionary(int64(), this->type()),
+                                 R"(["azȺz矢ba", null, "bab", "zȺz"])"),
+                   this->type(), R"(["zȺz矢ba", null, "", "zȺz"])", &options);
+  this->CheckUnary("utf8_rtrim",
+                   ArrayFromJSON(dictionary(int64(), this->type()),
+                                 R"(["azȺz矢ba", null, "bab", "zȺz"])"),
+                   this->type(), R"(["azȺz矢", null, "", "zȺz"])", &options);
 
   options = TrimOptions{"ȺA"};
   this->CheckUnary("utf8_trim", "[\"ȺȺfoo矢ȺAȺ\", null, \"barȺAȺ\", \"ȺAȺfooȺAȺ矢barA\"]",

--- a/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
@@ -881,10 +881,32 @@ const FunctionDoc utf8_rtrim_whitespace_doc(
 
 #endif  // ARROW_WITH_UTF8PROC
 
+// Trim functions additionally dispatch dictionary-encoded inputs to the kernel
+// for their value type (the dictionary is then decoded via Cast() before Exec
+// runs), matching CompareFunction/ScalarCTypeToInt64Function elsewhere.
+struct UnaryStringWithDictionaryFunction : public ScalarFunction {
+  using ScalarFunction::ScalarFunction;
+
+  Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* types) const override {
+    RETURN_NOT_OK(CheckArity(types->size()));
+
+    using arrow::compute::detail::DispatchExactImpl;
+    if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
+
+    EnsureDictionaryDecoded(types);
+
+    if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
+    return arrow::compute::detail::NoMatchingKernel(this, *types);
+  }
+};
+
 void AddUtf8StringTrim(FunctionRegistry* registry) {
-  MakeUnaryStringBatchKernelWithState<UTF8Trim>("utf8_trim", registry, utf8_trim_doc);
-  MakeUnaryStringBatchKernelWithState<UTF8LTrim>("utf8_ltrim", registry, utf8_ltrim_doc);
-  MakeUnaryStringBatchKernelWithState<UTF8RTrim>("utf8_rtrim", registry, utf8_rtrim_doc);
+  MakeUnaryStringBatchKernelWithState<UTF8Trim, UnaryStringWithDictionaryFunction>(
+      "utf8_trim", registry, utf8_trim_doc);
+  MakeUnaryStringBatchKernelWithState<UTF8LTrim, UnaryStringWithDictionaryFunction>(
+      "utf8_ltrim", registry, utf8_ltrim_doc);
+  MakeUnaryStringBatchKernelWithState<UTF8RTrim, UnaryStringWithDictionaryFunction>(
+      "utf8_rtrim", registry, utf8_rtrim_doc);
 #ifdef ARROW_WITH_UTF8PROC
   MakeUnaryStringBatchKernel<UTF8TrimWhitespace>("utf8_trim_whitespace", registry,
                                                  utf8_trim_whitespace_doc);


### PR DESCRIPTION
### Rationale for this change

utf8_trim, utf8_ltrim, and utf8_rtrim error out on dictionary encoded string arrays instead of working.

### What changes are included in this PR?

A new ScalarFunction subclass with a DispatchBest mechanism that unwraps a dictionary
to its value type and retries dispatch, and the three trim functions (utf8_trim,
utf8_ltrim, utf8_rtrim) switched over to use it instead of the default.

### Are these changes tested?

These changes are tested. arrow-compute-scalar-type-test (253 tests, including the
new one) passed, and I ran the entire arrow::compute test suite (15 test binaries)
to make sure nothing else broke. pre-commit (C++ Format + C++ Lint) came back clean.

### Are there any user-facing changes?

Yes. The three trim functions now accept dictionary encoded string arrays instead
of raising NotImplemented.

### AI Disclosure

Claude helped and guided me through most of the work: it helped trace the dispatch
mechanism, identified the existing pattern to follow (from scalar_compare.cc), wrote
the implementation and the added test case, and ran the builds and test suites. Claude
also walked me through the mechanism until I understood it. I decided to scope this
to just the three trim functions rather than the whole file, reviewed the diff, and
wrote the commit message and this PR description myself.

* GitHub Issue: #35815
