### PR TITLE
GH-51135: [C++][Parquet] Avoid misaligned stores when reading BYTE_ARRAY decimals

### DIFF
--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -725,9 +725,7 @@ struct DecimalConverter<DecimalArrayType, ByteArrayType> {
         return Status::Invalid("Invalid BYTE_ARRAY length for ", type->ToString());
       }
 
-      auto out_ptr_view = reinterpret_cast<uint64_t*>(out_ptr);
-      out_ptr_view[0] = 0;
-      out_ptr_view[1] = 0;
+      std::memset(out_ptr, 0, type_length);
 
       // only convert rows that are not null if there are nulls, or
       // all rows, if there are not


### PR DESCRIPTION
### Rationale for this change

The BYTE_ARRAY decimal converter always clears 16 bytes through `uint64_t` stores. After Decimal32/64 support was added, Decimal32 output slots can be only 4-byte aligned, causing undefined behavior.

### What changes are included in this PR?

Replace the fixed `uint64_t` stores with `std::memset(out_ptr, 0, type_length)`.

### Are these changes tested?

Yes. The existing Decimal32/64/128/256 BYTE_ARRAY tests all pass. No new test is needed because `TestReadDecimals.Decimal32ByteArray` directly exercises this path.

### Are there any user-facing changes?

No, this is a bug fix.

AI usage: OpenAI Codex was used to investigate and draft this change. The patch was reviewed and tested locally.

* GitHub Issue: #51135