### PR TITLE
GH-51043: [Python] Reject null required Arrow objects

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1121,7 +1121,8 @@ cdef class FileSystemDataset(Dataset):
     cdef:
         CFileSystemDataset* filesystem_dataset
 
-    def __init__(self, fragments, Schema schema, FileFormat format,
+    def __init__(self, fragments, Schema schema not None,
+                 FileFormat format not None,
                  FileSystem filesystem=None, root_partition=None):
         cdef:
             FileFragment fragment=None
@@ -1138,6 +1139,8 @@ cdef class FileSystemDataset(Dataset):
             )
 
         for fragment in fragments:
+            if fragment is None:
+                raise TypeError("Fragment must not be None")
             c_fragments.push_back(
                 static_pointer_cast[CFileFragment, CFragment](
                     fragment.unwrap()))

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -755,7 +755,8 @@ cdef class SortingColumn:
         self.nulls_first = nulls_first
 
     @classmethod
-    def from_ordering(cls, Schema schema, sort_keys, null_placement='at_end'):
+    def from_ordering(cls, Schema schema not None, sort_keys,
+                      null_placement='at_end'):
         """
         Create a tuple of SortingColumn objects from the same arguments as
         :class:`pyarrow.compute.SortOptions`.
@@ -816,7 +817,7 @@ cdef class SortingColumn:
         return tuple(sorting_columns)
 
     @staticmethod
-    def to_ordering(Schema schema, sorting_columns):
+    def to_ordering(Schema schema not None, sorting_columns):
         """
         Convert a tuple of SortingColumn objects to the same format as
         :class:`pyarrow.compute.SortOptions`.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4293,8 +4293,9 @@ cdef class DictionaryArray(Array):
         return self._indices
 
     @staticmethod
-    def from_buffers(DataType type, int64_t length, buffers, Array dictionary,
-                     int64_t null_count=-1, int64_t offset=0):
+    def from_buffers(DataType type not None, int64_t length, buffers,
+                     Array dictionary, int64_t null_count=-1,
+                     int64_t offset=0):
         """
         Construct a DictionaryArray from buffers.
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4294,7 +4294,7 @@ cdef class DictionaryArray(Array):
 
     @staticmethod
     def from_buffers(DataType type not None, int64_t length, buffers,
-                     Array dictionary, int64_t null_count=-1,
+                     Array dictionary not None, int64_t null_count=-1,
                      int64_t offset=0):
         """
         Construct a DictionaryArray from buffers.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1328,8 +1328,8 @@ cdef class Array(_PandasConvertible):
             (_reduce_array_data(self.sp_array.get().data().get()),)
 
     @staticmethod
-    def from_buffers(DataType type, length, buffers, null_count=-1, offset=0,
-                     children=None):
+    def from_buffers(DataType type not None, length, buffers, null_count=-1,
+                     offset=0, children=None):
         """
         Construct an Array from a sequence of buffers.
 
@@ -1385,6 +1385,8 @@ cdef class Array(_PandasConvertible):
             c_buffers.push_back(pyarrow_unwrap_buffer(buf))
 
         for child in children:
+            if child is None:
+                raise TypeError("Array child must not be None")
             c_child_data.push_back(child.ap.data())
 
         array_data = CArrayData.MakeWithChildren(type.sp_type, length,
@@ -4711,8 +4713,8 @@ cdef class RunEndEncodedArray(Array):
                                                run_ends, values, 0)
 
     @staticmethod
-    def from_buffers(DataType type, length, buffers, null_count=-1, offset=0,
-                     children=None):
+    def from_buffers(DataType type not None, length, buffers, null_count=-1,
+                     offset=0, children=None):
         """
         Construct a RunEndEncodedArray from all the parameters that make up an
         Array.

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -351,6 +351,12 @@ def test_parquet_sorting_column():
     with pytest.raises(ValueError):
         pq.SortingColumn.from_ordering(schema, (("a", "not a valid sort order")))
 
+    with pytest.raises(TypeError, match="Argument 'schema' has incorrect type"):
+        pq.SortingColumn.from_ordering(None, ())
+
+    with pytest.raises(TypeError, match="Argument 'schema' has incorrect type"):
+        pq.SortingColumn.to_ordering(None, ())
+
     with pytest.raises(ValueError, match="inconsistent null placement"):
         sorting_cols = (
             pq.SortingColumn(1, nulls_first=True),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -931,6 +931,9 @@ def test_dictionary_from_buffers(offset):
     with pytest.raises(TypeError, match="Argument 'type' has incorrect type"):
         pa.DictionaryArray.from_buffers(
             None, len(a), a.indices.buffers(), a.dictionary)
+    with pytest.raises(TypeError, match="Argument 'dictionary' has incorrect type"):
+        pa.DictionaryArray.from_buffers(
+            a.type, len(a), a.indices.buffers(), None)
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -928,6 +928,10 @@ def test_dictionary_from_buffers(offset):
                                         offset=offset)
     assert a[offset:] == b
 
+    with pytest.raises(TypeError, match="Argument 'type' has incorrect type"):
+        pa.DictionaryArray.from_buffers(
+            None, len(a), a.indices.buffers(), a.dictionary)
+
 
 @pytest.mark.numpy
 def test_dictionary_from_numpy():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -725,6 +725,9 @@ def test_array_from_buffers():
     with pytest.raises(TypeError):
         pa.Array.from_buffers(pa.int16(), 3, ['', ''], offset=1)
 
+    with pytest.raises(TypeError, match="Argument 'type' has incorrect type"):
+        pa.Array.from_buffers(type=None, length=0, buffers=[])
+
 
 def test_string_binary_from_buffers():
     array = pa.array(["a", None, "b", "c"])
@@ -759,6 +762,20 @@ def test_string_binary_from_buffers():
         len(sliced), buffers[1], buffers[2], None, -1, sliced.offset)
     assert copied.to_pylist() == ["b", "c"]
     assert copied.null_count == 0
+
+
+@pytest.mark.parametrize("array_type", [pa.StringArray, pa.LargeStringArray])
+def test_string_from_buffers_null_buffers(array_type):
+    empty = array_type.from_buffers(
+        length=0, value_offsets=None, data=pa.py_buffer(b""))
+    assert empty.to_pylist() == []
+
+    with pytest.raises(pa.ArrowInvalid, match="Value data buffer is null"):
+        array_type.from_buffers(length=0, value_offsets=None, data=None)
+
+    with pytest.raises(pa.ArrowInvalid, match="Non-empty array but offsets are null"):
+        array_type.from_buffers(
+            length=1, value_offsets=None, data=pa.py_buffer(b"x"))
 
 
 def test_string_view_from_buffers():
@@ -808,6 +825,10 @@ def test_list_from_buffers(list_type_factory):
         # too many children
         pa.Array.from_buffers(ty, 4, buffers[:ty.num_buffers],
                               children=[child, child])
+
+    with pytest.raises(TypeError, match="Array child must not be None"):
+        pa.Array.from_buffers(
+            type=ty, length=4, buffers=buffers[:ty.num_buffers], children=[None])
 
 
 def test_struct_from_buffers():
@@ -4145,6 +4166,9 @@ def test_run_end_encoded_from_buffers():
     with pytest.raises(ValueError):
         pa.RunEndEncodedArray.from_buffers(ree_type, length, buffers,
                                            1, offset, children)
+
+    with pytest.raises(TypeError, match="Argument 'type' has incorrect type"):
+        pa.RunEndEncodedArray.from_buffers(type=None, length=0, buffers=[])
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -396,6 +396,12 @@ def test_filesystem_dataset(mockfs):
     # validation of required arguments
     with pytest.raises(TypeError, match="incorrect type"):
         ds.FileSystemDataset(fragments, file_format, schema)
+    with pytest.raises(TypeError, match="Fragment must not be None"):
+        ds.FileSystemDataset([None], schema=schema, format=file_format)
+    with pytest.raises(TypeError, match="Argument 'schema' has incorrect type"):
+        ds.FileSystemDataset(fragments, schema=None, format=file_format)
+    with pytest.raises(TypeError, match="Argument 'format' has incorrect type"):
+        ds.FileSystemDataset(fragments, schema=schema, format=None)
     # validation of root_partition
     with pytest.raises(TypeError, match="incorrect type"):
         ds.FileSystemDataset(fragments, schema=schema,


### PR DESCRIPTION
### Rationale for this change

Passing null values for required Arrow objects can terminate Python or raise an unrelated AttributeError. Array buffer constructors should reject missing types and child arrays with TypeError.

Fixes https://github.com/apache/arrow/issues/51043.

### What changes are included in this PR?

Required schema, file-format, data-type, dictionary, fragment, and child-array arguments reject null before use. The base Array and RunEndEncodedArray buffer constructors require a data type. String constructors retain their existing buffer validation, including null offsets for empty arrays.

### Are these changes tested?

Native Arrow 26.0.0-SNAPSHOT reproduced the remaining AttributeErrors before the fix and TypeErrors afterward. The focused buffer tests include dictionary construction and both string variants.

```console
$ python -c 'import pyarrow as pa; pa.Array.from_buffers(type=None, length=0, buffers=[])'
Before:
AttributeError: 'NoneType' object has no attribute 'num_fields'
After:
TypeError: Argument 'type' has incorrect type (expected pyarrow.lib.DataType, got NoneType)

$ python -c 'import pyarrow as pa; pa.RunEndEncodedArray.from_buffers(type=None, length=0, buffers=[])'
Before:
AttributeError: 'NoneType' object has no attribute 'num_fields'
After:
TypeError: Argument 'type' has incorrect type (expected pyarrow.lib.DataType, got NoneType)

$ python -c 'import pyarrow as pa; pa.Array.from_buffers(type=pa.list_(pa.int8()), length=0, buffers=[None, pa.py_buffer(bytes(4))], children=[None])'
Before:
AttributeError: 'NoneType' object has no attribute 'ap'
After:
TypeError: Array child must not be None

```

### Are there any user-facing changes?

Missing required objects raise TypeError. Valid null buffers keep their existing behavior.

[New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request) |
[Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html) |
[AI-generated Code Guidance](https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code)

### Was AI used for this PR?

AI assisted with the code, regression tests, and description.

**PR code and description written by:**

- [ ] Human
- [x] AI

**Reviewed before submission by:**

- [ ] Human
- [x] AI
- [ ] Not reviewed

* GitHub Issue: #51043