### PR TITLE
GH-49817: [C++] Reject overflowing decimal strings

### DIFF
--- a/cpp/src/arrow/json/converter_test.cc
+++ b/cpp/src/arrow/json/converter_test.cc
@@ -254,9 +254,15 @@ TEST(ConverterTest, Decimal128And256PrecisionError) {
     std::shared_ptr<StructArray> parse_array;
     ASSERT_OK(ParseFromString(options, json_source, &parse_array));
 
-    std::string error_msg =
-        "Invalid: Failed to convert JSON to " + decimal_type->ToString() +
-        ": 123456789012345678901234567890.0123456789 requires precision 40";
+    std::string error_msg;
+    if (decimal_type->id() == Type::DECIMAL128) {
+      error_msg =
+          "Invalid: The string '123456789012345678901234567890.0123456789' "
+          "cannot be represented as decimal128";
+    } else {
+      error_msg = "Invalid: Failed to convert JSON to " + decimal_type->ToString() +
+                  ": 123456789012345678901234567890.0123456789 requires precision 40";
+    }
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid, ::testing::HasSubstr(error_msg),
         Convert(decimal_type, parse_array->GetFieldByName("")));

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -769,7 +769,8 @@ std::string Decimal128::ToString(int32_t scale) const {
 // the appropriate power of 10 necessary to add source parsed as uint64 and
 // then adds the parsed value of source.
 static inline bool ShiftAndAddWithOverflow(std::string_view input, uint64_t out[],
-                                           size_t out_size) {
+                                           size_t out_size, bool negative) {
+  constexpr uint64_t kSignBit = uint64_t{1} << 63;
   for (size_t posn = 0; posn < input.size();) {
     const size_t group_size = std::min(kInt64DecimalDigits, input.size() - posn);
     const uint64_t multiple = kUInt64PowersOfTen[group_size];
@@ -787,22 +788,15 @@ static inline bool ShiftAndAddWithOverflow(std::string_view input, uint64_t out[
     if (chunk != 0) {
       return true;
     }
+    const uint64_t high = out[out_size - 1];
+    if ((high & kSignBit) != 0 &&
+        (!negative || high != kSignBit ||
+         std::any_of(out, out + out_size - 1, [](uint64_t word) { return word != 0; }))) {
+      return true;
+    }
     posn += group_size;
   }
   return false;
-}
-
-static inline bool MagnitudeOverflowsSignedDecimal(const uint64_t out[], size_t out_size,
-                                                   bool negative) {
-  constexpr uint64_t kSignBit = uint64_t{1} << 63;
-  const uint64_t high = out[out_size - 1];
-  if (high < kSignBit) {
-    return false;
-  }
-  if (!negative || high > kSignBit) {
-    return true;
-  }
-  return std::any_of(out, out + out_size - 1, [](uint64_t word) { return word != 0; });
 }
 
 namespace {
@@ -914,11 +908,9 @@ Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out
     static_assert(Decimal::kBitWidth % 64 == 0, "decimal bit-width not a multiple of 64");
     std::array<uint64_t, Decimal::kBitWidth / 64> little_endian_array{};
     if (ShiftAndAddWithOverflow(dec.whole_digits, little_endian_array.data(),
-                                little_endian_array.size()) ||
+                                little_endian_array.size(), dec.sign == '-') ||
         ShiftAndAddWithOverflow(dec.fractional_digits, little_endian_array.data(),
-                                little_endian_array.size()) ||
-        MagnitudeOverflowsSignedDecimal(little_endian_array.data(),
-                                        little_endian_array.size(), dec.sign == '-')) {
+                                little_endian_array.size(), dec.sign == '-')) {
       return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
     }
     *out = Decimal(bit_util::little_endian::ToNative(little_endian_array));
@@ -985,8 +977,8 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
 
   if (out != nullptr) {
     uint64_t value{0};
-    if (ShiftAndAddWithOverflow(dec.whole_digits, &value, 1) ||
-        ShiftAndAddWithOverflow(dec.fractional_digits, &value, 1) ||
+    if (ShiftAndAddWithOverflow(dec.whole_digits, &value, 1, dec.sign == '-') ||
+        ShiftAndAddWithOverflow(dec.fractional_digits, &value, 1, dec.sign == '-') ||
         value > static_cast<uint64_t>(
                     std::numeric_limits<typename DecimalClass::ValueType>::max())) {
       return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -768,7 +768,8 @@ std::string Decimal128::ToString(int32_t scale) const {
 // Iterates over input and for each group of kInt64DecimalDigits multiple out by
 // the appropriate power of 10 necessary to add source parsed as uint64 and
 // then adds the parsed value of source.
-static inline void ShiftAndAdd(std::string_view input, uint64_t out[], size_t out_size) {
+static inline bool ShiftAndAddWithOverflow(std::string_view input, uint64_t out[],
+                                           size_t out_size) {
   for (size_t posn = 0; posn < input.size();) {
     const size_t group_size = std::min(kInt64DecimalDigits, input.size() - posn);
     const uint64_t multiple = kUInt64PowersOfTen[group_size];
@@ -783,8 +784,25 @@ static inline void ShiftAndAdd(std::string_view input, uint64_t out[], size_t ou
       out[i] = static_cast<uint64_t>(tmp & 0xFFFFFFFFFFFFFFFFULL);
       chunk = static_cast<uint64_t>(tmp >> 64);
     }
+    if (chunk != 0) {
+      return true;
+    }
     posn += group_size;
   }
+  return false;
+}
+
+static inline bool MagnitudeOverflowsSignedDecimal(const uint64_t out[], size_t out_size,
+                                                   bool negative) {
+  constexpr uint64_t kSignBit = uint64_t{1} << 63;
+  const uint64_t high = out[out_size - 1];
+  if (high < kSignBit) {
+    return false;
+  }
+  if (!negative || high > kSignBit) {
+    return true;
+  }
+  return std::any_of(out, out + out_size - 1, [](uint64_t word) { return word != 0; });
 }
 
 namespace {
@@ -895,9 +913,14 @@ Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out
   if (out != nullptr) {
     static_assert(Decimal::kBitWidth % 64 == 0, "decimal bit-width not a multiple of 64");
     std::array<uint64_t, Decimal::kBitWidth / 64> little_endian_array{};
-    ShiftAndAdd(dec.whole_digits, little_endian_array.data(), little_endian_array.size());
-    ShiftAndAdd(dec.fractional_digits, little_endian_array.data(),
-                little_endian_array.size());
+    if (ShiftAndAddWithOverflow(dec.whole_digits, little_endian_array.data(),
+                                little_endian_array.size()) ||
+        ShiftAndAddWithOverflow(dec.fractional_digits, little_endian_array.data(),
+                                little_endian_array.size()) ||
+        MagnitudeOverflowsSignedDecimal(little_endian_array.data(),
+                                        little_endian_array.size(), dec.sign == '-')) {
+      return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
+    }
     *out = Decimal(bit_util::little_endian::ToNative(little_endian_array));
     if (dec.sign == '-') {
       out->Negate();
@@ -962,9 +985,9 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
 
   if (out != nullptr) {
     uint64_t value{0};
-    ShiftAndAdd(dec.whole_digits, &value, 1);
-    ShiftAndAdd(dec.fractional_digits, &value, 1);
-    if (value > static_cast<uint64_t>(
+    if (ShiftAndAddWithOverflow(dec.whole_digits, &value, 1) ||
+        ShiftAndAddWithOverflow(dec.fractional_digits, &value, 1) ||
+        value > static_cast<uint64_t>(
                     std::numeric_limits<typename DecimalClass::ValueType>::max())) {
       return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
     }

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -904,15 +904,15 @@ Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out
     parsed_scale = static_cast<int32_t>(dec.fractional_digits.size());
   }
 
+  static_assert(Decimal::kBitWidth % 64 == 0, "decimal bit-width not a multiple of 64");
+  std::array<uint64_t, Decimal::kBitWidth / 64> little_endian_array{};
+  if (ShiftAndAddWithOverflow(dec.whole_digits, little_endian_array.data(),
+                              little_endian_array.size(), dec.sign == '-') ||
+      ShiftAndAddWithOverflow(dec.fractional_digits, little_endian_array.data(),
+                              little_endian_array.size(), dec.sign == '-')) {
+    return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
+  }
   if (out != nullptr) {
-    static_assert(Decimal::kBitWidth % 64 == 0, "decimal bit-width not a multiple of 64");
-    std::array<uint64_t, Decimal::kBitWidth / 64> little_endian_array{};
-    if (ShiftAndAddWithOverflow(dec.whole_digits, little_endian_array.data(),
-                                little_endian_array.size(), dec.sign == '-') ||
-        ShiftAndAddWithOverflow(dec.fractional_digits, little_endian_array.data(),
-                                little_endian_array.size(), dec.sign == '-')) {
-      return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
-    }
     *out = Decimal(bit_util::little_endian::ToNative(little_endian_array));
     if (dec.sign == '-') {
       out->Negate();
@@ -975,16 +975,15 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
     parsed_scale = static_cast<int32_t>(dec.fractional_digits.size());
   }
 
+  uint64_t value{0};
+  if (ShiftAndAddWithOverflow(dec.whole_digits, &value, 1, dec.sign == '-') ||
+      ShiftAndAddWithOverflow(dec.fractional_digits, &value, 1, dec.sign == '-') ||
+      value > static_cast<uint64_t>(
+                  std::numeric_limits<typename DecimalClass::ValueType>::max()) +
+                  static_cast<uint64_t>(dec.sign == '-')) {
+    return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
+  }
   if (out != nullptr) {
-    uint64_t value{0};
-    if (ShiftAndAddWithOverflow(dec.whole_digits, &value, 1, dec.sign == '-') ||
-        ShiftAndAddWithOverflow(dec.fractional_digits, &value, 1, dec.sign == '-') ||
-        value > static_cast<uint64_t>(
-                    std::numeric_limits<typename DecimalClass::ValueType>::max()) +
-                    static_cast<uint64_t>(dec.sign == '-')) {
-      return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
-    }
-
     *out = DecimalClass(value);
     if (dec.sign == '-') {
       out->Negate();

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -980,7 +980,8 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
     if (ShiftAndAddWithOverflow(dec.whole_digits, &value, 1, dec.sign == '-') ||
         ShiftAndAddWithOverflow(dec.fractional_digits, &value, 1, dec.sign == '-') ||
         value > static_cast<uint64_t>(
-                    std::numeric_limits<typename DecimalClass::ValueType>::max())) {
+                    std::numeric_limits<typename DecimalClass::ValueType>::max()) +
+                    static_cast<uint64_t>(dec.sign == '-')) {
       return Status::Invalid("The string '", s, "' cannot be represented as ", type_name);
     }
 

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -444,6 +444,8 @@ TEST(Decimal128Test, FromStringLimits) {
   //   Decimal128::FromString("-999999999999999999999999999999999999999e1"));
   ASSERT_RAISES(Invalid, Decimal128::FromString(
                              "1.55555555555555555555555555555555555555555555555555"));
+  AssertDecimalFromString("-170141183460469231731687303715884105728",
+                          Decimal128FromLE({0, uint64_t{1} << 63}), 39, 0);
   ASSERT_RAISES(Invalid,
                 Decimal128::FromString("170141183460469231731687303715884105728"));
   ASSERT_RAISES(Invalid,
@@ -556,8 +558,14 @@ TEST(Decimal256Test, FromStringLimits) {
   //   ASSERT_RAISES(Invalid,
   //     Decimal256::FromString("99999999999999999999999999999999999999999999999999999999999999999999999999999"));
   ASSERT_RAISES(Invalid, Decimal256::FromString(std::string(78, '9')));
+  AssertDecimalFromString(
+      "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+      Decimal256FromLE({0, 0, 0, uint64_t{1} << 63}), 77, 0);
   ASSERT_RAISES(Invalid, Decimal256::FromString("5789604461865809771178549250434395392663"
                                                 "4992332820282019728792003956564819968"));
+  ASSERT_RAISES(Invalid,
+                Decimal256::FromString("-5789604461865809771178549250434395392663"
+                                       "4992332820282019728792003956564819969"));
 
   // No exponent, many fractional digits
   AssertDecimalFromString(

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -233,6 +233,9 @@ TEST(Decimal32Test, TestIntMinFitsPrecision) {
 TEST(Decimal32Test, FromStringLimits) {
   AssertDecimalFromString("-2147483648", Decimal32(INT32_MIN), 10, 0);
   ASSERT_RAISES(Invalid, Decimal32::FromString("-2147483649"));
+  int32_t precision, scale;
+  ASSERT_RAISES(Invalid,
+                Decimal32::FromString("-2147483649", nullptr, &precision, &scale));
 }
 
 TEST(Decimal64Test, TestIntMinNegate) {
@@ -249,6 +252,9 @@ TEST(Decimal64Test, TestIntMinFitsPrecision) {
 TEST(Decimal64Test, FromStringLimits) {
   AssertDecimalFromString("-9223372036854775808", Decimal64(INT64_MIN), 19, 0);
   ASSERT_RAISES(Invalid, Decimal64::FromString("-9223372036854775809"));
+  int32_t precision, scale;
+  ASSERT_RAISES(Invalid, Decimal64::FromString("-9223372036854775809", nullptr,
+                                               &precision, &scale));
 }
 
 TYPED_TEST_SUITE(DecimalFromStringTest, DecimalTypes);
@@ -460,6 +466,10 @@ TEST(Decimal128Test, FromStringLimits) {
                 Decimal128::FromString("170141183460469231731687303715884105728"));
   ASSERT_RAISES(Invalid,
                 Decimal128::FromString("-170141183460469231731687303715884105729"));
+  int32_t precision, scale;
+  ASSERT_RAISES(
+      Invalid, Decimal128::FromString("-170141183460469231731687303715884105729", nullptr,
+                                      &precision, &scale));
 
   // No exponent, many fractional digits
   AssertDecimalFromString("9.9999999999999999999999999999999999999", dec38times9pos, 38,
@@ -576,6 +586,11 @@ TEST(Decimal256Test, FromStringLimits) {
   ASSERT_RAISES(Invalid,
                 Decimal256::FromString("-5789604461865809771178549250434395392663"
                                        "4992332820282019728792003956564819969"));
+  int32_t precision, scale;
+  ASSERT_RAISES(Invalid,
+                Decimal256::FromString("-5789604461865809771178549250434395392663"
+                                       "4992332820282019728792003956564819969",
+                                       nullptr, &precision, &scale));
 
   // No exponent, many fractional digits
   AssertDecimalFromString(

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -230,6 +230,11 @@ TEST(Decimal32Test, TestIntMinFitsPrecision) {
   ASSERT_FALSE(d.FitsInPrecision(9));
 }
 
+TEST(Decimal32Test, FromStringLimits) {
+  AssertDecimalFromString("-2147483648", Decimal32(INT32_MIN), 10, 0);
+  ASSERT_RAISES(Invalid, Decimal32::FromString("-2147483649"));
+}
+
 TEST(Decimal64Test, TestIntMinNegate) {
   Decimal64 d(INT64_MIN);
   auto neg = d.Negate();
@@ -239,6 +244,11 @@ TEST(Decimal64Test, TestIntMinNegate) {
 TEST(Decimal64Test, TestIntMinFitsPrecision) {
   Decimal64 d(INT64_MIN);
   ASSERT_FALSE(d.FitsInPrecision(18));
+}
+
+TEST(Decimal64Test, FromStringLimits) {
+  AssertDecimalFromString("-9223372036854775808", Decimal64(INT64_MIN), 19, 0);
+  ASSERT_RAISES(Invalid, Decimal64::FromString("-9223372036854775809"));
 }
 
 TYPED_TEST_SUITE(DecimalFromStringTest, DecimalTypes);

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -435,15 +435,19 @@ TEST(Decimal128Test, FromStringLimits) {
   ASSERT_RAISES(Invalid, Decimal128::FromString("-9e39"));
   ASSERT_RAISES(Invalid, Decimal128::FromString("9.9e40"));
   ASSERT_RAISES(Invalid, Decimal128::FromString("-9.9e40"));
-  // XXX conversion overflows are currently not detected
+  // XXX conversion overflows after parsing are currently not detected
   //   ASSERT_RAISES(Invalid, Decimal128::FromString("99e38"));
   //   ASSERT_RAISES(Invalid, Decimal128::FromString("-99e38"));
   //   ASSERT_RAISES(Invalid,
   //   Decimal128::FromString("999999999999999999999999999999999999999e1"));
   //   ASSERT_RAISES(Invalid,
   //   Decimal128::FromString("-999999999999999999999999999999999999999e1"));
-  //   ASSERT_RAISES(Invalid,
-  //   Decimal128::FromString("999999999999999999999999999999999999999"));
+  ASSERT_RAISES(Invalid, Decimal128::FromString(
+                             "1.55555555555555555555555555555555555555555555555555"));
+  ASSERT_RAISES(Invalid,
+                Decimal128::FromString("170141183460469231731687303715884105728"));
+  ASSERT_RAISES(Invalid,
+                Decimal128::FromString("-170141183460469231731687303715884105729"));
 
   // No exponent, many fractional digits
   AssertDecimalFromString("9.9999999999999999999999999999999999999", dec38times9pos, 38,
@@ -541,7 +545,8 @@ TEST(Decimal256Test, FromStringLimits) {
   ASSERT_RAISES(Invalid, Decimal256::FromString("9.9e78"));
   ASSERT_RAISES(Invalid, Decimal256::FromString("-9.9e78"));
 
-  // XXX conversion overflows are currently not detected
+  // XXX precision limits and conversion overflows after parsing are currently not
+  // detected
   //   ASSERT_RAISES(Invalid, Decimal256::FromString("99e76"));
   //   ASSERT_RAISES(Invalid, Decimal256::FromString("-99e76"));
   //   ASSERT_RAISES(Invalid,
@@ -550,6 +555,9 @@ TEST(Decimal256Test, FromStringLimits) {
   //     Decimal256::FromString("-9999999999999999999999999999999999999999999999999999999999999999999999999999e1"));
   //   ASSERT_RAISES(Invalid,
   //     Decimal256::FromString("99999999999999999999999999999999999999999999999999999999999999999999999999999"));
+  ASSERT_RAISES(Invalid, Decimal256::FromString(std::string(78, '9')));
+  ASSERT_RAISES(Invalid, Decimal256::FromString("5789604461865809771178549250434395392663"
+                                                "4992332820282019728792003956564819968"));
 
   // No exponent, many fractional digits
   AssertDecimalFromString(


### PR DESCRIPTION
### Rationale for this change

Parsing an oversized decimal string can return success with a wrapped integer. The caller receives corrupted data instead of an invalid-input error.

Closes https://github.com/apache/arrow/issues/49817.

### What changes are included in this PR?

Reject carry beyond the destination limbs and values outside the signed range. The smallest negative values remain valid, and metadata-only parsing performs the same range checks.

### Are these changes tested?

#### Testing Done

The same native parser probe returns OK before the fix and Invalid afterward. Save it as arrow-decimal-probe.cc:

```cpp
#include <iostream>
#include <arrow/util/decimal.h>

int main(int, char**) {
  arrow::Decimal128 decimal128;
  arrow::Decimal256 decimal256;
  auto status128 = arrow::Decimal128::FromString(
      "170141183460469231731687303715884105728", &decimal128, nullptr, nullptr);
  auto status256 = arrow::Decimal256::FromString(
      "57896044618658097711785492504343953926634992332820282019728792003956564819968",
      &decimal256, nullptr, nullptr);
  std::cout << "decimal128: " << status128 << '\n';
  std::cout << "decimal256: " << status256 << '\n';
  return status128.ok() || status256.ok();
}
```

Using a shared Arrow build with headers installed under `install`:

```bash
g++ -std=c++20 -I install/include -L build/release arrow-decimal-probe.cc -larrow -o arrow-decimal-probe
export LD_LIBRARY_PATH="$PWD/build/release"
./arrow-decimal-probe
```

Before:

```text
decimal128: OK
decimal256: OK
```

After:

```text
decimal128: Invalid: The string '170141183460469231731687303715884105728' cannot be represented as decimal128
decimal256: Invalid: The string '57896044618658097711785492504343953926634992332820282019728792003956564819968' cannot be represented as decimal256
```

The native regression coverage also includes negative boundaries, metadata-only parsing, and JSON conversion.

### Are there any user-facing changes?

Out-of-range decimal strings return Invalid instead of a wrapped value. Precision, scale, and rounding policy are unchanged.

**This PR contains a "Critical Fix".** It prevents integer overflow from returning incorrect data.

[New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request) |
[Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html) |
[AI-generated Code Guidance](https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code)

### Was AI used for this PR?

AI assisted with the code, regression tests, and description.

**PR code and description written by:**

- [ ] Human
- [x] AI

**Reviewed before submission by:**

- [ ] Human
- [x] AI
- [ ] Not reviewed

* GitHub Issue: #49817