### PR TITLE
GH-51264: [C++][Parquet] Make MemoryPool settable on ReaderProperties

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -68,46 +68,25 @@ parquet::ReaderProperties MakeReaderProperties(
     const ParquetFileFormat& format, ParquetFragmentScanOptions* parquet_scan_options,
     const std::string& path = "", std::shared_ptr<fs::FileSystem> filesystem = nullptr,
     MemoryPool* pool = default_memory_pool()) {
-  // FIXME (GH-51264): Can't mutate pool after ReaderProperties construction.
-  parquet::ReaderProperties properties(pool);
-  if (parquet_scan_options->reader_properties->is_buffered_stream_enabled()) {
-    properties.enable_buffered_stream();
-  } else {
-    properties.disable_buffered_stream();
-  }
-  properties.set_buffer_size(parquet_scan_options->reader_properties->buffer_size());
-  properties.set_footer_read_size(
-      parquet_scan_options->reader_properties->footer_read_size());
-
-  auto file_decryption_prop =
-      parquet_scan_options->reader_properties->file_decryption_properties();
+  parquet::ReaderProperties properties = *parquet_scan_options->reader_properties;
+  properties.set_memory_pool(pool);
+  properties.disable_read_dense_for_nullable();
 
 #ifdef PARQUET_REQUIRE_ENCRYPTION
   auto parquet_decrypt_config = parquet_scan_options->parquet_decryption_config;
 
   if (parquet_decrypt_config != nullptr) {
-    file_decryption_prop =
+    auto file_decryption_prop =
         parquet_decrypt_config->crypto_factory->GetFileDecryptionProperties(
             *parquet_decrypt_config->kms_connection_config,
             *parquet_decrypt_config->decryption_config, path, filesystem);
+    properties.file_decryption_properties(file_decryption_prop);
   }
 #else
   if (parquet_scan_options->parquet_decryption_config != nullptr) {
     parquet::ParquetException::NYI("Encryption is not supported in this build.");
   }
 #endif
-
-  properties.file_decryption_properties(file_decryption_prop);
-
-  properties.set_thrift_string_size_limit(
-      parquet_scan_options->reader_properties->thrift_string_size_limit());
-  properties.set_thrift_container_size_limit(
-      parquet_scan_options->reader_properties->thrift_container_size_limit());
-  properties.set_schema_depth_limit(
-      parquet_scan_options->reader_properties->schema_depth_limit());
-
-  properties.set_page_checksum_verification(
-      parquet_scan_options->reader_properties->page_checksum_verification());
 
   return properties;
 }

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -81,6 +81,8 @@ class PARQUET_EXPORT ReaderProperties {
       : pool_(pool) {}
 
   MemoryPool* memory_pool() const { return pool_; }
+  /// Set the memory pool.
+  void set_memory_pool(MemoryPool* pool) { pool_ = pool; }
 
   std::shared_ptr<ArrowInputStream> GetStream(std::shared_ptr<ArrowInputFile> source,
                                               int64_t start, int64_t num_bytes);

--- a/cpp/src/parquet/properties_test.cc
+++ b/cpp/src/parquet/properties_test.cc
@@ -24,6 +24,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/io/memory.h"
+#include "arrow/memory_pool.h"
 
 #include "parquet/file_reader.h"
 #include "parquet/properties.h"
@@ -42,6 +43,22 @@ TEST(TestReaderProperties, Basics) {
   ASSERT_EQ(props.footer_read_size(), kDefaultFooterReadSize);
   ASSERT_FALSE(props.is_buffered_stream_enabled());
   ASSERT_FALSE(props.page_checksum_verification());
+}
+
+TEST(TestReaderProperties, SetMemoryPool) {
+  ReaderProperties props;
+  ASSERT_EQ(props.memory_pool(), ::arrow::default_memory_pool());
+
+  ::arrow::ProxyMemoryPool custom_pool(::arrow::default_memory_pool());
+  props.set_memory_pool(&custom_pool);
+  ASSERT_EQ(props.memory_pool(), &custom_pool);
+
+  ReaderProperties copied_props = props;
+  ASSERT_EQ(copied_props.memory_pool(), &custom_pool);
+
+  copied_props.set_memory_pool(::arrow::default_memory_pool());
+  ASSERT_EQ(copied_props.memory_pool(), ::arrow::default_memory_pool());
+  ASSERT_EQ(props.memory_pool(), &custom_pool);
 }
 
 TEST(TestWriterProperties, Basics) {

--- a/python/pyarrow/includes/libparquet.pxd
+++ b/python/pyarrow/includes/libparquet.pxd
@@ -418,6 +418,9 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
                                        uint32_t* metadata_len)
 
     cdef cppclass CReaderProperties" parquet::ReaderProperties":
+        CMemoryPool* memory_pool() const
+        void set_memory_pool(CMemoryPool* pool)
+
         c_bool is_buffered_stream_enabled() const
         void enable_buffered_stream()
         void disable_buffered_stream()


### PR DESCRIPTION
**Rationale for this change**
In arrow::dataset::MakeReaderProperties, all parquet::ReaderProperties options had to be copied field-by-field from parquet_scan_options->reader_properties because ReaderProperties did not support mutating or setting MemoryPool* after construction.

**What changes are included in this PR?**
Added set_memory_pool to parquet::ReaderProperties in cpp/src/parquet/properties.h. 
Added unit test TestReaderProperties.SetMemoryPool in cpp/src/parquet/properties_test.cc.

Are these changes tested?
Yes

Are there any user-facing changes?
No
* GitHub Issue: #51264