### PR TITLE
GH-51229: [Python] Raise instead of crashing on unopened resize

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1101,6 +1101,7 @@ cdef class MemoryMappedFile(NativeFile):
         ----------
         new_size : new size in bytes
         """
+        self._assert_open()
         check_status(self.handle.get().Resize(new_size))
 
     def fileno(self):

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -27,7 +27,6 @@ import os
 import pathlib
 import pytest
 import random
-import subprocess
 import sys
 import tempfile
 import weakref
@@ -1218,21 +1217,8 @@ def test_memory_map_resize(tmpdir):
 
 
 def test_memory_map_resize_uninitialized():
-    code = """if 1:
-    import pyarrow as pa
-
-    try:
+    with pytest.raises(ValueError, match="I/O operation on closed file"):
         pa.MemoryMappedFile().resize(0)
-    except ValueError as exc:
-        assert str(exc) == "I/O operation on closed file"
-    else:
-        raise AssertionError("expected ValueError")
-    """
-    res = subprocess.run([sys.executable, "-c", code],
-                         universal_newlines=True, stderr=subprocess.PIPE)
-    if res.returncode != 0:
-        print(res.stderr, file=sys.stderr)
-        res.check_returncode()
 
 
 def test_memory_zero_length(tmpdir):

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -27,6 +27,7 @@ import os
 import pathlib
 import pytest
 import random
+import subprocess
 import sys
 import tempfile
 import weakref
@@ -1214,6 +1215,24 @@ def test_memory_map_resize(tmpdir):
 
     with open(path, 'rb') as f:
         assert f.read() == bytes(arr[:SIZE])
+
+
+def test_memory_map_resize_uninitialized():
+    code = """if 1:
+    import pyarrow as pa
+
+    try:
+        pa.MemoryMappedFile().resize(0)
+    except ValueError as exc:
+        assert str(exc) == "I/O operation on closed file"
+    else:
+        raise AssertionError("expected ValueError")
+    """
+    res = subprocess.run([sys.executable, "-c", code],
+                         universal_newlines=True, stderr=subprocess.PIPE)
+    if res.returncode != 0:
+        print(res.stderr, file=sys.stderr)
+        res.check_returncode()
 
 
 def test_memory_zero_length(tmpdir):


### PR DESCRIPTION
### Rationale for this change

Calling resize on a memory-mapped file that has never been opened takes down the Python process with a SIGSEGV, so an application cannot catch or recover from it.

### What changes are included in this PR?

The resize path now applies the same open-state check the other file operations already use, before it reaches the native resize call. A directly constructed object raises ValueError.

### Are these changes tested?

The regression runs in-process and checks ValueError and its message with pytest.raises. It does not spawn a subprocess.

Separate, 20-second-bounded processes reproduced the original crash and the exception after the fix. Both used native Arrow 26.0.0-SNAPSHOT; the reused patched extension has byte-identical resize source to this PR.

<details>
<summary>Raw logs</summary>

```console
$ python -c 'import pyarrow as pa; pa.MemoryMappedFile().resize(0)'
Before:
returncode=-11

After:
ValueError: I/O operation on closed file
returncode=1

$ cd python
$ python -m pytest pyarrow/tests/test_io.py -k memory_map_resize -q
..                                                                       [100%]
2 passed, 161 deselected, 1 warning in 1.02s
```

</details>

### Are there any user-facing changes?

Yes. Misuse of a directly constructed memory-mapped file now raises a Python exception instead of terminating the process.

**This PR contains a "Critical Fix".** It fixes a process crash reachable from ordinary Python-level object state.

* GitHub Issue: #51229