### PR TITLE
GH-51260: [Python][Docs][CI] Disabled numpydoc PR02 check may skip PR03

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1556,7 +1556,7 @@ services:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         pip install -e /arrow/dev/archery[numpydoc] &&
-        archery numpydoc --allow-rule GL10,PR01,PR03,PR04,PR05,PR10,RT03,YD01 &&
+        archery numpydoc --allow-rule GL10,PR01,PR02,PR03,PR04,PR05,PR10,RT03,YD01 &&
         /arrow/ci/scripts/python_test.sh /arrow &&
         /arrow/ci/scripts/python_test_type_annotations.sh /arrow/python"]
 

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -93,6 +93,10 @@ class NumpyDoc:
         EnumMeta: ["PR01"]
     }
 
+    # When there's no signature (like for Cython classes where it can't parse
+    # __init__), numpydoc sees zero parameters and reports "Unknown parameters"
+    PARAMETER_CHECKS = ("PR01", "PR02", "PR03")
+
     def __init__(self, symbols=None):
         if not have_numpydoc:
             raise RuntimeError(
@@ -203,6 +207,13 @@ class NumpyDoc:
                 logger.warning(f"Unable to validate `{symbol}` due to `{e}`")
                 return
 
+            try:
+                inspect.signature(obj)
+            except (TypeError, ValueError):
+                has_signature = False
+            else:
+                has_signature = True
+
             errors = []
             for errcode, errmsg in result.get('errors', []):
                 if allow_rules and errcode not in allow_rules:
@@ -212,6 +223,9 @@ class NumpyDoc:
                 if any(isinstance(obj, obj_type) and errcode in errcode_list
                        for obj_type, errcode_list
                        in NumpyDoc.IGNORE_VALIDATION_ERRORS_FOR_TYPE.items()):
+                    continue
+                if (not has_signature and
+                        errcode in NumpyDoc.PARAMETER_CHECKS):
                     continue
                 errors.append((errcode, errmsg))
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,6 +69,7 @@ test = [
 checks = [
     "GL10",
     "PR01",
+    "PR02",
     "PR03",
     "PR04",
     "PR05",


### PR DESCRIPTION
### Rationale for this change
#51260, ensure PR03 is reported

### What changes are included in this PR?
Test enabling PR02

### Are these changes tested?
Not yet fully.

### Are there any user-facing changes?

* GitHub Issue: #51260