### PR TITLE
GH-51208: [CI][Python] Update builds to CPython 3.15.0rc2 (cp315)

### DIFF
--- a/.env
+++ b/.env
@@ -98,6 +98,6 @@ VCPKG="9b965a116838c6cdcd36bca60d1b81b030c8ab8d"    # 2026.05.27 (not release, u
 # ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-08-14
-PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-08-14
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-09-09
+PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-09-09
 

--- a/ci/docker/python-free-threaded-wheel-musllinux-test-imports.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-musllinux-test-imports.dockerfile
@@ -36,7 +36,7 @@ RUN apk update && \
 RUN set -e; \
     case "${python_version}" in \
       3.14) python_patch_version="3.14.7";; \
-      3.15) python_patch_version="3.15.0rc1";; \
+      3.15) python_patch_version="3.15.0rc2";; \
     esac && \
     curl -L -o python.tar.zst \
     https://github.com/astral-sh/python-build-standalone/releases/download/${build_date}/cpython-${python_patch_version}+${build_date}-${arch}-unknown-linux-musl-freethreaded+lto-full.tar.zst && \

--- a/ci/docker/python-free-threaded-wheel-musllinux-test-unittests.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-musllinux-test-unittests.dockerfile
@@ -38,7 +38,7 @@ RUN apk update && \
 RUN set -e; \
     case "${python_version}" in \
       3.14) python_patch_version="3.14.7";; \
-      3.15) python_patch_version="3.15.0rc1";; \
+      3.15) python_patch_version="3.15.0rc2";; \
     esac && \
     curl -L -o python.tar.zst \
     https://github.com/astral-sh/python-build-standalone/releases/download/${build_date}/cpython-${python_patch_version}+${build_date}-${arch}-unknown-linux-musl-freethreaded+lto-full.tar.zst && \

--- a/ci/docker/python-free-threaded-wheel-windows-test-vs2022.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-windows-test-vs2022.dockerfile
@@ -27,10 +27,10 @@ FROM ${base}
 ARG python=3.14
 
 # PYTHON_RELEASE is the python.org ftp directory, which for a pre-release is the
-# final release it leads to, e.g. 3.15.0/python-3.15.0rc1-amd64.exe
+# final release it leads to, e.g. 3.15.0/python-3.15.0rc2-amd64.exe
 # hadolint ignore=SC1072
 RUN (if "%python%"=="3.14" setx PYTHON_VERSION "3.14.7" && setx PYTHON_RELEASE "3.14.7") & \
-    (if "%python%"=="3.15" setx PYTHON_VERSION "3.15.0rc1" && setx PYTHON_RELEASE "3.15.0")
+    (if "%python%"=="3.15" setx PYTHON_VERSION "3.15.0rc2" && setx PYTHON_RELEASE "3.15.0")
 
 SHELL ["powershell", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN $version = $env:PYTHON_VERSION; \

--- a/ci/docker/python-wheel-windows-test-vs2022.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022.dockerfile
@@ -32,7 +32,7 @@ RUN (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.9" && setx PYTHON_CMD "py -
     (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.10" && setx PYTHON_CMD "py -3.12") & \
     (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.14" && setx PYTHON_CMD "py -3.13") & \
     (if "%python%"=="3.14" setx PYTHON_VERSION "3.14.7" && setx PYTHON_CMD "py -3.14") & \
-    (if "%python%"=="3.15" setx PYTHON_VERSION "3.15.0-rc1" && setx PYTHON_CMD "py -3.15")
+    (if "%python%"=="3.15" setx PYTHON_VERSION "3.15.0-rc2" && setx PYTHON_CMD "py -3.15")
 
 
 # hadolint ignore=DL3059

--- a/ci/scripts/install_python.sh
+++ b/ci/scripts/install_python.sh
@@ -30,8 +30,8 @@ versions=([3.11]=3.11.9
           [3.13]=3.13.14
           [3.14]=3.14.7
           [3.14t]=3.14.7
-          [3.15]=3.15.0rc1
-          [3.15t]=3.15.0rc1
+          [3.15]=3.15.0rc2
+          [3.15t]=3.15.0rc2
           )
 
 if [ "$#" -ne 2 ]; then
@@ -50,7 +50,7 @@ if [ "$platform" = "macOS" ]; then
     echo "Downloading Python installer..."
 
     # Match python.org directory by truncating any pre-release suffix: 
-    # 3.15.0rc1 is https://www.python.org/ftp/python/3.15.0/python-3.15.0rc1-macos11.pkg
+    # 3.15.0rc2 is https://www.python.org/ftp/python/3.15.0/python-3.15.0rc2-macos11.pkg
     release_version="${full_version%%[abrc]*}"
     fname="python-${full_version}-macos11.pkg"
     wget "https://www.python.org/ftp/python/${release_version}/${fname}"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1180,7 +1180,7 @@ services:
       args:
         arch: ${ARCH}
         arch_short: ${ARCH_SHORT}
-        base: quay.io/pypa/manylinux_2_28_${ARCH_ALIAS}:2026.08.08-1
+        base: quay.io/pypa/manylinux_2_28_${ARCH_ALIAS}:2026.09.05-1
         manylinux: 2_28
         python: ${PYTHON}
         python_abi_tag: ${PYTHON_ABI_TAG}
@@ -1205,7 +1205,7 @@ services:
       args:
         arch: ${ARCH}
         arch_short: ${ARCH_SHORT}
-        base: quay.io/pypa/musllinux_1_2_${ARCH_ALIAS}:2026.08.08-1
+        base: quay.io/pypa/musllinux_1_2_${ARCH_ALIAS}:2026.09.05-1
         musllinux: 1_2
         python: ${PYTHON}
         python_abi_tag: ${PYTHON_ABI_TAG}
@@ -1246,7 +1246,7 @@ services:
       args:
         base: "alpine:${ALPINE_LINUX}"
         python_version: ${PYTHON}
-        build_date: "20260807"  # python-build-standalone release date
+        build_date: "20260901"  # python-build-standalone release date
         arch: ${ARCH_ALIAS}
       context: .
       dockerfile: ci/docker/python-free-threaded-wheel-musllinux-test-imports.dockerfile
@@ -1290,7 +1290,7 @@ services:
       args:
         base: "alpine:${ALPINE_LINUX}"
         python_version: ${PYTHON}
-        build_date: "20260807"  # python-build-standalone release date
+        build_date: "20260901"  # python-build-standalone release date
         arch: ${ARCH_ALIAS}
       context: .
       dockerfile: ci/docker/python-free-threaded-wheel-musllinux-test-unittests.dockerfile


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/48191 added 3.15 to CI, but pins to rc1 in a few places.

rc2 is now available, this is a minimal update from rc1 to rc2. 

### What changes are included in this PR?

Moves pin from rc1 to rc2 in the dockerfiles and install_python.sh

### Are these changes tested?

Tested the manylinux build

### Are there any user-facing changes?

No
* GitHub Issue: #51208