### PR TITLE
GH-48743: [C++] Reenable timezone tests on Windows GCC

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2570,11 +2570,6 @@ TEST(Cast, TimestampToTime) {
 }
 
 TEST_F(CastTimezone, ZonedTimestampToTime) {
-  // TODO(GH-48743): GCC libstdc++ has a bug with DST transitions
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116110
-#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-  GTEST_SKIP() << "Test triggers GCC libstdc++ bug (GH-48743).";
-#endif
   CheckCast(ArrayFromJSON(timestamp(TimeUnit::NANO, "Pacific/Marquesas"), kTimestampJson),
             ArrayFromJSON(time64(TimeUnit::NANO), R"([
           52259123456789, 50003999999999, 56480001001001, 65000000000000,

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -708,11 +708,6 @@ TEST_F(ScalarTemporalTest, TestIsLeapYear) {
 }
 
 TEST_F(ScalarTemporalTest, TestZoned1) {
-  // TODO(GH-48743): GCC libstdc++ has a bug with DST transitions
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116110
-#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-  GTEST_SKIP() << "Test triggers GCC libstdc++ bug (GH-48743).";
-#endif
   std::vector<std::string> timezones = {"Pacific/Marquesas", "-09:30"};
   for (const auto& timezone : timezones) {
     auto unit = timestamp(TimeUnit::NANO, timezone);
@@ -811,11 +806,6 @@ TEST_F(ScalarTemporalTest, TestZoned1) {
 }
 
 TEST_F(ScalarTemporalTest, TestZoned2) {
-  // TODO(GH-48743): GCC libstdc++ has a bug with DST transitions
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116110
-#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-  GTEST_SKIP() << "Test triggers GCC libstdc++ bug (GH-48743).";
-#endif
   for (auto u : TimeUnit::values()) {
     auto unit = timestamp(u, "Australia/Broken_Hill");
     auto month = "[1, 3, 1, 5, 1, 12, 12, 12, 1, 1, 1, 1, 12, 12, 12, 1, null]";
@@ -2777,11 +2767,6 @@ TEST_F(ScalarTemporalTestMultipleSinceGreaterUnit, CeilUTC) {
 }
 
 TEST_F(ScalarTemporalTestMultipleSinceGreaterUnit, CeilZoned) {
-  // TODO(GH-48743): GCC libstdc++ has a bug with DST transitions
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116110
-#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-  GTEST_SKIP() << "Test triggers GCC libstdc++ bug (GH-48743).";
-#endif
   std::string op = "ceil_temporal";
 
   // Data for tests below was generated via lubridate with the exception
@@ -3172,11 +3157,6 @@ TEST_F(ScalarTemporalTestMultipleSinceGreaterUnit, FloorUTC) {
 }
 
 TEST_F(ScalarTemporalTestMultipleSinceGreaterUnit, FloorZoned) {
-  // TODO(GH-48743): GCC libstdc++ has a bug with DST transitions
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116110
-#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-  GTEST_SKIP() << "Test triggers GCC libstdc++ bug (GH-48743).";
-#endif
   std::string op = "floor_temporal";
 
   // Data for tests below was generated via lubridate with the exception
@@ -3610,11 +3590,6 @@ TEST_F(ScalarTemporalTestMultipleSinceGreaterUnit, RoundUTC) {
 }
 
 TEST_F(ScalarTemporalTestMultipleSinceGreaterUnit, RoundZoned) {
-  // TODO(GH-48743): GCC libstdc++ has a bug with DST transitions
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116110
-#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-  GTEST_SKIP() << "Test triggers GCC libstdc++ bug (GH-48743).";
-#endif
   std::string op = "round_temporal";
 
   // Data for tests below was generated via lubridate with the exception


### PR DESCRIPTION
### Rationale for this change

GCC has has fixed libstdc++ bug [116110](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116110).

### What changes are included in this PR?

Remove all six Windows GCC timezone test skips now and run the tests without version gates first so any remaining toolchain-specific failures can be identified by CI.

Leave the Windows libc++ fallback unchanged.

### Are these changes tested?

By CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #48743