### PR TITLE
GH-47393: [C++][Acero] Support for multi threaded input: SortedMergeNode Version 2

### DIFF
--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -259,7 +259,7 @@ class InputState final : public util::SerialSequencingQueue::Processor {
 
   FlowAction BatchBuffered();
   FlowAction BatchConsumed();
-  FlowAction Shutdown();
+  void Shutdown();
 
  private:
   FlowAction SetUpstreamPausedUnlocked(bool paused);
@@ -653,7 +653,7 @@ class SortedMergeNode : public ExecNode {
 
   Status FinishNormally() {
     for (auto& input : state_) {
-      input->Shutdown().Apply();
+      input->Shutdown();
     }
     return output_->InputFinished(this, batches_produced_);
   }
@@ -668,7 +668,7 @@ class SortedMergeNode : public ExecNode {
       }
     }
     for (auto& input : state_) {
-      input->Shutdown().Apply();
+      input->Shutdown();
     }
   }
 
@@ -781,16 +781,13 @@ FlowAction InputState::BatchConsumed() {
                                             : FlowAction{};
 }
 
-FlowAction InputState::Shutdown() {
+void InputState::Shutdown() {
   std::lock_guard lock(flow_mutex_);
   if (shutdown_) {
-    return {};
+    return;
   }
   shutdown_ = true;
-  upstream_paused_ = false;
   buffered_batches_ = 0;
-  // Always send a final, newer resume so a delayed pause cannot strand an input.
-  return {FlowAction::Kind::Resume, input_, node_, ++outgoing_counter_};
 }
 
 }  // namespace

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -308,7 +308,7 @@ enum class MergeState { Idle, Running, Terminal };
 enum class OutputGate { Open, Paused, Flushing };
 
 class SortedMergeNode : public ExecNode {
-  static constexpr int64_t kTargetOutputBatchSize = 1024 * 1024;
+  static constexpr int64_t kTargetOutputBatchSize = ExecPlan::kMaxBatchSize;
 
  public:
   SortedMergeNode(arrow::acero::ExecPlan* plan,

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -440,6 +440,7 @@ class SortedMergeNode : public ExecNode {
 
   void ResumeProducing(arrow::acero::ExecNode* output, int32_t counter) override {
     std::optional<Task> task;
+    Future<> handoff;
     {
       std::lock_guard lock(coordinator_mutex_);
       if (merge_state_ == MergeState::Terminal || counter <= downstream_counter_) {
@@ -450,9 +451,22 @@ class SortedMergeNode : public ExecNode {
         output_gate_ = OutputGate::Open;
       }
       task = MaybeStartUnlocked();
+      if (task) {
+        // Resume may be called outside the scheduler by a consuming sink.  Reserve a
+        // scheduler task before releasing the coordinator lock so a concurrent final
+        // InputFinished cannot end the scheduler before the drain is registered.
+        auto maybe_handoff =
+            plan()->query_context()->BeginExternalTask("SortedMergeNode::ResumeHandoff");
+        if (!maybe_handoff.ok() || !maybe_handoff->is_valid()) {
+          merge_state_ = MergeState::Idle;
+          return;
+        }
+        handoff = std::move(*maybe_handoff);
+      }
     }
     if (task) {
       Schedule(std::move(*task), "SortedMergeNode::Resume");
+      handoff.MarkFinished();
     }
   }
 

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -15,36 +15,34 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <any>
+#include <algorithm>
 #include <atomic>
+#include <deque>
+#include <limits>
+#include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
-#include <thread>
-#include <tuple>
-#include <unordered_map>
+#include <string_view>
+#include <utility>
 #include <vector>
 
-#include "arrow/acero/concurrent_queue_internal.h"
+#include "arrow/acero/accumulation_queue.h"
 #include "arrow/acero/exec_plan.h"
 #include "arrow/acero/exec_plan_internal.h"
 #include "arrow/acero/options.h"
 #include "arrow/acero/query_context.h"
 #include "arrow/acero/time_series_util.h"
-#include "arrow/acero/unmaterialized_table_internal.h"
 #include "arrow/acero/util.h"
 #include "arrow/array/builder_base.h"
+#include "arrow/array/util.h"
 #include "arrow/result.h"
 #include "arrow/type_fwd.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging_internal.h"
 
 namespace {
-template <typename Callable>
-struct Defer {
-  Callable callable;
-  explicit Defer(Callable callable_) : callable(std::move(callable_)) {}
-  ~Defer() noexcept { callable(); }
-};
-
 std::vector<std::string> GetInputLabels(
     const arrow::acero::ExecNode::NodeVector& inputs) {
   std::vector<std::string> labels(inputs.size());
@@ -54,204 +52,260 @@ std::vector<std::string> GetInputLabels(
   return labels;
 }
 
-template <typename T, typename V = typename T::value_type>
-inline typename T::const_iterator std_find(const T& container, const V& val) {
-  return std::find(container.begin(), container.end(), val);
-}
-
-template <typename T, typename V = typename T::value_type>
-inline bool std_has(const T& container, const V& val) {
-  return container.end() != std_find(container, val);
-}
-
 }  // namespace
 
 namespace arrow::acero {
 
 namespace {
 
-// Each slice is associated with a single input source, so we only need 1 record
-// batch per slice
-using SingleRecordBatchSliceBuilder = arrow::acero::UnmaterializedSliceBuilder<1>;
-using SingleRecordBatchCompositeTable = arrow::acero::UnmaterializedCompositeTable<1>;
-
 using row_index_t = uint64_t;
 using time_unit_t = uint64_t;
 using col_index_t = int;
+using Task = util::SequencingQueue::Task;
 
-constexpr bool kNewTask = true;
-constexpr bool kPoisonPill = false;
+template <Type::type kTypeId>
+Result<std::optional<time_unit_t>> ReadTimeValue(const Datum& value, int64_t row) {
+  using ArrowType = typename TypeIdTraits<kTypeId>::Type;
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
 
-class BackpressureController : public BackpressureControl {
- public:
-  BackpressureController(ExecNode* node, ExecNode* output,
-                         std::atomic<int32_t>& backpressure_counter)
-      : node_(node), output_(output), backpressure_counter_(backpressure_counter) {}
+  if (value.is_scalar()) {
+    const auto& scalar =
+        ::arrow::internal::checked_cast<const ScalarType&>(*value.scalar());
+    if (!scalar.is_valid) {
+      return std::nullopt;
+    }
+    return NormalizeTime(static_cast<CType>(scalar.value));
+  }
+  if (value.is_array()) {
+    ArraySpan array(*value.array());
+    if (array.IsNull(row)) {
+      return std::nullopt;
+    }
+    return NormalizeTime(array.GetValues<CType>(1)[row]);
+  }
+  return Status::Invalid("SortedMerge sort key must be an array or scalar, but got ",
+                         ::arrow::ToString(value.kind()));
+}
 
-  void Pause() override { node_->PauseProducing(output_, ++backpressure_counter_); }
-  void Resume() override { node_->ResumeProducing(output_, ++backpressure_counter_); }
+Result<std::optional<time_unit_t>> ReadTimeValue(const Datum& value, int64_t row) {
+  switch (value.type()->id()) {
+#define SORTED_MERGE_TIME_CASE(ID) \
+  case Type::ID:                   \
+    return ReadTimeValue<Type::ID>(value, row)
+    SORTED_MERGE_TIME_CASE(INT8);
+    SORTED_MERGE_TIME_CASE(INT16);
+    SORTED_MERGE_TIME_CASE(INT32);
+    SORTED_MERGE_TIME_CASE(INT64);
+    SORTED_MERGE_TIME_CASE(UINT8);
+    SORTED_MERGE_TIME_CASE(UINT16);
+    SORTED_MERGE_TIME_CASE(UINT32);
+    SORTED_MERGE_TIME_CASE(UINT64);
+    SORTED_MERGE_TIME_CASE(DATE32);
+    SORTED_MERGE_TIME_CASE(DATE64);
+    SORTED_MERGE_TIME_CASE(TIME32);
+    SORTED_MERGE_TIME_CASE(TIME64);
+    SORTED_MERGE_TIME_CASE(TIMESTAMP);
+#undef SORTED_MERGE_TIME_CASE
+    default:
+      return Status::Invalid("Unsupported SortedMerge sort-key type ",
+                             value.type()->ToString());
+  }
+}
 
- private:
-  ExecNode* node_;
-  ExecNode* output_;
-  std::atomic<int32_t>& backpressure_counter_;
+bool TimeIsLater(const std::optional<time_unit_t>& left,
+                 const std::optional<time_unit_t>& right,
+                 compute::NullPlacement null_placement) {
+  if (left && right) {
+    return *left > *right;
+  }
+  if (!left && !right) {
+    return false;
+  }
+  return null_placement == compute::NullPlacement::AtStart ? left.has_value()
+                                                           : !left.has_value();
+}
+
+struct PreparedBatch {
+  ExecBatch batch;
+  std::vector<std::optional<time_unit_t>> times;
 };
 
-/// InputState corresponds to an input. Input record batches are queued up in InputState
-/// until processed and turned into output record batches.
-class InputState {
+struct SelectionRun {
+  std::shared_ptr<PreparedBatch> source;
+  int64_t offset;
+  int64_t length;
+};
+
+struct Selection {
+  std::vector<SelectionRun> runs;
+  int64_t length = 0;
+
+  void Append(std::shared_ptr<PreparedBatch> source, int64_t offset, int64_t run_length) {
+    runs.push_back({std::move(source), offset, run_length});
+    length += run_length;
+  }
+
+  bool empty() const { return runs.empty(); }
+};
+
+struct FlowAction {
+  enum class Kind { None, Pause, Resume };
+
+  void Apply() const {
+    if (kind == Kind::Pause) {
+      input->PauseProducing(output, counter);
+    } else if (kind == Kind::Resume) {
+      input->ResumeProducing(output, counter);
+    }
+  }
+
+  Kind kind = Kind::None;
+  ExecNode* input = nullptr;
+  ExecNode* output = nullptr;
+  int32_t counter = 0;
+};
+
+class SortedMergeNode;
+
+/// Sequences and buffers one sorted input.  Buffer contents and row position are
+/// protected by SortedMergeNode's coordinator mutex; flow-control state uses its own
+/// lock because it is touched before and after coordinator work.
+class InputState final : public util::SerialSequencingQueue::Processor {
  public:
-  InputState(size_t index, BackpressureHandler handler,
-             const std::shared_ptr<arrow::Schema>& schema, const int time_col_index)
-      : index_(index),
-        queue_(std::move(handler)),
-        schema_(schema),
-        time_col_index_(time_col_index),
-        time_type_id_(schema_->fields()[time_col_index_]->type()->id()) {}
+  InputState(SortedMergeNode* node, size_t index, ExecNode* input,
+             col_index_t time_col_index, compute::NullPlacement null_placement);
 
-  template <typename PtrType>
-  static arrow::Result<PtrType> Make(size_t index, arrow::acero::ExecNode* input,
-                                     arrow::acero::ExecNode* output,
-                                     std::atomic<int32_t>& backpressure_counter,
-                                     const std::shared_ptr<arrow::Schema>& schema,
-                                     const col_index_t time_col_index) {
-    constexpr size_t low_threshold = 4, high_threshold = 8;
-    std::unique_ptr<arrow::acero::BackpressureControl> backpressure_control =
-        std::make_unique<BackpressureController>(input, output, backpressure_counter);
-    ARROW_ASSIGN_OR_RAISE(auto handler,
-                          BackpressureHandler::Make(low_threshold, high_threshold,
-                                                    std::move(backpressure_control)));
-    return PtrType(new InputState(index, std::move(handler), schema, time_col_index));
+  Status InsertBatch(ExecBatch batch);
+  Status Process(ExecBatch batch) override;
+
+  // The methods below are called only while the node's coordinator mutex is held.
+  bool HasData() const { return !batches_.empty(); }
+  bool AllBatchesReceived() const {
+    return total_batches_ && received_batches_ == *total_batches_;
+  }
+  bool Finished() const { return AllBatchesReceived() && !HasData(); }
+
+  const std::shared_ptr<PreparedBatch>& GetLatestBatch() const {
+    DCHECK(HasData());
+    return batches_.front();
   }
 
-  bool IsTimeColumn(col_index_t i) const {
-    DCHECK_LT(i, schema_->num_fields());
-    return (i == time_col_index_);
+  const std::optional<time_unit_t>& GetLatestTime() const {
+    return GetLatestBatch()->times[latest_ref_row_];
   }
 
-  // Gets the latest row index, assuming the queue isn't empty
-  row_index_t GetLatestRow() const { return latest_ref_row_; }
+  bool Advance(const std::optional<time_unit_t>* upper_bound, int64_t max_length,
+               Selection* selection) {
+    DCHECK(HasData());
+    DCHECK_GT(max_length, 0);
+    const row_index_t start = latest_ref_row_;
+    std::shared_ptr<PreparedBatch> batch = batches_.front();
+    const row_index_t rows_in_batch = static_cast<row_index_t>(batch->batch.length);
+    const row_index_t limit =
+        std::min(rows_in_batch, start + static_cast<row_index_t>(max_length));
 
-  bool Empty() const {
-    // cannot be empty if ref row is >0 -- can avoid slow queue lock
-    // below
-    if (latest_ref_row_ > 0) {
-      return false;
+    while (latest_ref_row_ < limit &&
+           (upper_bound == nullptr ||
+            !TimeIsLater(GetLatestTime(), *upper_bound, null_placement_))) {
+      ++latest_ref_row_;
     }
-    return queue_.Empty();
-  }
-
-  size_t index() const { return index_; }
-
-  int total_batches() const { return total_batches_; }
-
-  // Gets latest batch (precondition: must not be empty)
-  const std::shared_ptr<arrow::RecordBatch>& GetLatestBatch() const {
-    return queue_.Front();
-  }
-
-#define LATEST_VAL_CASE(id, val)                                   \
-  case arrow::Type::id: {                                          \
-    using T = typename arrow::TypeIdTraits<arrow::Type::id>::Type; \
-    using CType = typename arrow::TypeTraits<T>::CType;            \
-    return val(data->GetValues<CType>(1)[row]);                    \
-  }
-
-  inline time_unit_t GetLatestTime() const {
-    return GetTime(GetLatestBatch().get(), time_type_id_, time_col_index_,
-                   latest_ref_row_);
-  }
-
-#undef LATEST_VAL_CASE
-
-  bool Finished() const { return batches_processed_ == total_batches_; }
-
-  void Advance(SingleRecordBatchSliceBuilder& builder) {
-    // Advance the row until a new time is encountered or the record batch
-    // ends. This will return a range of {-1, -1} and a nullptr if there is
-    // no input
-    bool active =
-        (latest_ref_row_ > 0 /*short circuit the lock on the queue*/) || !queue_.Empty();
-
-    if (!active) {
-      return;
+    DCHECK_GT(latest_ref_row_, start);
+    selection->Append(batch, static_cast<int64_t>(start),
+                      static_cast<int64_t>(latest_ref_row_ - start));
+    if (latest_ref_row_ >= rows_in_batch) {
+      latest_ref_row_ = 0;
+      batches_.pop_front();
+      return true;
     }
-
-    row_index_t start = latest_ref_row_;
-    row_index_t end = latest_ref_row_;
-    time_unit_t startTime = GetLatestTime();
-    std::shared_ptr<arrow::RecordBatch> batch = queue_.Front();
-    auto rows_in_batch = (row_index_t)batch->num_rows();
-
-    while (GetLatestTime() == startTime) {
-      end = ++latest_ref_row_;
-      if (latest_ref_row_ >= rows_in_batch) {
-        // hit the end of the batch, need to get the next batch if
-        // possible.
-        ++batches_processed_;
-        latest_ref_row_ = 0;
-        active &= !queue_.TryPop();
-        if (active) {
-          DCHECK_GT(queue_.Front()->num_rows(),
-                    0);  // empty batches disallowed, sanity check
-        }
-        break;
-      }
-    }
-    builder.AddEntry(batch, start, end);
+    return false;
   }
 
-  arrow::Status Push(const std::shared_ptr<arrow::RecordBatch>& rb) {
-    if (rb->num_rows() > 0) {
-      queue_.Push(rb);
-    } else {
-      ++batches_processed_;  // don't enqueue empty batches, just record
-                             // as processed
+  Status PushSequenced(std::shared_ptr<PreparedBatch> batch) {
+    if (total_batches_ && received_batches_ >= *total_batches_) {
+      return Status::Invalid("SortedMerge input ", index_,
+                             " produced more batches than declared");
     }
-    return arrow::Status::OK();
+    ++received_batches_;
+    if (batch->batch.length > 0) {
+      batches_.push_back(std::move(batch));
+    }
+    return Status::OK();
   }
 
-  const std::shared_ptr<arrow::Schema>& get_schema() const { return schema_; }
+  Status SetTotal(int total_batches) {
+    if (total_batches < 0) {
+      return Status::Invalid("SortedMerge input ", index_,
+                             " reported a negative batch count");
+    }
+    if (total_batches_) {
+      return *total_batches_ == total_batches
+                 ? Status::OK()
+                 : Status::Invalid("SortedMerge input ", index_,
+                                   " changed its total batch count");
+    }
+    if (received_batches_ > total_batches) {
+      return Status::Invalid("SortedMerge input ", index_,
+                             " declared fewer batches than it produced");
+    }
+    total_batches_ = total_batches;
+    return Status::OK();
+  }
 
-  void set_total_batches(int n) { total_batches_ = n; }
+  void ClearBuffered() {
+    batches_.clear();
+    latest_ref_row_ = 0;
+  }
+
+  FlowAction BatchBuffered();
+  FlowAction BatchConsumed();
+  FlowAction Shutdown();
 
  private:
+  FlowAction SetUpstreamPausedUnlocked(bool paused);
+  Result<std::shared_ptr<PreparedBatch>> PrepareBatch(ExecBatch batch);
+  Status ValidateTime(const std::optional<time_unit_t>& time);
+
+  static constexpr size_t kLowWatermark = 4;
+  static constexpr size_t kHighWatermark = 8;
+
+  SortedMergeNode* node_;
   size_t index_;
-  // Pending record batches. The latest is the front. Batches cannot be empty.
-  BackpressureConcurrentQueue<std::shared_ptr<arrow::RecordBatch>> queue_;
-  // Schema associated with the input
-  std::shared_ptr<arrow::Schema> schema_;
-  // Total number of batches (only int because InputFinished uses int)
-  std::atomic<int> total_batches_{-1};
-  // Number of batches processed so far (only int because InputFinished uses
-  // int)
-  std::atomic<int> batches_processed_{0};
-  // Index of the time col
+  ExecNode* input_;
   col_index_t time_col_index_;
-  // Type id of the time column
-  arrow::Type::type time_type_id_;
-  // Index of the latest row reference within; if >0 then queue_ cannot be
-  // empty Must be < queue_.front()->num_rows() if queue_ is non-empty
+  compute::NullPlacement null_placement_;
+
+  std::unique_ptr<util::SerialSequencingQueue> sequencer_;
+
+  std::deque<std::shared_ptr<PreparedBatch>> batches_;
+  int received_batches_ = 0;
+  std::optional<int> total_batches_;
   row_index_t latest_ref_row_ = 0;
-  // Time of latest row
-  time_unit_t latest_time_ = std::numeric_limits<time_unit_t>::lowest();
+
+  std::optional<time_unit_t> last_time_;
+  bool saw_null_ = false;
+  bool saw_non_null_ = false;
+
+  std::mutex flow_mutex_;
+  size_t buffered_batches_ = 0;
+  bool upstream_paused_ = false;
+  int32_t outgoing_counter_ = 0;
+  bool shutdown_ = false;
 };
 
 struct InputStateComparator {
-  bool operator()(const std::shared_ptr<InputState>& lhs,
-                  const std::shared_ptr<InputState>& rhs) const {
-    // True if lhs is ahead of time of rhs
-    if (lhs->Finished()) {
-      return false;
-    }
-    if (rhs->Finished()) {
-      return false;
-    }
-    time_unit_t lFirst = lhs->GetLatestTime();
-    time_unit_t rFirst = rhs->GetLatestTime();
-    return lFirst > rFirst;
+  explicit InputStateComparator(compute::NullPlacement null_placement)
+      : null_placement(null_placement) {}
+
+  bool operator()(const InputState* lhs, const InputState* rhs) const {
+    return TimeIsLater(lhs->GetLatestTime(), rhs->GetLatestTime(), null_placement);
   }
+
+  compute::NullPlacement null_placement;
 };
+
+enum class MergeState { Idle, Running, Terminal };
+enum class OutputGate { Open, Paused, Flushing };
 
 class SortedMergeNode : public ExecNode {
   static constexpr int64_t kTargetOutputBatchSize = 1024 * 1024;
@@ -262,24 +316,8 @@ class SortedMergeNode : public ExecNode {
                   std::shared_ptr<arrow::Schema> output_schema,
                   arrow::Ordering new_ordering)
       : ExecNode(plan, inputs, GetInputLabels(inputs), std::move(output_schema)),
-        ordering_(std::move(new_ordering)),
-        input_counter(inputs_.size()),
-        output_counter(inputs_.size())
-#ifdef ARROW_ENABLE_THREADING
-        ,
-        process_thread()
-#endif
-  {
+        ordering_(std::move(new_ordering)) {
     SetLabel("sorted_merge");
-  }
-
-  ~SortedMergeNode() override {
-    PushTask(kPoisonPill);
-#ifdef ARROW_ENABLE_THREADING
-    if (process_thread.joinable()) {
-      process_thread.join();
-    }
-#endif
   }
 
   static arrow::Result<arrow::acero::ExecNode*> Make(
@@ -320,17 +358,19 @@ class SortedMergeNode : public ExecNode {
   const arrow::Ordering& ordering() const override { return ordering_; }
 
   arrow::Status Init() override {
-    ARROW_CHECK(ordering_.sort_keys().size() == 1) << "Only one sort key supported";
+    if (ordering_.sort_keys().size() != 1) {
+      return Status::NotImplemented("SortedMerge supports exactly one sort key");
+    }
+
+    const auto& sort_key = ordering_.sort_keys()[0];
+    if (sort_key.order != arrow::compute::SortOrder::Ascending) {
+      return Status::NotImplemented("Only ascending sort order is supported");
+    }
 
     auto inputs = this->inputs();
     for (size_t i = 0; i < inputs.size(); i++) {
       ExecNode* input = inputs[i];
       const auto& schema = input->output_schema();
-
-      const auto& sort_key = ordering_.sort_keys()[0];
-      if (sort_key.order != arrow::compute::SortOrder::Ascending) {
-        return Status::NotImplemented("Only ascending sort order is supported");
-      }
 
       const FieldRef& ref = sort_key.target;
       auto match_res = ref.FindOne(*schema);
@@ -340,83 +380,97 @@ class SortedMergeNode : public ExecNode {
       ARROW_ASSIGN_OR_RAISE(auto match, match_res);
       ARROW_DCHECK(match.indices().size() == 1);
 
-      ARROW_ASSIGN_OR_RAISE(auto input_state,
-                            InputState::Make<std::shared_ptr<InputState>>(
-                                i, input, this, backpressure_counter, schema,
-                                std::move(match.indices()[0])));
-      state.push_back(std::move(input_state));
+      state_.push_back(std::make_unique<InputState>(
+          this, i, input, std::move(match.indices()[0]), sort_key.null_placement));
     }
     return Status::OK();
   }
 
   arrow::Status InputReceived(arrow::acero::ExecNode* input,
                               arrow::ExecBatch batch) override {
-    ARROW_DCHECK(std_has(inputs_, input));
-    const size_t index = std_find(inputs_, input) - inputs_.begin();
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> rb,
-                          batch.ToRecordBatch(output_schema_));
-
-    // Push into the queue. Note that we don't need to lock since
-    // InputState's ConcurrentQueue manages locking
-    input_counter[index] += rb->num_rows();
-    ARROW_RETURN_NOT_OK(state[index]->Push(rb));
-    PushTask(kNewTask);
-    return Status::OK();
-  }
-
-  void PushTask(bool ok) {
-#ifdef ARROW_ENABLE_THREADING
-    process_queue.Push(ok);
-#else
-    if (process_task.is_finished()) {
-      return;
+    if (terminal_.load()) {
+      return Status::OK();
     }
-    if (ok == kNewTask) {
-      PollOnce();
-    } else {
-      EndFromProcessThread();
+    auto it = std::find(inputs_.begin(), inputs_.end(), input);
+    if (it == inputs_.end()) {
+      return Status::Invalid("SortedMerge received a batch from an unknown input");
     }
-#endif
+    const size_t index = static_cast<size_t>(it - inputs_.begin());
+    return state_[index]->InsertBatch(std::move(batch));
   }
 
   arrow::Status InputFinished(arrow::acero::ExecNode* input, int total_batches) override {
-    ARROW_DCHECK(std_has(inputs_, input));
-    {
-      std::lock_guard<std::mutex> guard(gate);
-      ARROW_DCHECK(std_has(inputs_, input));
-      size_t k = std_find(inputs_, input) - inputs_.begin();
-      state.at(k)->set_total_batches(total_batches);
-    }
-    // Trigger a final process call for stragglers
-    PushTask(kNewTask);
-
-    return Status::OK();
-  }
-
-  arrow::Status StartProducing() override {
-    ARROW_ASSIGN_OR_RAISE(process_task, plan_->query_context()->BeginExternalTask(
-                                            "SortedMergeNode::ProcessThread"));
-    if (!process_task.is_valid()) {
-      // Plan has already aborted.  Do not start process thread
+    if (terminal_.load()) {
       return Status::OK();
     }
-#ifdef ARROW_ENABLE_THREADING
-    process_thread = std::thread(&SortedMergeNode::StartPoller, this);
-#endif
-    return Status::OK();
+    auto it = std::find(inputs_.begin(), inputs_.end(), input);
+    if (it == inputs_.end()) {
+      return Status::Invalid("SortedMerge received completion from an unknown input");
+    }
+    const size_t index = static_cast<size_t>(it - inputs_.begin());
+    std::optional<Task> task;
+    {
+      std::lock_guard lock(coordinator_mutex_);
+      if (merge_state_ == MergeState::Terminal) {
+        return Status::OK();
+      }
+      ARROW_RETURN_NOT_OK(state_[index]->SetTotal(total_batches));
+      task = MaybeStartUnlocked();
+    }
+    return task ? std::move(*task)() : Status::OK();
   }
+
+  arrow::Status StartProducing() override { return Status::OK(); }
 
   arrow::Status StopProducingImpl() override {
-#ifdef ARROW_ENABLE_THREADING
-    process_queue.Clear();
-#endif
-    PushTask(kPoisonPill);
+    EnterTerminal();
     return Status::OK();
   }
 
-  // handled by the backpressure controller
-  void PauseProducing(arrow::acero::ExecNode* output, int32_t counter) override {}
-  void ResumeProducing(arrow::acero::ExecNode* output, int32_t counter) override {}
+  void PauseProducing(arrow::acero::ExecNode* output, int32_t counter) override {
+    std::lock_guard lock(coordinator_mutex_);
+    if (merge_state_ == MergeState::Terminal || counter <= downstream_counter_) {
+      return;
+    }
+    downstream_counter_ = counter;
+    if (output_gate_ != OutputGate::Flushing) {
+      output_gate_ = OutputGate::Paused;
+    }
+  }
+
+  void ResumeProducing(arrow::acero::ExecNode* output, int32_t counter) override {
+    std::optional<Task> task;
+    {
+      std::lock_guard lock(coordinator_mutex_);
+      if (merge_state_ == MergeState::Terminal || counter <= downstream_counter_) {
+        return;
+      }
+      downstream_counter_ = counter;
+      if (output_gate_ != OutputGate::Flushing) {
+        output_gate_ = OutputGate::Open;
+      }
+      task = MaybeStartUnlocked();
+    }
+    if (task) {
+      Schedule(std::move(*task), "SortedMergeNode::Resume");
+    }
+  }
+
+  void Schedule(Task task, std::string_view name = "SortedMergeNode::Merge") {
+    plan()->query_context()->ScheduleTask(std::move(task), name);
+  }
+
+  Result<std::optional<Task>> OnSequenced(size_t input_index,
+                                          std::shared_ptr<PreparedBatch> batch) {
+    std::lock_guard lock(coordinator_mutex_);
+    if (merge_state_ == MergeState::Terminal) {
+      return std::nullopt;
+    }
+    ARROW_RETURN_NOT_OK(state_[input_index]->PushSequenced(std::move(batch)));
+    return MaybeStartUnlocked();
+  }
+
+  bool IsTerminal() const { return terminal_.load(); }
 
  protected:
   std::string ToStringExtra(int indent) const override {
@@ -426,213 +480,318 @@ class SortedMergeNode : public ExecNode {
   }
 
  private:
-  void EndFromProcessThread(arrow::Status st = arrow::Status::OK()) {
-    ARROW_CHECK(!cleanup_started);
-    for (size_t i = 0; i < input_counter.size(); ++i) {
-      ARROW_CHECK(input_counter[i] == output_counter[i])
-          << input_counter[i] << " != " << output_counter[i];
+  void MaybeEnterFlushingUnlocked() {
+    if (std::all_of(state_.begin(), state_.end(),
+                    [](const auto& input) { return input->AllBatchesReceived(); })) {
+      output_gate_ = OutputGate::Flushing;
     }
-
-#ifdef ARROW_ENABLE_THREADING
-    ARROW_UNUSED(
-        plan_->query_context()->executor()->Spawn([this, st = std::move(st)]() mutable {
-          Defer cleanup([this, &st]() { process_task.MarkFinished(st); });
-          if (st.ok()) {
-            st = output_->InputFinished(this, batches_produced);
-          }
-        }));
-#else
-    process_task.MarkFinished(st);
-    if (st.ok()) {
-      st = output_->InputFinished(this, batches_produced);
-    }
-#endif
   }
 
-  bool CheckEnded() {
-    bool all_finished = true;
-    for (const auto& s : state) {
-      all_finished &= s->Finished();
-    }
-    if (all_finished) {
-      EndFromProcessThread();
-      return false;
-    }
-    return true;
+  bool CanProgressUnlocked() const {
+    return std::all_of(state_.begin(), state_.end(), [](const auto& input) {
+      return input->HasData() || input->Finished();
+    });
   }
 
-  /// Streams the input states in sorted order until we run out of input
-  arrow::Result<std::shared_ptr<arrow::RecordBatch>> getNextBatch() {
-    DCHECK(!state.empty());
-    for (const auto& s : state) {
-      if (s->Empty() && !s->Finished()) {
-        return nullptr;  // not enough data, wait
+  bool FinishedUnlocked() const {
+    return std::all_of(state_.begin(), state_.end(),
+                       [](const auto& input) { return input->Finished(); });
+  }
+
+  std::optional<Task> MaybeStartUnlocked() {
+    MaybeEnterFlushingUnlocked();
+    if (merge_state_ != MergeState::Idle || output_gate_ == OutputGate::Paused ||
+        !CanProgressUnlocked()) {
+      return std::nullopt;
+    }
+    merge_state_ = MergeState::Running;
+    return Task([this] { return Drain(); });
+  }
+
+  Selection GetNextSelectionUnlocked(std::vector<InputState*>* consumed) {
+    DCHECK(CanProgressUnlocked());
+    Selection selection;
+    std::vector<InputState*> heap;
+    heap.reserve(state_.size());
+    for (const auto& input : state_) {
+      if (input->HasData()) {
+        heap.push_back(input.get());
       }
     }
-
-    std::vector<std::shared_ptr<InputState>> heap = state;
-    // filter out finished states
-    heap.erase(std::remove_if(
-                   heap.begin(), heap.end(),
-                   [](const std::shared_ptr<InputState>& s) { return s->Finished(); }),
-               heap.end());
-
-    // If any are Empty(), then return early since we don't have enough data
-    if (std::any_of(heap.begin(), heap.end(),
-                    [](const std::shared_ptr<InputState>& s) { return s->Empty(); })) {
-      return nullptr;
+    if (heap.empty()) {
+      return selection;
     }
 
-    // Currently we only support one sort key
-    const auto sort_col = *ordering_.sort_keys().at(0).target.name();
-    const auto comp = InputStateComparator();
+    const auto comp = InputStateComparator(ordering_.sort_keys()[0].null_placement);
     std::make_heap(heap.begin(), heap.end(), comp);
 
-    // Each slice only has one record batch with the same schema as the output
-    std::unordered_map<int, std::pair<int, int>> output_col_to_src;
-    for (int i = 0; i < output_schema_->num_fields(); i++) {
-      output_col_to_src[i] = std::make_pair(0, i);
-    }
-    SingleRecordBatchCompositeTable output(output_schema(), 1,
-                                           std::move(output_col_to_src),
-                                           plan()->query_context()->memory_pool());
-
-    // Generate rows until we run out of data or we exceed the target output
-    // size
-    bool waiting_for_more_data = false;
-    while (!waiting_for_more_data && !heap.empty() &&
-           output.Size() < kTargetOutputBatchSize) {
+    // Generate rows until we run out of data or reach the target output size.
+    while (!heap.empty() && selection.length < kTargetOutputBatchSize) {
       std::pop_heap(heap.begin(), heap.end(), comp);
 
       auto& next_item = heap.back();
-      time_unit_t latest_time = std::numeric_limits<time_unit_t>::min();
-      time_unit_t new_time = next_item->GetLatestTime();
-      ARROW_CHECK(new_time >= latest_time)
-          << "Input state " << next_item->index()
-          << " has out of order data. newTime=" << new_time
-          << " latestTime=" << latest_time;
-
-      latest_time = new_time;
-      SingleRecordBatchSliceBuilder builder{&output};
-      next_item->Advance(builder);
-
-      if (builder.Size() > 0) {
-        output_counter[next_item->index()] += builder.Size();
-        builder.Finalize();
+      // pop_heap leaves the remaining heap's earliest input at the front.  The selected
+      // input can safely contribute every row up to that timestamp; no other input can
+      // contain an earlier row.
+      const std::optional<time_unit_t>* upper_bound =
+          heap.size() > 1 ? &heap.front()->GetLatestTime() : nullptr;
+      bool batch_consumed = next_item->Advance(
+          upper_bound, kTargetOutputBatchSize - selection.length, &selection);
+      if (batch_consumed) {
+        consumed->push_back(next_item);
       }
       if (next_item->Finished()) {
         heap.pop_back();
-      } else if (next_item->Empty()) {
+        continue;
+      }
+      if (!next_item->HasData()) {
         // We've run out of data on one of the inputs
-        waiting_for_more_data = true;
-        continue;  // skip the unnecessary make_heap
+        break;
       }
-      std::make_heap(heap.begin(), heap.end(), comp);
+      std::push_heap(heap.begin(), heap.end(), comp);
     }
-
-    // Emit the batch
-    if (output.Size() == 0) {
-      return nullptr;
-    }
-
-    ARROW_ASSIGN_OR_RAISE(auto maybe_rb, output.Materialize());
-    return maybe_rb.value_or(nullptr);
+    return selection;
   }
-  /// Gets a batch. Returns true if there is more data to process, false if we
-  /// are done or an error occurred
-  bool PollOnce() {
-    std::lock_guard<std::mutex> guard(gate);
-    if (!CheckEnded()) {
-      return false;
-    }
 
-    // Process batches while we have data
+  Result<ExecBatch> Materialize(const Selection& selection) {
+    std::vector<Datum> values;
+    values.reserve(output_schema_->num_fields());
+    for (int column = 0; column < output_schema_->num_fields(); ++column) {
+      ARROW_ASSIGN_OR_RAISE(auto builder,
+                            MakeBuilder(output_schema_->field(column)->type(),
+                                        plan()->query_context()->memory_pool()));
+      ARROW_RETURN_NOT_OK(builder->Reserve(selection.length));
+      const ArrayData* current_source = nullptr;
+      std::optional<ArraySpan> current_span;
+      for (const SelectionRun& run : selection.runs) {
+        const Datum& source = run.source->batch.values[column];
+        if (source.is_scalar()) {
+          ARROW_RETURN_NOT_OK(builder->AppendScalar(*source.scalar(), run.length));
+          continue;
+        }
+        if (!source.is_array()) {
+          return Status::Invalid("SortedMerge input must be an array or scalar, but got ",
+                                 ::arrow::ToString(source.kind()), " in column ", column);
+        }
+
+        if (source.array().get() != current_source) {
+          current_source = source.array().get();
+          current_span.emplace(*source.array());
+        }
+        Status status = builder->AppendArraySlice(*current_span, run.offset, run.length);
+        if (status.IsNotImplemented()) {
+          auto source_array = MakeArray(source.array());
+          for (int64_t row = run.offset; row < run.offset + run.length; ++row) {
+            ARROW_ASSIGN_OR_RAISE(auto scalar, source_array->GetScalar(row));
+            ARROW_RETURN_NOT_OK(builder->AppendScalar(*scalar));
+          }
+        } else {
+          ARROW_RETURN_NOT_OK(status);
+        }
+      }
+      ARROW_ASSIGN_OR_RAISE(auto array, builder->Finish());
+      values.emplace_back(std::move(array));
+    }
+    return ExecBatch(std::move(values), selection.length);
+  }
+
+  Status Drain() {
     for (;;) {
-      Result<std::shared_ptr<RecordBatch>> result = getNextBatch();
+      std::vector<InputState*> consumed;
+      Selection selection;
+      int32_t output_index = -1;
+      bool finish = false;
+      {
+        std::lock_guard lock(coordinator_mutex_);
+        if (merge_state_ == MergeState::Terminal) {
+          return Status::OK();
+        }
+        DCHECK_EQ(merge_state_, MergeState::Running);
+        MaybeEnterFlushingUnlocked();
+        if (output_gate_ == OutputGate::Paused || !CanProgressUnlocked()) {
+          merge_state_ = MergeState::Idle;
+          return Status::OK();
+        }
 
-      if (result.ok()) {
-        auto out_rb = *result;
-        if (!out_rb) {
-          break;
+        selection = GetNextSelectionUnlocked(&consumed);
+        if (!selection.empty()) {
+          // The sole merge task owns output numbering, independent of executor mode.
+          output_index = batches_produced_++;
+        } else if (FinishedUnlocked()) {
+          merge_state_ = MergeState::Terminal;
+          terminal_.store(true);
+          finish = true;
+        } else {
+          merge_state_ = MergeState::Idle;
         }
-        ExecBatch out_b(*out_rb);
-        out_b.index = batches_produced++;
-        Status st = output_->InputReceived(this, std::move(out_b));
-        if (!st.ok()) {
-          ARROW_LOG(FATAL) << "Error in output_::InputReceived: " << st.ToString();
-          EndFromProcessThread(std::move(st));
-        }
-      } else {
-        EndFromProcessThread(result.status());
-        return false;
+      }
+
+      for (InputState* input : consumed) {
+        input->BatchConsumed().Apply();
+      }
+      if (finish) {
+        return FinishNormally();
+      }
+      if (selection.empty()) {
+        return Status::OK();
+      }
+
+      auto materialized = Materialize(selection);
+      if (!materialized.ok()) {
+        EnterTerminal();
+        return materialized.status();
+      }
+      ExecBatch output = std::move(*materialized);
+      output.index = output_index;
+      Status status = output_->InputReceived(this, std::move(output));
+      if (!status.ok()) {
+        EnterTerminal();
+        return status;
       }
     }
-
-    // Report to the output the total batch count, if we've already
-    // finished everything (there are two places where this can happen:
-    // here and InputFinished)
-    //
-    // It may happen here in cases where InputFinished was called before
-    // we were finished producing results (so we didn't know the output
-    // size at that time)
-    if (!CheckEnded()) {
-      return false;
-    }
-
-    // There is no more we can do now but there is still work remaining
-    // for later when more data arrives.
-    return true;
   }
 
-#ifdef ARROW_ENABLE_THREADING
-  void EmitBatches() {
-    while (true) {
-      // Implementation note: If the queue is empty, we will block here
-      if (process_queue.WaitAndPop() == kPoisonPill) {
-        EndFromProcessThread();
-      }
-      // Either we're out of data or something went wrong
-      if (!PollOnce()) {
-        return;
-      }
+  Status FinishNormally() {
+    for (auto& input : state_) {
+      input->Shutdown().Apply();
     }
+    return output_->InputFinished(this, batches_produced_);
   }
 
-  /// The entry point for processThread
-  static void StartPoller(SortedMergeNode* node) { node->EmitBatches(); }
-#endif
+  void EnterTerminal() {
+    terminal_.store(true);
+    {
+      std::lock_guard lock(coordinator_mutex_);
+      merge_state_ = MergeState::Terminal;
+      for (auto& input : state_) {
+        input->ClearBuffered();
+      }
+    }
+    for (auto& input : state_) {
+      input->Shutdown().Apply();
+    }
+  }
 
   arrow::Ordering ordering_;
+  std::vector<std::unique_ptr<InputState>> state_;
 
-  // Each input state corresponds to an input (e.g. a parquet data file)
-  std::vector<std::shared_ptr<InputState>> state;
-  std::vector<std::atomic_int64_t> input_counter;
-  std::vector<std::atomic_int64_t> output_counter;
-  std::mutex gate;
-
-  std::atomic<bool> cleanup_started{false};
-
-  // Backpressure counter common to all input states
-  std::atomic<int32_t> backpressure_counter;
-
-  std::atomic<int32_t> batches_produced{0};
-
-#ifdef ARROW_ENABLE_THREADING
-  // Queue to trigger processing of a given input. False acts as a poison pill
-  ConcurrentQueue<bool> process_queue;
-  // Once StartProducing is called, we initialize this thread to poll the
-  // input states and emit batches
-  std::thread process_thread;
-#endif
-  arrow::Future<> process_task;
-
-  // Map arg index --> completion counter
-  std::vector<arrow::acero::AtomicCounter> counter_;
-  // Map arg index --> data
-  std::vector<InputState> accumulation_queue_;
-  std::mutex mutex_;
-  std::atomic<int> total_batches_{0};
+  std::mutex coordinator_mutex_;
+  MergeState merge_state_ = MergeState::Idle;
+  OutputGate output_gate_ = OutputGate::Open;
+  int32_t downstream_counter_ = std::numeric_limits<int32_t>::min();
+  int32_t batches_produced_ = 0;
+  std::atomic<bool> terminal_{false};
 };
+
+InputState::InputState(SortedMergeNode* node, size_t index, ExecNode* input,
+                       col_index_t time_col_index, compute::NullPlacement null_placement)
+    : node_(node),
+      index_(index),
+      input_(input),
+      time_col_index_(time_col_index),
+      null_placement_(null_placement),
+      sequencer_(util::SerialSequencingQueue::Make(this)) {}
+
+Status InputState::InsertBatch(ExecBatch batch) {
+  if (batch.index == compute::kUnsequencedIndex) {
+    return Status::Invalid("SortedMerge requires sequenced input");
+  }
+  return sequencer_->InsertBatch(std::move(batch));
+}
+
+Status InputState::Process(ExecBatch batch) {
+  if (node_->IsTerminal()) {
+    return Status::OK();
+  }
+  // Sequence the original ExecBatch.  Once its index is current, prepare only the
+  // sort-key view needed to select rows; payload columns stay unmaterialized until the
+  // complete output selection is known.
+  ARROW_ASSIGN_OR_RAISE(auto prepared, PrepareBatch(std::move(batch)));
+
+  // Only sequenced, non-empty batches count toward backpressure.  Counting physical
+  // arrivals can deadlock with a reordering input if later batches reach the high
+  // watermark while that input still owns the batch which closes the sequencing gap.
+  FlowAction buffered = prepared->batch.length == 0 ? FlowAction{} : BatchBuffered();
+  ARROW_ASSIGN_OR_RAISE(auto task, node_->OnSequenced(index_, std::move(prepared)));
+  buffered.Apply();
+  return task ? std::move(*task)() : Status::OK();
+}
+
+Result<std::shared_ptr<PreparedBatch>> InputState::PrepareBatch(ExecBatch batch) {
+  auto prepared = std::make_shared<PreparedBatch>();
+  prepared->batch = std::move(batch);
+  prepared->times.reserve(prepared->batch.length);
+  const Datum& time_column = prepared->batch.values[time_col_index_];
+  for (int64_t row = 0; row < prepared->batch.length; ++row) {
+    ARROW_ASSIGN_OR_RAISE(auto time, ReadTimeValue(time_column, row));
+    ARROW_RETURN_NOT_OK(ValidateTime(time));
+    prepared->times.push_back(time);
+  }
+  return prepared;
+}
+
+Status InputState::ValidateTime(const std::optional<time_unit_t>& time) {
+  if (!time) {
+    if (null_placement_ == compute::NullPlacement::AtStart && saw_non_null_) {
+      return Status::Invalid("SortedMerge input ", index_,
+                             " has out-of-order nulls in its sort key");
+    }
+    saw_null_ = true;
+    return Status::OK();
+  }
+  if ((null_placement_ == compute::NullPlacement::AtEnd && saw_null_) ||
+      (last_time_ && *time < *last_time_)) {
+    return Status::Invalid("SortedMerge input ", index_,
+                           " has out-of-order values in its sort key");
+  }
+  saw_non_null_ = true;
+  last_time_ = *time;
+  return Status::OK();
+}
+
+FlowAction InputState::SetUpstreamPausedUnlocked(bool paused) {
+  if (upstream_paused_ == paused || shutdown_) {
+    return {};
+  }
+  upstream_paused_ = paused;
+  return {paused ? FlowAction::Kind::Pause : FlowAction::Kind::Resume, input_, node_,
+          ++outgoing_counter_};
+}
+
+FlowAction InputState::BatchBuffered() {
+  std::lock_guard lock(flow_mutex_);
+  if (shutdown_) {
+    return {};
+  }
+  ++buffered_batches_;
+  return buffered_batches_ >= kHighWatermark ? SetUpstreamPausedUnlocked(true)
+                                             : FlowAction{};
+}
+
+FlowAction InputState::BatchConsumed() {
+  std::lock_guard lock(flow_mutex_);
+  if (shutdown_) {
+    return {};
+  }
+  DCHECK_GT(buffered_batches_, 0);
+  if (buffered_batches_ > 0) {
+    --buffered_batches_;
+  }
+  return buffered_batches_ <= kLowWatermark ? SetUpstreamPausedUnlocked(false)
+                                            : FlowAction{};
+}
+
+FlowAction InputState::Shutdown() {
+  std::lock_guard lock(flow_mutex_);
+  if (shutdown_) {
+    return {};
+  }
+  shutdown_ = true;
+  upstream_paused_ = false;
+  buffered_batches_ = 0;
+  // Always send a final, newer resume so a delayed pause cannot strand an input.
+  return {FlowAction::Kind::Resume, input_, node_, ++outgoing_counter_};
+}
 
 }  // namespace
 

--- a/cpp/src/arrow/acero/sorted_merge_node_test.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node_test.cc
@@ -24,13 +24,16 @@
 #include "arrow/array/builder_base.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/compute/ordering.h"
+#include "arrow/compute/test_util_internal.h"
 #include "arrow/result.h"
 #include "arrow/scalar.h"
 #include "arrow/table.h"
+#include "arrow/testing/future_util.h"
 #include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::acero {
 
@@ -65,8 +68,6 @@ TEST(SortedMergeNode, Basic) {
   auto ops = OrderByNodeOptions(compute::Ordering({compute::SortKey("timestamp")}));
 
   Declaration sorted_merge{"sorted_merge", src_decls, ops};
-  // We can't use threads for sorted merging since it relies on
-  // ascending deterministic order of timestamps
   ASSERT_OK_AND_ASSIGN(auto output,
                        DeclarationToTable(sorted_merge, /*use_threads=*/false));
   ASSERT_EQ(output->num_rows(), 18);
@@ -81,6 +82,163 @@ TEST(SortedMergeNode, Basic) {
   ASSERT_OK_AND_ASSIGN(auto output_ts, Concatenate(output_col->chunks()));
 
   AssertArraysEqual(*expected_ts, *output_ts);
+}
+
+TEST(SortedMergeNode, SignedValuesCrossZero) {
+  auto table1 = TestTable(
+      /*start=*/-4,
+      /*step=*/2,
+      /*rows_per_batch=*/3,
+      /*num_batches=*/1);
+  auto table2 = TestTable(
+      /*start=*/-3,
+      /*step=*/2,
+      /*rows_per_batch=*/4,
+      /*num_batches=*/1);
+  std::vector<Declaration::Input> src_decls;
+  src_decls.emplace_back(Declaration("table_source", TableSourceNodeOptions(table1)));
+  src_decls.emplace_back(Declaration("table_source", TableSourceNodeOptions(table2)));
+
+  auto options = OrderByNodeOptions(compute::Ordering({compute::SortKey("timestamp")}));
+  Declaration sorted_merge{"sorted_merge", src_decls, options};
+  ASSERT_OK_AND_ASSIGN(auto output,
+                       DeclarationToTable(sorted_merge, /*use_threads=*/false));
+
+  auto expected = ArrayFromJSON(int32(), "[-4, -3, -2, -1, 0, 1, 3]");
+  ASSERT_OK_AND_ASSIGN(auto actual, Concatenate(output->column(0)->chunks()));
+  AssertArraysEqual(*expected, *actual);
+}
+
+TEST(SortedMergeNode, MergesScalarPayload) {
+  auto input_schema = schema({field("timestamp", int32()), field("source", utf8())});
+  ExecBatch left(
+      {ArrayFromJSON(int32(), "[0, 2]"), std::make_shared<StringScalar>("left")}, 2);
+  ExecBatch right(
+      {ArrayFromJSON(int32(), "[1, 3]"), std::make_shared<StringScalar>("right")}, 2);
+
+  Declaration merge{
+      "sorted_merge",
+      {Declaration{"exec_batch_source",
+                   ExecBatchSourceNodeOptions(input_schema, {std::move(left)})},
+       Declaration{"exec_batch_source",
+                   ExecBatchSourceNodeOptions(input_schema, {std::move(right)})}},
+      OrderByNodeOptions(compute::Ordering({compute::SortKey("timestamp")}))};
+  ASSERT_OK_AND_ASSIGN(auto output,
+                       DeclarationToTable(std::move(merge), /*use_threads=*/false));
+
+  ASSERT_OK_AND_ASSIGN(auto timestamps, Concatenate(output->column(0)->chunks()));
+  AssertArraysEqual(*ArrayFromJSON(int32(), "[0, 1, 2, 3]"), *timestamps);
+  ASSERT_OK_AND_ASSIGN(auto sources, Concatenate(output->column(1)->chunks()));
+  AssertArraysEqual(*ArrayFromJSON(utf8(), R"(["left", "right", "left", "right"])"),
+                    *sources);
+}
+
+TEST(SortedMergeNode, ProducesSortedOutputFromJitteredInputsOnBothExecutors) {
+  // Use enough small batches that delivery and flow control overlap.  Correctness must
+  // depend on logical batch indices rather than physical arrival order.
+  constexpr int kBatchesPerInput = 64;
+  RegisterTestNodes();
+  auto table0 = TestTable(0, 3, /*rows_per_batch=*/1, kBatchesPerInput);
+  auto table1 = TestTable(1, 3, /*rows_per_batch=*/1, kBatchesPerInput);
+  auto table2 = TestTable(2, 3, /*rows_per_batch=*/1, kBatchesPerInput);
+
+  for (bool use_threads : {false, true}) {
+    SCOPED_TRACE(use_threads ? "threaded" : "serial");
+    std::vector<Declaration::Input> inputs;
+    inputs.emplace_back(Declaration::Sequence(
+        {{"table_source", TableSourceNodeOptions(table0)},
+         {"jitter", JitterNodeOptions(/*seed=*/42, /*max_jitter_modifier=*/4)}}));
+    inputs.emplace_back(Declaration::Sequence(
+        {{"table_source", TableSourceNodeOptions(table1)},
+         {"jitter", JitterNodeOptions(/*seed=*/84, /*max_jitter_modifier=*/4)}}));
+    inputs.emplace_back(Declaration::Sequence(
+        {{"table_source", TableSourceNodeOptions(table2)},
+         {"jitter", JitterNodeOptions(/*seed=*/126, /*max_jitter_modifier=*/4)}}));
+
+    QueryOptions query_options;
+    query_options.use_threads = use_threads;
+    Declaration merge{
+        "sorted_merge", std::move(inputs),
+        OrderByNodeOptions(compute::Ordering({compute::SortKey("timestamp")}))};
+    ASSERT_OK_AND_ASSIGN(auto output,
+                         DeclarationToTable(std::move(merge), query_options));
+
+    ASSERT_EQ(output->num_rows(), 3 * kBatchesPerInput);
+    ASSERT_OK_AND_ASSIGN(auto actual, Concatenate(output->column(0)->chunks()));
+    ASSERT_OK_AND_ASSIGN(auto expected_builder,
+                         MakeBuilder(int32(), default_memory_pool()));
+    for (int value = 0; value < 3 * kBatchesPerInput; ++value) {
+      ASSERT_OK(expected_builder->AppendScalar(*MakeScalar(value)));
+    }
+    ASSERT_OK_AND_ASSIGN(auto expected, expected_builder->Finish());
+    AssertArraysEqual(*expected, *actual);
+  }
+}
+
+TEST(SortedMergeNode, DownstreamBackpressureAndStop) {
+  for (bool stop_while_paused : {false, true}) {
+    SCOPED_TRACE(stop_while_paused ? "stop" : "resume");
+    auto input_schema = schema({field("timestamp", int32())});
+    PushGenerator<std::optional<ExecBatch>> left_generator;
+    PushGenerator<std::optional<ExecBatch>> right_generator;
+    AsyncGenerator<std::optional<ExecBatch>> sink_generator;
+    BackpressureMonitor* backpressure_monitor = nullptr;
+
+    Declaration left{
+        "source", SourceNodeOptions(input_schema, left_generator, Ordering::Implicit())};
+    Declaration right{
+        "source", SourceNodeOptions(input_schema, right_generator, Ordering::Implicit())};
+    Declaration merge{
+        "sorted_merge",
+        {std::move(left), std::move(right)},
+        OrderByNodeOptions(compute::Ordering({compute::SortKey("timestamp")}))};
+    Declaration sink{"sink",
+                     {std::move(merge)},
+                     SinkNodeOptions(&sink_generator, /*schema=*/nullptr,
+                                     BackpressureOptions(/*resume_if_below=*/1,
+                                                         /*pause_if_above=*/1),
+                                     &backpressure_monitor, /*sequence_output=*/false)};
+
+    ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make(*threaded_exec_context()));
+    ASSERT_OK(sink.AddToPlan(plan.get()));
+    ASSERT_OK(plan->Validate());
+    ASSERT_NE(backpressure_monitor, nullptr);
+    plan->StartProducing();
+
+    left_generator.producer().Push(compute::ExecBatchFromJSON({int32()}, "[[0]]"));
+    right_generator.producer().Push(compute::ExecBatchFromJSON({int32()}, "[[1]]"));
+    BusyWait(10.0, [&] { return backpressure_monitor->is_paused(); });
+    ASSERT_TRUE(backpressure_monitor->is_paused());
+
+    if (stop_while_paused) {
+      plan->StopProducing();
+      left_generator.producer().Push(IterationEnd<std::optional<ExecBatch>>());
+      right_generator.producer().Push(IterationEnd<std::optional<ExecBatch>>());
+      ASSERT_TRUE(plan->finished().Wait(kDefaultAssertFinishesWaitSeconds));
+      ASSERT_TRUE(plan->finished().status().IsCancelled());
+      continue;
+    }
+
+    const uint64_t paused_bytes = backpressure_monitor->bytes_in_use();
+    left_generator.producer().Push(compute::ExecBatchFromJSON({int32()}, "[[2]]"));
+    right_generator.producer().Push(compute::ExecBatchFromJSON({int32()}, "[[3]]"));
+    arrow::internal::GetCpuThreadPool()->WaitForIdle();
+    EXPECT_EQ(backpressure_monitor->bytes_in_use(), paused_bytes);
+
+    ASSERT_FINISHES_OK_AND_ASSIGN(auto first_output, sink_generator());
+    ASSERT_TRUE(first_output.has_value());
+    BusyWait(10.0, [&] { return backpressure_monitor->bytes_in_use() > 0; });
+    const bool resumed = backpressure_monitor->bytes_in_use() > 0;
+
+    left_generator.producer().Push(IterationEnd<std::optional<ExecBatch>>());
+    right_generator.producer().Push(IterationEnd<std::optional<ExecBatch>>());
+    for (;;) {
+      ASSERT_FINISHES_OK_AND_ASSIGN(auto output, sink_generator());
+      if (!output) break;
+    }
+    ASSERT_FINISHES_OK(plan->finished());
+    EXPECT_TRUE(resumed);
+  }
 }
 
 }  // namespace arrow::acero

--- a/cpp/src/arrow/acero/time_series_util.cc
+++ b/cpp/src/arrow/acero/time_series_util.cc
@@ -22,13 +22,6 @@
 
 namespace arrow::acero {
 
-template <typename T, enable_if_t<std::is_integral<T>::value, bool>>
-inline uint64_t NormalizeTime(T t) {
-  uint64_t bias =
-      std::is_signed<T>::value ? static_cast<uint64_t>(1) << (8 * sizeof(T) - 1) : 0;
-  return t < 0 ? static_cast<uint64_t>(t + bias) : static_cast<uint64_t>(t);
-}
-
 uint64_t GetTime(const RecordBatch* batch, Type::type time_type, int col, uint64_t row) {
 #define LATEST_VAL_CASE(id, val)                     \
   case Type::id: {                                   \

--- a/cpp/src/arrow/acero/time_series_util.h
+++ b/cpp/src/arrow/acero/time_series_util.h
@@ -17,14 +17,25 @@
 
 #pragma once
 
+#include <limits>
+#include <type_traits>
+
 #include "arrow/record_batch.h"
 #include "arrow/type_traits.h"
 
 namespace arrow::acero {
 
 // normalize the value to unsigned 64-bits while preserving ordering of values
-template <typename T, enable_if_t<std::is_integral<T>::value, bool> = true>
-uint64_t NormalizeTime(T t);
+template <typename T,
+          enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool>, bool> = true>
+uint64_t NormalizeTime(T t) {
+  using U = std::make_unsigned_t<T>;
+  U normalized = static_cast<U>(t);
+  if constexpr (std::is_signed_v<T>) {
+    normalized ^= U{1} << (std::numeric_limits<U>::digits - 1);
+  }
+  return static_cast<uint64_t>(normalized);
+}
 
 uint64_t GetTime(const RecordBatch* batch, Type::type time_type, int col, uint64_t row);
 


### PR DESCRIPTION
### Rationale for this change

SortedMerge uses a dedicated worker thread and assumes input batches arrive in logical order. This prevents safe threaded execution and leaves backpressure, completion, stopping, and error propagation split across separate execution paths. The earlier implementation in #47394 added per-input sequencing and backpressure while retaining the existing worker thread; this PR is a new version that addresses #47393 with a single executor-managed implementation.

### What changes are included in this PR?

- Replace the worker thread, process queue, and poison-pill shutdown with one executor-managed merge flow. Per-input `SerialSequencingQueue`s restore logical `ExecBatch::index` order for threaded, serial, and compile-time no-thread builds.
- Add bounded upstream backpressure and downstream pause/resume handling. Completion flushes buffered rows, stopping propagates upstream, and sink-driven resume cannot race scheduler teardown.
- Select multi-row runs up to the earliest row visible on another input, allowing one selection to span multiple timestamps. Runs retain their original `ExecBatch` payloads until direct materialization with Arrow builders. This supports scalar payloads and bypasses Boolean slices with non-zero offsets reported in #48072.
- Validate ascending input order and propagate validation, materialization, and downstream errors through normal ExecPlan status handling.

### Are these changes tested?

Yes. All tests pass in threaded and `ARROW_ENABLE_THREADING=OFF` builds. Coverage includes signed keys crossing zero, scalar payloads, deterministic sequencing under jittered delivery, and downstream backpressure, resume, and stop. 

### Are there any user-facing changes?

SortedMerge now supports concurrent input delivery, upstream and downstream backpressure, scalar payloads. Inputs that violate their declared ascending order return an `Invalid` status. 
No API changes.

* GitHub Issue: #47393