### PR TITLE
GH-51207: [CI][GPU] Improve compilation caching on CUDA CI jobs

### DIFF
--- a/.github/workflows/cuda_extra.yml
+++ b/.github/workflows/cuda_extra.yml
@@ -86,14 +86,14 @@ jobs:
             ubuntu: 22.04
             image: ubuntu-cuda-cpp
             title: AMD64 Ubuntu 22 CUDA 11.7.1
-          - cuda: 12.9.0
-            ubuntu: 24.04
-            image: ubuntu-cuda-python
-            title: AMD64 Ubuntu 24 CUDA 12.9.0 Python
-          - cuda: 11.7.1
-            ubuntu: 22.04
-            image: ubuntu-cuda-python
-            title: AMD64 Ubuntu 22 CUDA 11.7.1 Python
+          # - cuda: 12.9.0
+          #   ubuntu: 24.04
+          #   image: ubuntu-cuda-python
+          #   title: AMD64 Ubuntu 24 CUDA 12.9.0 Python
+          # - cuda: 11.7.1
+          #   ubuntu: 22.04
+          #   image: ubuntu-cuda-python
+          #   title: AMD64 Ubuntu 22 CUDA 11.7.1 Python
     env:
       ARCHERY_DEBUG: 1
       ARROW_ENABLE_TIMING_TESTS: OFF

--- a/.github/workflows/cuda_extra.yml
+++ b/.github/workflows/cuda_extra.yml
@@ -86,14 +86,14 @@ jobs:
             ubuntu: 22.04
             image: ubuntu-cuda-cpp
             title: AMD64 Ubuntu 22 CUDA 11.7.1
-          # - cuda: 12.9.0
-          #   ubuntu: 24.04
-          #   image: ubuntu-cuda-python
-          #   title: AMD64 Ubuntu 24 CUDA 12.9.0 Python
-          # - cuda: 11.7.1
-          #   ubuntu: 22.04
-          #   image: ubuntu-cuda-python
-          #   title: AMD64 Ubuntu 22 CUDA 11.7.1 Python
+          - cuda: 12.9.0
+            ubuntu: 24.04
+            image: ubuntu-cuda-python
+            title: AMD64 Ubuntu 24 CUDA 12.9.0 Python
+          - cuda: 11.7.1
+            ubuntu: 22.04
+            image: ubuntu-cuda-python
+            title: AMD64 Ubuntu 22 CUDA 11.7.1 Python
     env:
       ARCHERY_DEBUG: 1
       ARROW_ENABLE_TIMING_TESTS: OFF

--- a/.github/workflows/cuda_extra.yml
+++ b/.github/workflows/cuda_extra.yml
@@ -105,12 +105,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@v6
+      - name: Restore Docker Volumes
+        uses: apache/infrastructure-actions/stash/restore@ce952724eb5210790bd5d466d70d5d60ac3e6c21
         with:
           path: .docker
-          key: extra-${{ matrix.image }}-${{ hashFiles('cpp/**') }}
-          restore-keys: extra-${{ matrix.image }}-
+          key: extra-${{ matrix.image }}-${{ matrix.ubuntu }}-${{ matrix.cuda }}
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
@@ -134,6 +133,14 @@ jobs:
           sudo sysctl -w vm.mmap_rnd_bits=28
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run ${{ matrix.run-options || '' }} ${{ matrix.image }}
+      - name: Save Docker Volumes
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: apache/infrastructure-actions/stash/save@ce952724eb5210790bd5d466d70d5d60ac3e6c21
+        with:
+          path: .docker
+          key: extra-${{ matrix.image }}-${{ matrix.ubuntu }}-${{ matrix.cuda }}
+          include-hidden-files: true
       - name: Docker Push
         if: >-
           success() &&


### PR DESCRIPTION
### What changes are included in this PR?

Switch to apache/infrastructure-actions/stash for caching of compilation results on CUDA CI jobs, instead of GHA's native caching, because the cache is evicted too often using GHA native caching.

### Are these changes tested?

By existing CI jobs.

### Are there any user-facing changes?

No.
* GitHub Issue: #51207