### PR TITLE
GH-51144: [C++] Incorrect Logic for AdaptiveUIntBuilder::AppendValues

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -3260,6 +3260,21 @@ TEST_F(TestAdaptiveUIntBuilder, TestAppendEmptyValue) {
   AssertArraysEqual(*result_, *ArrayFromJSON(uint8(), "[null, null, 0, 42, 0, 0]"));
 }
 
+TEST_F(TestAdaptiveUIntBuilder, TestAppendValuesAfterAppend) {
+  ASSERT_OK(builder_->Append(1));
+  ASSERT_OK(builder_->Append(2));
+  ASSERT_OK(builder_->Append(3));
+  ASSERT_OK(builder_->Append(4));
+  std::vector<uint64_t> values{5, 6, 7, 8};
+  ASSERT_OK(builder_->AppendValues(values.data(), values.size()));
+  Done();
+  ASSERT_OK(result_->ValidateFull());
+
+  std::shared_ptr<Array> expected;
+  ArrayFromVector<UInt8Type>({1, 2, 3, 4, 5, 6, 7, 8}, &expected);
+  AssertArraysEqual(*expected, *result_);
+}
+
 TEST(TestAdaptiveUIntBuilderWithStartIntSize, TestReset) {
   auto builder = std::make_shared<AdaptiveUIntBuilder>(
       static_cast<uint8_t>(sizeof(uint16_t)), default_memory_pool());

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -349,6 +349,7 @@ Status AdaptiveUIntBuilder::AppendValuesInternal(const uint64_t* values, int64_t
 
 Status AdaptiveUIntBuilder::AppendValues(const uint64_t* values, int64_t length,
                                          const uint8_t* valid_bytes) {
+  RETURN_NOT_OK(CommitPendingData());
   RETURN_NOT_OK(Reserve(length));
 
   return AppendValuesInternal(values, length, valid_bytes);


### PR DESCRIPTION
### Rationale for this change

`arrow::AdaptiveUIntBuilder::AppendValues` creates incorrect results when combined with `arrow::AdaptiveUIntBuilder::Append`.

### What changes are included in this PR?

Correct the logic of `arrow::AdaptiveUIntBuilder::AppendValues` and add the relevant unit test.

### Are these changes tested?

Yes. I ran the relevant unit test.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** (b) A bug that caused incorrect or invalid data to be produced.

* GitHub Issue: #51144