### PR TITLE
GH-51140: [C++] Require simdjson 4.3.0 for fractured_json APIs

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2852,7 +2852,7 @@ function(build_simdjson)
 endfunction()
 
 if(ARROW_WITH_SIMDJSON)
-  set(ARROW_SIMDJSON_REQUIRED_VERSION "4.0.0")
+  set(ARROW_SIMDJSON_REQUIRED_VERSION "4.3.0")
   resolve_dependency(simdjson
                      FORCE_ANY_NEWER_VERSION
                      TRUE


### PR DESCRIPTION
### Rationale for this change
Fix #51140, CMake configuration should not accept simdjson earlier than v4.3.0.

### What changes are included in this PR?
Set ARROW_SIMDJSON_REQUIRED_VERSION to "4.3.0"

### Are these changes tested?
Yes. Locally, CMake configuration rejects system simdjson 4.2.3 now
`CMake Error at cmake_modules/ThirdpartyToolchain.cmake:316 (message):`
`  Couldn't find simdjson >= 4.3.0`

### Are there any user-facing changes?
No.

* GitHub Issue: #51140