### PR TITLE
GH-51003: [CI][Dev][Python] Bump cython-lint to 0.21.1 and remove Cython pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,7 +146,7 @@ repos:
           ?^python/pyarrow/vendored/|
           )
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.21.0
+    rev: v0.21.1
     hooks:
       - id: cython-lint
         alias: python
@@ -155,10 +155,6 @@ repos:
           - "--no-pycodestyle"
         files: >-
           ^python/
-        # Pin Cython to 3.2.9 until cython-lint supports Cython 3.3:
-        # https://github.com/MarcoGorelli/cython-lint/issues/201
-        additional_dependencies:
-        - Cython==3.2.9
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
     hooks:


### PR DESCRIPTION
### Rationale for this change

A new cython-lint version has been released which allows us to remove a Cython pin for linting.

### What changes are included in this PR?

Bump the cython-lint version and remove the pin.

### Are these changes tested?

Yes, locally and CI

### Are there any user-facing changes?

No

* GitHub Issue: #51003