### PR TITLE
MINOR: [C++][CI] Bump ccache max size

### DIFF
--- a/ci/scripts/ccache_setup.sh
+++ b/ci/scripts/ccache_setup.sh
@@ -25,6 +25,6 @@ set -eux
   echo "CCACHE_COMPILERCHECK=content"
   echo "CCACHE_COMPRESS=1"
   echo "CCACHE_COMPRESSLEVEL=6"
-  echo "CCACHE_MAXSIZE=1G"
+  echo "CCACHE_MAXSIZE=1.5G"
   echo "CCACHE_NOHASHDIR=1"
 } >> "$GITHUB_ENV"

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,7 +57,7 @@ x-ccache: &ccache
   CCACHE_COMPILERCHECK: content
   CCACHE_COMPRESS: 1
   CCACHE_COMPRESSLEVEL: 6
-  CCACHE_MAXSIZE: 1G
+  CCACHE_MAXSIZE: 1.5G
   CCACHE_DIR: /ccache
   # Some builds (such as PyArrow) copy their source files in a temporary directory,
   # avoid hashing the current directory to make ccache useful on those builds.


### PR DESCRIPTION
### Rationale for this change

When trying to analyze the compilation caching behavior on https://github.com/apache/arrow/pull/51255, I realized that our maximum ccache size of 1GB had become too small for some builds. The result is that a single build cannot be cached in its entirety, making identical rebuilds costlier than they should be.

### What changes are included in this PR?

Bump ccache max size to 1.5 GB.

### Are these changes tested?

Yes, by existing builds.

### Are there any user-facing changes?

No.