### PR TITLE
GH-51228: [Python] Raise instead of crashing on an invalid registry

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -3482,6 +3482,8 @@ def _register_user_defined_function(register_func, func, function_name, function
 
     if func_registry is None:
         c_func_registry = NULL
+    elif not isinstance(func_registry, FunctionRegistry):
+        raise TypeError("func_registry must be a FunctionRegistry")
     else:
         c_func_registry = (<FunctionRegistry>func_registry).registry
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -3516,6 +3516,8 @@ def call_tabular_function(function_name, args=None, func_registry=None):
     c_func_name = tobytes(function_name)
     if func_registry is None:
         c_func_registry = NULL
+    elif not isinstance(func_registry, FunctionRegistry):
+        raise TypeError("func_registry must be a FunctionRegistry")
     else:
         c_func_registry = (<FunctionRegistry>func_registry).registry
     if args is None:

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -252,6 +252,25 @@ def test_call_tabular_function_rejects_invalid_registry():
         pc.call_tabular_function("", None, 1)
 
 
+@pytest.mark.parametrize("register_function", [
+    pc.register_scalar_function,
+    pc.register_vector_function,
+    pc.register_aggregate_function,
+    pc.register_tabular_function,
+])
+def test_register_function_rejects_invalid_registry(register_function):
+    with pytest.raises(TypeError,
+                       match="func_registry must be a FunctionRegistry"):
+        register_function(
+            func=lambda context: None,
+            function_name="invalid_registry",
+            function_doc={"summary": "", "description": ""},
+            in_types={},
+            out_type=pa.struct([]),
+            func_registry=1,
+        )
+
+
 def _check_get_function(name, expected_func_cls, expected_ker_cls,
                         min_num_kernels=1):
     func = pc.get_function(name)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -247,6 +247,7 @@ def test_list_functions():
     assert "add" in pc.list_functions()
 
 
+@pytest.mark.processes
 def test_call_tabular_function_rejects_invalid_registry():
     code = """if 1:
     import pyarrow.compute as pc

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -25,6 +25,7 @@ import math
 import os
 import pytest
 import random
+import subprocess
 import sys
 import textwrap
 
@@ -244,6 +245,24 @@ def test_option_class_equality(request):
 def test_list_functions():
     assert len(pc.list_functions()) > 10
     assert "add" in pc.list_functions()
+
+
+def test_call_tabular_function_rejects_invalid_registry():
+    code = """if 1:
+    import pyarrow.compute as pc
+
+    try:
+        pc.call_tabular_function("", None, 1)
+    except TypeError as exc:
+        assert str(exc) == "func_registry must be a FunctionRegistry"
+    else:
+        raise AssertionError("expected TypeError")
+    """
+    res = subprocess.run([sys.executable, "-c", code],
+                         universal_newlines=True, stderr=subprocess.PIPE)
+    if res.returncode != 0:
+        print(res.stderr, file=sys.stderr)
+        res.check_returncode()
 
 
 def _check_get_function(name, expected_func_cls, expected_ker_cls,

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -25,7 +25,6 @@ import math
 import os
 import pytest
 import random
-import subprocess
 import sys
 import textwrap
 
@@ -247,23 +246,10 @@ def test_list_functions():
     assert "add" in pc.list_functions()
 
 
-@pytest.mark.processes
 def test_call_tabular_function_rejects_invalid_registry():
-    code = """if 1:
-    import pyarrow.compute as pc
-
-    try:
+    with pytest.raises(TypeError,
+                       match="func_registry must be a FunctionRegistry"):
         pc.call_tabular_function("", None, 1)
-    except TypeError as exc:
-        assert str(exc) == "func_registry must be a FunctionRegistry"
-    else:
-        raise AssertionError("expected TypeError")
-    """
-    res = subprocess.run([sys.executable, "-c", code],
-                         universal_newlines=True, stderr=subprocess.PIPE)
-    if res.returncode != 0:
-        print(res.stderr, file=sys.stderr)
-        res.check_returncode()
 
 
 def _check_get_function(name, expected_func_cls, expected_ker_cls,


### PR DESCRIPTION
### Rationale for this change

An invalid registry passed to a tabular call or UDF registration can terminate Python with SIGSEGV. Applications should receive TypeError instead.

Fixes https://github.com/apache/arrow/issues/51228.

### What changes are included in this PR?

Validate the registry before reading its native pointer. The shared registration check covers scalar, vector, aggregate, and tabular functions. Default and explicit registries retain their behavior.

### Are these changes tested?

#### Testing Done

The following probe runs each API in a separate native process. Save it as arrow-registry-probe.py:

```python
import subprocess
import sys

prefix = "import pyarrow as pa; import pyarrow.compute as pc; "
calls = {"tabular_call": "pc.call_tabular_function('', None, 1)"}
for kind in ("scalar", "vector", "aggregate", "tabular"):
    calls[kind] = (
        f"pc.register_{kind}_function("
        "func=lambda context: None, function_name='example', "
        "function_doc={'summary': '', 'description': ''}, in_types={}, "
        "out_type=pa.struct([]), func_registry=1)"
    )

outcomes: list[bool] = []
for name, call in calls.items():
    result = subprocess.run(
        args=[sys.executable, "-c", prefix + call],
        capture_output=True, text=True, timeout=20,
    )
    print(f"{name}: returncode={result.returncode}", flush=True)
    if result.stderr:
        print(result.stderr.splitlines()[-1], flush=True)
    outcomes.append(
        result.returncode == 1
        and "TypeError: func_registry must be a FunctionRegistry" in result.stderr
    )
assert all(outcomes)
```

```console
$ python arrow-registry-probe.py
Before:
tabular_call: returncode=-11
scalar: returncode=-11
vector: returncode=-11
aggregate: returncode=-11
tabular: returncode=-11
AssertionError

After:
tabular_call: returncode=1
TypeError: func_registry must be a FunctionRegistry
scalar: returncode=1
TypeError: func_registry must be a FunctionRegistry
vector: returncode=1
TypeError: func_registry must be a FunctionRegistry
aggregate: returncode=1
TypeError: func_registry must be a FunctionRegistry
tabular: returncode=1
TypeError: func_registry must be a FunctionRegistry
```

The parent probe exits 1 before the fix and 0 afterward.

### Are there any user-facing changes?

Invalid registry arguments raise TypeError instead of terminating Python.

[New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request) |
[Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html) |
[AI-generated Code Guidance](https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code)

### Was AI used for this PR?

AI assisted with the code, regression tests, and description.

**PR code and description written by:**

- [ ] Human
- [x] AI

**Reviewed before submission by:**

- [ ] Human
- [x] AI
- [ ] Not reviewed

* GitHub Issue: #51228