### PR TITLE
GH-51148: [Docs] Repoint three dead links

### DIFF
--- a/docs/source/developers/continuous_integration/crossbow.rst
+++ b/docs/source/developers/continuous_integration/crossbow.rst
@@ -111,7 +111,7 @@ to step 3:
 6. Install Python (minimum supported version is 3.11):
 
    | Miniconda is preferred, see installation instructions:
-   | https://conda.io/docs/user-guide/install/index.html
+   | https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html
 
 7. Install the archery toolset containing crossbow itself:
 

--- a/docs/source/developers/java/development.rst
+++ b/docs/source/developers/java/development.rst
@@ -174,7 +174,7 @@ This applies the style to all pom.xml files under the current directory or from 
 .. _benchmark: https://github.com/ursacomputing/benchmarks
 .. _archery: https://github.com/apache/arrow/blob/main/dev/conbench_envs/README.md#L188
 .. _conbench: https://github.com/conbench/conbench
-.. _checkstyle: https://github.com/apache/arrow/blob/main/java/dev/checkstyle/checkstyle.xml
+.. _checkstyle: https://github.com/apache/arrow-java/blob/main/dev/checkstyle/checkstyle.xml
 .. _Apache Maven pom.xml guidelines: https://maven.apache.org/developers/conventions/code.html#pom-code-convention
 .. _Spotless: https://github.com/diffplug/spotless
 .. _Google Java Style: https://google.github.io/styleguide/javaguide.html

--- a/docs/source/format/CDeviceDataInterface.rst
+++ b/docs/source/format/CDeviceDataInterface.rst
@@ -1064,5 +1064,5 @@ Any incompatible changes should be part of a new specification, for example
 .. _OpenCL (Open Computing Language): https://www.khronos.org/opencl/
 .. _Vulkan: https://www.vulkan.org/
 .. _Metal: https://developer.apple.com/metal/
-.. _ROCm: https://www.amd.com/en/graphics/servers-solutions-rocm
+.. _ROCm: https://www.amd.com/en/products/software/rocm.html
 .. _oneAPI: https://www.intel.com/content/www/us/en/developer/tools/oneapi/overview.html


### PR DESCRIPTION
### Rationale for this change

Three links in the docs return 404. Each one is the reference target for advice the page is giving, so following it leaves the reader with nothing:

- the checkstyle config a Java contributor is told to follow,
- the conda install guide in the Crossbow setup instructions,
- the ROCm reference in the C device data interface spec.

### What changes are included in this PR?

Three URL strings.

- `developers/java/development.rst`: `apache/arrow/blob/main/java/dev/checkstyle/checkstyle.xml` becomes `apache/arrow-java/blob/main/dev/checkstyle/checkstyle.xml`. The file moved with the Java split and the `java/` path segment went with it; it is 10,851 bytes on `arrow-java@main`. This was the last remaining `apache/arrow/.../java/...` link under `docs/source`.
- `developers/continuous_integration/crossbow.rst`: `conda.io/docs/user-guide/install/index.html` becomes `docs.conda.io/projects/conda/en/latest/user-guide/install/index.html`.
- `format/CDeviceDataInterface.rst`: the `_ROCm:` target becomes `amd.com/en/products/software/rocm.html`, since AMD retired `en/graphics/servers-solutions-rocm`.

### Are these changes tested?

Not by the test suite; nothing outside `docs/source` changed and no code is touched. Each old URL was requested and returns 404, each new one returns 200, and the two GitHub paths were checked through the contents API rather than the HTML pages, because github.com rate-limits a bulk sweep and a 429 is indistinguishable from a 404. I did not build the docs locally.

### Are there any user-facing changes?

Documentation only. Three links that were broken now resolve.

Disclosure: prepared with AI assistance (Claude, via Claude Code), per the AI-generated Code Guidance in the contributing overview. I reviewed the diff; it introduces no third-party material.
* GitHub Issue: #51148