### PR TITLE
GH-12594: [Python][GPU] Remove inherently crashy CUDA test

### DIFF
--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -297,14 +297,6 @@ def test_foreign_buffer():
     del hbuf
     fbuf.copy_to_host()
 
-    # test deallocating the host buffer memory making it inaccessible
-    hbuf = cuda.new_host_buffer(size * dtype.itemsize)
-    fbuf = ctx.foreign_buffer(hbuf.address, hbuf.size)
-    del hbuf
-    with pytest.raises(pa.ArrowIOError,
-                       match=('Cuda error ')):
-        fbuf.copy_to_host()
-
 
 @pytest.mark.parametrize("size", [0, 1, 1000])
 def test_CudaBuffer(size):


### PR DESCRIPTION
### What changes are included in this PR?

Remove a CUDA test that tries to access an invalid pointer (after the owning resource was deallocated).

On old CUDA setups it used to raise an exception:
```
Cuda error 1 in function 'cuMemcpyDtoH': [CUDA_ERROR_INVALID_VALUE] invalid argument
```
but more recently it has simply started crashing.

### Are these changes tested?

By existing CI tests. This should fix a crash in the CUDA Python CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #12594