### PR TITLE
GH-51131: [C++][CI] Remove obsolete google-cloud-cpp macOS workaround

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -1007,13 +1007,6 @@ if(ARROW_FILESYSTEM)
                                              "-Wno-documentation;-Wno-documentation-deprecated-sync"
       )
     endif()
-    # Workaround deprecated Abseil APIs used by google-cloud-cpp on macOS
-    # https://github.com/googleapis/google-cloud-cpp/issues/16354
-    if(APPLE)
-      set_property(SOURCE filesystem/gcsfs.cc filesystem/gcsfs_internal.cc
-                   APPEND
-                   PROPERTY COMPILE_OPTIONS "-Wno-error=deprecated-declarations")
-    endif()
   endif()
   if(ARROW_HDFS)
     list(APPEND ARROW_FILESYSTEM_SRCS filesystem/hdfs.cc)


### PR DESCRIPTION
### Rationale for this change

Issue #51131 tracks removal of the macOS compiler-warning workaround added for deprecated Abseil APIs in google-cloud-cpp. The upstream google-cloud-cpp fix referenced by the issue has now merged.

### What changes are included in this PR?

Remove the APPLE-specific `-Wno-error=deprecated-declarations` compile option from the GCS filesystem sources. The existing documentation-warning options and unrelated Windows/reproducible-build workarounds are unchanged.

Closes #51131

### Are these changes tested?

- `git diff HEAD^ HEAD --check`
- CMake configuration could not run because CMake is not installed in the local environment.

### Are there any user-facing changes?

No.

### AI-assisted contribution

An AI coding assistant was used to help prepare this patch. The final change was kept to the single workaround requested by the issue and the exact diff was checked before publication; no third-party code or generated material was copied.
* GitHub Issue: #51131