### PR TITLE
GH-14734: [R] Deprecated filter + across usage

### DIFF
--- a/r/R/dplyr-filter.R
+++ b/r/R/dplyr-filter.R
@@ -33,7 +33,23 @@ apply_filter_impl <- function(
     out$group_by_vars <- by$names
   }
 
-  expanded_filters <- expand_across(out, quos(...))
+  dots <- quos(...)
+  verb <- if (isTRUE(negate)) "filter_out" else "filter"
+  if (any(map_lgl(dots, ~ is_call(quo_get_expr(.x), "across")))) {
+    warn(
+      paste0(
+        "Using `across()` in `",
+        verb,
+        "()` is deprecated, ",
+        "use `if_any()` or `if_all()` instead."
+      ),
+      .frequency = "regularly",
+      .frequency_id = paste0("arrow.", verb, "_across"),
+      class = "lifecycle_warning_deprecated"
+    )
+  }
+
+  expanded_filters <- expand_across(out, dots)
   if (length(expanded_filters) == 0) {
     # Nothing to do
     return(as_adq(.data))

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -547,3 +547,20 @@ test_that("More complex select/filter_out", {
     tbl
   )
 })
+
+test_that("filter() and filter_out() with across() warn about deprecation", {
+  # the warning is rate-limited to once per session by default
+  withr::local_options(rlib_warning_verbosity = "verbose")
+  tab <- arrow_table(tbl)
+
+  expect_warning(
+    tab |> filter(across(c(int, dbl), ~ .x > 2)) |> collect(),
+    "Using `across\\(\\)` in `filter\\(\\)` is deprecated",
+    class = "lifecycle_warning_deprecated"
+  )
+  expect_warning(
+    tab |> filter_out(across(c(int, dbl), ~ .x > 2)) |> collect(),
+    "Using `across\\(\\)` in `filter_out\\(\\)` is deprecated",
+    class = "lifecycle_warning_deprecated"
+  )
+})


### PR DESCRIPTION
### Rationale for this change

Wanna match deprecation of functions that dplyr has

### What changes are included in this PR?

Warn when using across i filter

### Are these changes tested?

Yeah

### Are there any user-facing changes?

Yeah
* GitHub Issue: #14734