### PR TITLE
GH-51224: [C++] Keep the correct nulls when winsorizing a sliced array

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_statistics.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics.cc
@@ -128,15 +128,16 @@ struct Winsorize {
     DCHECK_EQ(out->buffers.size(), data.buffers.size());
     out->null_count = data.null_count.load();
     out->length = data.length;
-    // The output is zero-offset, so a sliced input's validity bitmap cannot be shared as is:
-    // it would be read from bit 0 instead of from `data.offset`. Copy the slice's bits out.
-    if (data.buffers[0]) {
+    // A zero-offset input can share its validity bitmap, because the output is read from
+    // bit 0 as well. A sliced input cannot: sharing would read the bitmap from bit 0
+    // instead of from `data.offset`, so copy the slice's bits out.
+    if (data.buffers[0] && data.offset != 0) {
       ARROW_ASSIGN_OR_RAISE(
           out->buffers[0], arrow::internal::CopyBitmap(ctx->memory_pool(),
                                                        data.buffers[0]->data(), data.offset,
                                                        data.length));
     } else {
-      out->buffers[0] = nullptr;
+      out->buffers[0] = data.buffers[0];
     }
     ARROW_ASSIGN_OR_RAISE(out->buffers[1], ctx->Allocate(out->length * sizeof(CType)));
     // Avoid leaving uninitialized memory under null entries

--- a/cpp/src/arrow/compute/kernels/vector_statistics.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics.cc
@@ -32,6 +32,7 @@
 #include "arrow/scalar.h"
 #include "arrow/status.h"
 #include "arrow/util/bit_run_reader.h"
+#include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging_internal.h"
 
@@ -127,7 +128,16 @@ struct Winsorize {
     DCHECK_EQ(out->buffers.size(), data.buffers.size());
     out->null_count = data.null_count.load();
     out->length = data.length;
-    out->buffers[0] = data.buffers[0];
+    // The output is zero-offset, so a sliced input's validity bitmap cannot be shared as is:
+    // it would be read from bit 0 instead of from `data.offset`. Copy the slice's bits out.
+    if (data.buffers[0]) {
+      ARROW_ASSIGN_OR_RAISE(
+          out->buffers[0], arrow::internal::CopyBitmap(ctx->memory_pool(),
+                                                       data.buffers[0]->data(), data.offset,
+                                                       data.length));
+    } else {
+      out->buffers[0] = nullptr;
+    }
     ARROW_ASSIGN_OR_RAISE(out->buffers[1], ctx->Allocate(out->length * sizeof(CType)));
     // Avoid leaving uninitialized memory under null entries
     std::memset(out->buffers[1]->mutable_data(), 0, out->length * sizeof(CType));

--- a/cpp/src/arrow/compute/kernels/vector_statistics.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics.cc
@@ -133,9 +133,9 @@ struct Winsorize {
     // instead of from `data.offset`, so copy the slice's bits out.
     if (data.buffers[0] && data.offset != 0) {
       ARROW_ASSIGN_OR_RAISE(
-          out->buffers[0], arrow::internal::CopyBitmap(ctx->memory_pool(),
-                                                       data.buffers[0]->data(), data.offset,
-                                                       data.length));
+          out->buffers[0],
+          arrow::internal::CopyBitmap(ctx->memory_pool(), data.buffers[0]->data(),
+                                      data.offset, data.length));
     } else {
       out->buffers[0] = data.buffers[0];
     }

--- a/cpp/src/arrow/compute/kernels/vector_statistics.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics.cc
@@ -128,6 +128,10 @@ struct Winsorize {
     DCHECK_EQ(out->buffers.size(), data.buffers.size());
     out->null_count = data.null_count.load();
     out->length = data.length;
+    // ExecChunked seeds the output from the input chunk, so it can arrive carrying that
+    // chunk's offset. The buffers below are built for this slice alone and are read from
+    // bit and element zero, so the output owns no offset of its own.
+    out->offset = 0;
     // A zero-offset input can share its validity bitmap, because the output is read from
     // bit 0 as well. A sliced input cannot: sharing would read the bitmap from bit 0
     // instead of from `data.offset`, so copy the slice's bits out.

--- a/cpp/src/arrow/compute/kernels/vector_statistics_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics_test.cc
@@ -110,7 +110,8 @@ TEST_F(TestWinsorize, SlicedInput) {
   options_.lower_limit = 0.25;
   options_.upper_limit = 0.75;
   auto dense = ArrayFromJSON(float64(), "[1.0, 2.0, 3.0, 44.0, 55.0, 66.0, 77.0]");
-  CheckWinsorize(dense->Slice(1, 5), ArrayFromJSON(float64(), "[3.0, 3.0, 44.0, 55.0, 55.0]"));
+  CheckWinsorize(dense->Slice(1, 5),
+                 ArrayFromJSON(float64(), "[3.0, 3.0, 44.0, 55.0, 55.0]"));
 }
 
 TEST_F(TestWinsorize, Integral) {

--- a/cpp/src/arrow/compute/kernels/vector_statistics_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics_test.cc
@@ -87,6 +87,32 @@ TEST_F(TestWinsorize, FloatingPoint) {
   }
 }
 
+TEST_F(TestWinsorize, SlicedInput) {
+  // GH-51224: the output is zero-offset, so a sliced input's validity bitmap must be
+  // copied from the slice rather than shared, otherwise it is read from bit 0.
+  for (auto type : FloatingPointTypes()) {
+    options_.lower_limit = 0.0;
+    options_.upper_limit = 1.0;
+    // The parent's leading nulls sit at different positions than the slice's, so sharing
+    // the bitmap would move the nulls.
+    auto parent = ArrayFromJSON(type, "[1.1, 2.2, null, 4.4, null, 6.6, 7.7, 8.8]");
+    auto expected = ArrayFromJSON(type, "[null, 4.4, null, 6.6, 7.7]");
+    CheckWinsorize(parent->Slice(2, 5), expected);
+  }
+  for (auto type : IntTypes()) {
+    options_.lower_limit = 0.0;
+    options_.upper_limit = 1.0;
+    auto parent = ArrayFromJSON(type, "[1, 2, null, 4, null, 6, 7, 8]");
+    auto expected = ArrayFromJSON(type, "[null, 4, null, 6, 7]");
+    CheckWinsorize(parent->Slice(2, 5), expected);
+  }
+  // A slice of an array with no nulls at all keeps the null-free fast path.
+  options_.lower_limit = 0.25;
+  options_.upper_limit = 0.75;
+  auto dense = ArrayFromJSON(float64(), "[1.0, 2.0, 3.0, 44.0, 55.0, 66.0, 77.0]");
+  CheckWinsorize(dense->Slice(1, 5), ArrayFromJSON(float64(), "[3.0, 3.0, 44.0, 55.0, 55.0]"));
+}
+
 TEST_F(TestWinsorize, Integral) {
   for (auto type : IntTypes()) {
     options_.lower_limit = 0.25;

--- a/cpp/src/arrow/compute/kernels/vector_statistics_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics_test.cc
@@ -114,6 +114,21 @@ TEST_F(TestWinsorize, SlicedInput) {
                  ArrayFromJSON(float64(), "[3.0, 3.0, 44.0, 55.0, 55.0]"));
 }
 
+TEST_F(TestWinsorize, SlicedChunkedInput) {
+  // ExecChunked seeds each output from the input chunk, so a sliced chunk carries a
+  // non-zero offset into ClipValues. The output buffers cover the slice alone.
+  options_.lower_limit = 0.0;
+  options_.upper_limit = 1.0;
+  auto parent = ArrayFromJSON(float64(), "[1.1, 2.2, null, 4.4, null, 6.6, 7.7, 8.8]");
+  auto chunked = std::make_shared<ChunkedArray>(
+      ArrayVector{parent->Slice(2, 3), parent->Slice(5, 3)});
+  auto expected = std::make_shared<ChunkedArray>(ArrayVector{
+      ArrayFromJSON(float64(), "[null, 4.4, null]"),
+      ArrayFromJSON(float64(), "[6.6, 7.7, 8.8]"),
+  });
+  CheckWinsorize(chunked, expected);
+}
+
 TEST_F(TestWinsorize, Integral) {
   for (auto type : IntTypes()) {
     options_.lower_limit = 0.25;


### PR DESCRIPTION
### Rationale for this change

Winsorizing a sliced array returns nulls in the wrong positions, even when the clipping limits should leave the input unchanged.

Closes https://github.com/apache/arrow/issues/51224.

### What changes are included in this PR?

Use the existing bitmap helper to preserve the slice's validity bits. It shares or copies the bitmap as needed and propagates allocation failures.

### Are these changes tested?

With native PyArrow built from the revision being checked, save this as arrow-winsorize-probe.py:

```python
import pyarrow as pa
import pyarrow.compute as pc

parent = pa.array([1.0, 2.0, None, 4.0, None, 6.0, 7.0, 8.0], type=pa.float64())
sliced = parent.slice(offset=2, length=5)
result = pc.winsorize(sliced, lower_limit=0.0, upper_limit=1.0)
print(result.to_pylist(), flush=True)
assert result.equals(sliced)
```

Before, against the unmodified native library:

```console
$ python arrow-winsorize-probe.py
[0.0, 4.0, None, 6.0, None]
AssertionError
```

After, against the library built with this change:

```console
$ python arrow-winsorize-probe.py
[None, 4.0, None, 6.0, 7.0]
```

The regression coverage includes sliced arrays and chunks, including a null-free slice.

### Are there any user-facing changes?

Sliced inputs retain the correct values and null positions.

[New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request) |
[Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html) |
[AI-generated Code Guidance](https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code)

### Was AI used for this PR?

AI assisted with the code, regression tests, and description.

**PR code and description written by:**

- [ ] Human
- [x] AI

**Reviewed before submission by:**

- [ ] Human
- [x] AI
- [ ] Not reviewed

* GitHub Issue: #51224