### PR TITLE
GH-51145: [Python] Accept Arrow integer scalars in slice methods

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -18,6 +18,7 @@
 from cpython.pycapsule cimport PyCapsule_CheckExact, PyCapsule_GetPointer, PyCapsule_New
 
 from collections.abc import Sequence
+import operator
 import os
 import warnings
 from cython import sizeof
@@ -1631,6 +1632,7 @@ cdef class Array(_PandasConvertible):
         """
         cdef shared_ptr[CArray] result
 
+        offset = operator.index(offset)
         if offset < 0:
             raise IndexError('Offset must be non-negative')
 
@@ -1638,6 +1640,7 @@ cdef class Array(_PandasConvertible):
         if length is None:
             result = self.ap.Slice(offset)
         else:
+            length = operator.index(length)
             if length < 0:
                 raise ValueError('Length must be non-negative')
             result = self.ap.Slice(offset, length)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1619,11 +1619,13 @@ cdef class Array(_PandasConvertible):
 
         Parameters
         ----------
-        offset : int, default 0
+        offset : int or pyarrow.Scalar, default 0
             Offset from start of array to slice.
-        length : int, default None
+            Arrow scalars must be non-null integers.
+        length : int or pyarrow.Scalar, default None
             Length of slice (default is until end of Array starting from
             offset).
+            Arrow scalars must be non-null integers.
 
         Returns
         -------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -911,6 +911,7 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         cdef shared_ptr[CChunkedArray] result
 
+        offset = operator.index(offset)
         if offset < 0:
             raise IndexError('Offset must be non-negative')
 
@@ -918,6 +919,7 @@ cdef class ChunkedArray(_PandasConvertible):
         if length is None:
             result = self.chunked_array.Slice(offset)
         else:
+            length = operator.index(length)
             result = self.chunked_array.Slice(offset, length)
 
         return pyarrow_wrap_chunked_array(result)
@@ -3172,6 +3174,7 @@ cdef class RecordBatch(_Tabular):
         """
         cdef shared_ptr[CRecordBatch] result
 
+        offset = operator.index(offset)
         if offset < 0:
             raise IndexError('Offset must be non-negative')
 
@@ -3179,6 +3182,7 @@ cdef class RecordBatch(_Tabular):
         if length is None:
             result = self.batch.Slice(offset)
         else:
+            length = operator.index(length)
             result = self.batch.Slice(offset, length)
 
         return pyarrow_wrap_batch(result)
@@ -4292,6 +4296,7 @@ cdef class Table(_Tabular):
         """
         cdef shared_ptr[CTable] result
 
+        offset = operator.index(offset)
         if offset < 0:
             raise IndexError('Offset must be non-negative')
 
@@ -4299,6 +4304,7 @@ cdef class Table(_Tabular):
         if length is None:
             result = self.table.Slice(offset)
         else:
+            length = operator.index(length)
             result = self.table.Slice(offset, length)
 
         return pyarrow_wrap_table(result)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -870,11 +870,13 @@ cdef class ChunkedArray(_PandasConvertible):
 
         Parameters
         ----------
-        offset : int, default 0
-            Offset from start of array to slice
-        length : int, default None
+        offset : int or pyarrow.Scalar, default 0
+            Offset from start of array to slice.
+            Arrow scalars must be non-null integers.
+        length : int or pyarrow.Scalar, default None
             Length of slice (default is until end of batch starting from
-            offset)
+            offset).
+            Arrow scalars must be non-null integers.
 
         Returns
         -------
@@ -3134,11 +3136,13 @@ cdef class RecordBatch(_Tabular):
 
         Parameters
         ----------
-        offset : int, default 0
-            Offset from start of record batch to slice
-        length : int, default None
+        offset : int or pyarrow.Scalar, default 0
+            Offset from start of record batch to slice.
+            Arrow scalars must be non-null integers.
+        length : int or pyarrow.Scalar, default None
             Length of slice (default is until end of batch starting from
-            offset)
+            offset).
+            Arrow scalars must be non-null integers.
 
         Returns
         -------
@@ -4250,11 +4254,13 @@ cdef class Table(_Tabular):
 
         Parameters
         ----------
-        offset : int, default 0
+        offset : int or pyarrow.Scalar, default 0
             Offset from start of table to slice.
-        length : int, default None
+            Arrow scalars must be non-null integers.
+        length : int or pyarrow.Scalar, default None
             Length of slice (default is until end of table starting from
             offset).
+            Arrow scalars must be non-null integers.
 
         Returns
         -------

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -563,6 +563,63 @@ def test_array_slice():
                 assert res.to_numpy().tolist() == expected
 
 
+@pytest.mark.parametrize("scalar_type", [
+    pa.int8(), pa.int16(), pa.int32(), pa.int64(),
+    pa.uint8(), pa.uint16(), pa.uint32(), pa.uint64(),
+])
+def test_array_slice_integer_scalars(scalar_type):
+    arr = pa.array(range(10))
+    offsets = pa.array([2, 4], type=scalar_type)
+
+    result = arr.slice(offsets[0], offsets[1])
+
+    assert result.equals(arr.slice(2, 4))
+
+
+@pytest.mark.numpy
+def test_array_slice_numpy_integer_scalars():
+    arr = pa.array(range(10))
+
+    result = arr.slice(np.int64(2), np.int64(4))
+
+    assert result.equals(arr.slice(2, 4))
+
+
+@pytest.mark.parametrize("scalar", [
+    pa.scalar(2.0),
+    pa.scalar(True),
+    pa.scalar(None, type=pa.int64()),
+])
+@pytest.mark.parametrize("args", [
+    lambda scalar: (scalar,),
+    lambda scalar: (0, scalar),
+])
+def test_array_slice_invalid_scalars(scalar, args):
+    arr = pa.array(range(10))
+
+    with pytest.raises(TypeError):
+        arr.slice(*args(scalar))
+
+
+def test_array_slice_negative_integer_scalars():
+    arr = pa.array(range(10))
+    negative = pa.scalar(-1, type=pa.int64())
+
+    with pytest.raises(IndexError):
+        arr.slice(negative)
+    with pytest.raises(ValueError):
+        arr.slice(0, negative)
+
+
+def test_array_slice_uint64_scalar_overflow():
+    arr = pa.array(range(10))
+    overflow = pa.scalar(2 ** 63, type=pa.uint64())
+
+    assert arr.slice(overflow).equals(arr.slice(len(arr)))
+    with pytest.raises(OverflowError):
+        arr.slice(0, overflow)
+
+
 def test_array_slice_negative_step():
     # ARROW-2714
     values = list(range(20))

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1372,6 +1372,48 @@ def _table_like_slice_tests(factory):
     assert obj.slice(len(obj) - 4, 2).equals(obj[-4:-2])
 
 
+@pytest.mark.parametrize("factory", [
+    pa.chunked_array,
+    pa.RecordBatch.from_arrays,
+    pa.table,
+])
+@pytest.mark.parametrize("scalar_type", [
+    pa.int8(), pa.int16(), pa.int32(), pa.int64(),
+    pa.uint8(), pa.uint16(), pa.uint32(), pa.uint64(),
+])
+def test_table_like_slice_integer_scalars(factory, scalar_type):
+    data = [pa.array(range(10))]
+    names = ["c0"]
+    if factory is pa.chunked_array:
+        obj = factory(data)
+    else:
+        obj = factory(data, names=names)
+    offsets = pa.array([2, 4], type=scalar_type)
+
+    result = obj.slice(offsets[0], offsets[1])
+
+    assert result.equals(obj.slice(2, 4))
+
+
+@pytest.mark.parametrize("factory", [
+    pa.chunked_array,
+    pa.RecordBatch.from_arrays,
+    pa.table,
+])
+def test_table_like_slice_uint64_scalar_overflow(factory):
+    data = [pa.array(range(10))]
+    names = ["c0"]
+    if factory is pa.chunked_array:
+        obj = factory(data)
+    else:
+        obj = factory(data, names=names)
+    overflow = pa.scalar(2 ** 63, type=pa.uint64())
+
+    assert obj.slice(overflow).equals(obj.slice(len(obj)))
+    with pytest.raises(OverflowError):
+        obj.slice(0, overflow)
+
+
 def test_recordbatch_slice_getitem():
     return _table_like_slice_tests(pa.RecordBatch.from_arrays)
 


### PR DESCRIPTION
### Rationale for this change

`Array.slice`, `ChunkedArray.slice`, `RecordBatch.slice`, and `Table.slice`
accept Python and NumPy integer-like values but reject Arrow integer scalars,
even though those scalars implement Python's integer-index protocol. This makes
values produced by Arrow APIs unnecessarily unusable as slice offsets and
lengths.

### What changes are included in this PR?

Normalize non-`None` offsets and lengths with `operator.index()` at the four
public Python wrapper boundaries before the existing validation and C++ calls.

Add regression coverage for all signed and unsigned Arrow integer scalar types
across the four wrappers, plus NumPy compatibility, invalid and null scalars,
negative values, offset clamping, and int64 overflow behavior.

### Are these changes tested?

Yes. Current Arrow C++ and editable PyArrow were built from source in an
isolated Python 3.13 environment. The focused new tests and existing slice
controls passed: 48 passed.

Cython translation, Python test-file compilation, Flake8, and
`git diff --check` also passed.

### Are there any user-facing changes?

Yes. The four Python `.slice()` methods now accept non-null Arrow integer
scalars for offsets and lengths. Existing Python/NumPy integer behavior and
error behavior for unsupported values are preserved.

### AI assistance

AI assisted analysis, implementation, test drafting, build work, and review.
The account holder reviewed and approved the final four-file diff. The account
holder did not personally run the commands reported above.

* GitHub Issue: #51145