### PR TITLE
Eliminate unnecessary refcount traffic from `shared_ptr` parameters passed by value that don't need to be

### DIFF
--- a/cpp/src/arrow/acero/asof_join_benchmark.cc
+++ b/cpp/src/arrow/acero/asof_join_benchmark.cc
@@ -54,7 +54,7 @@ static void TableJoinOverhead(benchmark::State& state,
                               TableGenerationProperties right_table_properties,
                               int batch_size, int num_right_tables,
                               std::string factory_name,
-                              std::shared_ptr<ExecNodeOptions> options) {
+                              const std::shared_ptr<ExecNodeOptions>& options) {
   left_table_properties.column_prefix = "lt";
   left_table_properties.seed = 0;
   ASSERT_OK_AND_ASSIGN(TableStats left_table_stats, MakeTable(left_table_properties));

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -237,7 +237,7 @@ struct MemoStore {
   struct Entry {
     Entry() = default;
 
-    Entry(OnType time, std::shared_ptr<arrow::RecordBatch> batch, row_index_t row)
+    Entry(OnType time, const std::shared_ptr<arrow::RecordBatch>& batch, row_index_t row)
         : time(time), batch(batch), row(row) {}
 
     void swap(Entry& other) {

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1396,7 +1396,7 @@ struct BackpressureCountingNode : public MapNode {
   }
 
   BackpressureCountingNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-                           std::shared_ptr<Schema> output_schema,
+                           const std::shared_ptr<Schema>& output_schema,
                            const BackpressureCountingNodeOptions& options)
       : MapNode(plan, inputs, output_schema), counters(options.counters) {}
 

--- a/cpp/src/arrow/acero/exec_plan.cc
+++ b/cpp/src/arrow/acero/exec_plan.cc
@@ -1150,10 +1150,10 @@ ExecFactoryRegistry* default_exec_factory_registry() {
 }
 
 Result<std::function<Future<std::optional<ExecBatch>>()>> MakeReaderGenerator(
-    std::shared_ptr<RecordBatchReader> reader, ::arrow::internal::Executor* io_executor,
+    const std::shared_ptr<RecordBatchReader>& reader, ::arrow::internal::Executor* io_executor,
     int max_q, int q_restart) {
   auto batch_it = MakeMapIterator(
-      [](std::shared_ptr<RecordBatch> batch) {
+      [](const std::shared_ptr<RecordBatch>& batch) {
         return std::make_optional(ExecBatch(*batch));
       },
       MakeIteratorFromReader(reader));

--- a/cpp/src/arrow/acero/exec_plan.h
+++ b/cpp/src/arrow/acero/exec_plan.h
@@ -812,7 +812,7 @@ constexpr int kDefaultBackgroundQRestart = 16;
 /// Useful as a source node for an Exec plan
 ARROW_ACERO_EXPORT
 Result<std::function<Future<std::optional<ExecBatch>>()>> MakeReaderGenerator(
-    std::shared_ptr<RecordBatchReader> reader, arrow::internal::Executor* io_executor,
+    const std::shared_ptr<RecordBatchReader>& reader, arrow::internal::Executor* io_executor,
     int max_q = kDefaultBackgroundMaxQ, int q_restart = kDefaultBackgroundQRestart);
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -227,7 +227,7 @@ Result<Datum> NaiveGroupBy(std::vector<Datum> arguments, std::vector<Datum> keys
 }
 
 Result<Datum> MakeGroupByOutput(const std::vector<ExecBatch>& output_batches,
-                                const std::shared_ptr<Schema> output_schema,
+                                const std::shared_ptr<Schema>& output_schema,
                                 size_t num_aggregates, size_t num_keys, bool naive) {
   ArrayVector out_arrays(num_aggregates + num_keys);
   for (size_t i = 0; i < out_arrays.size(); ++i) {

--- a/cpp/src/arrow/acero/source_node.cc
+++ b/cpp/src/arrow/acero/source_node.cc
@@ -301,7 +301,7 @@ struct SourceNode : ExecNode, public TracedNode {
 };
 
 struct TableSourceNode : public SourceNode {
-  TableSourceNode(ExecPlan* plan, std::shared_ptr<Table> table, int64_t batch_size)
+  TableSourceNode(ExecPlan* plan, const std::shared_ptr<Table>& table, int64_t batch_size)
       : SourceNode(plan, table->schema(), TableGenerator(*table, batch_size),
                    Ordering::Implicit()) {}
 
@@ -319,7 +319,7 @@ struct TableSourceNode : public SourceNode {
 
   const char* kind_name() const override { return "TableSourceNode"; }
 
-  static arrow::Status ValidateTableSourceNodeInput(const std::shared_ptr<Table> table,
+  static arrow::Status ValidateTableSourceNodeInput(const std::shared_ptr<Table>& table,
                                                     const int64_t batch_size) {
     if (table == nullptr) {
       return Status::Invalid("TableSourceNode requires table which is not null");
@@ -370,7 +370,7 @@ struct TableSourceNode : public SourceNode {
 
 template <typename This, typename Options>
 struct SchemaSourceNode : public SourceNode {
-  SchemaSourceNode(ExecPlan* plan, std::shared_ptr<Schema> schema,
+  SchemaSourceNode(ExecPlan* plan, const std::shared_ptr<Schema>& schema,
                    arrow::AsyncGenerator<std::optional<ExecBatch>> generator)
       : SourceNode(plan, schema, generator, Ordering::Implicit()) {}
 
@@ -406,7 +406,7 @@ struct SchemaSourceNode : public SourceNode {
 };
 
 struct RecordBatchReaderSourceNode : public SourceNode {
-  RecordBatchReaderSourceNode(ExecPlan* plan, std::shared_ptr<Schema> schema,
+  RecordBatchReaderSourceNode(ExecPlan* plan, const std::shared_ptr<Schema>& schema,
                               arrow::AsyncGenerator<std::optional<ExecBatch>> generator)
       : SourceNode(plan, schema, generator, Ordering::Implicit()) {}
 

--- a/cpp/src/arrow/acero/source_node_test.cc
+++ b/cpp/src/arrow/acero/source_node_test.cc
@@ -35,7 +35,7 @@ struct PauseThenStopNodeOptions : public ExecNodeOptions {
 template <typename ThisNode>
 struct PauseThenStopNode : public MapNode {
   PauseThenStopNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-                    std::shared_ptr<Schema> output_schema,
+                    const std::shared_ptr<Schema>& output_schema,
                     const PauseThenStopNodeOptions& options)
       : MapNode(plan, inputs, output_schema), num_pass(options.num_pass) {}
 

--- a/cpp/src/arrow/acero/test_nodes.cc
+++ b/cpp/src/arrow/acero/test_nodes.cc
@@ -274,7 +274,7 @@ struct GatedNode : public ExecNode, public TracedNode {
   }
 
   GatedNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-            std::shared_ptr<Schema> output_schema, const GatedNodeOptions& options)
+            const std::shared_ptr<Schema>& output_schema, const GatedNodeOptions& options)
       : ExecNode(plan, inputs, {"input"}, output_schema),
         TracedNode(this),
         gate_(options.gate) {}

--- a/cpp/src/arrow/acero/unmaterialized_table_internal.h
+++ b/cpp/src/arrow/acero/unmaterialized_table_internal.h
@@ -242,7 +242,7 @@ class UnmaterializedSliceBuilder {
       UnmaterializedCompositeTable<MAX_COMPOSITE_TABLES>* table_)
       : table(table_) {}
 
-  void AddEntry(std::shared_ptr<RecordBatch> rb, uint64_t start, uint64_t end) {
+  void AddEntry(const std::shared_ptr<RecordBatch>& rb, uint64_t start, uint64_t end) {
     if (rb) {
       table->AddRecordBatchRef(rb);
     }

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -135,7 +135,7 @@ constexpr int64_t kReadRowsBatch = 1000;
 class OrcStripeReader : public RecordBatchReader {
  public:
   OrcStripeReader(std::unique_ptr<liborc::RowReader> row_reader,
-                  std::shared_ptr<Schema> schema, int64_t batch_size, MemoryPool* pool)
+                  const std::shared_ptr<Schema>& schema, int64_t batch_size, MemoryPool* pool)
       : row_reader_(std::move(row_reader)),
         schema_(schema),
         pool_(pool),

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -103,7 +103,7 @@ std::shared_ptr<Buffer> GenerateFixedDifferenceBuffer(int32_t fixed_length,
 }
 
 std::shared_ptr<Array> CastFixedSizeBinaryArrayToBinaryArray(
-    std::shared_ptr<Array> array) {
+    const std::shared_ptr<Array>& array) {
   auto fixed_size_binary_array = checked_pointer_cast<FixedSizeBinaryArray>(array);
   std::shared_ptr<Buffer> value_offsets = GenerateFixedDifferenceBuffer(
       fixed_size_binary_array->byte_width(), array->length() + 1);
@@ -114,7 +114,7 @@ std::shared_ptr<Array> CastFixedSizeBinaryArrayToBinaryArray(
 
 template <typename TargetArrayType>
 std::shared_ptr<Array> CastInt64ArrayToTemporalArray(
-    const std::shared_ptr<DataType>& type, std::shared_ptr<Array> array) {
+    const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& array) {
   std::shared_ptr<ArrayData> new_array_data =
       ArrayData::Make(type, array->length(), array->data()->buffers);
   return std::make_shared<TargetArrayType>(new_array_data);
@@ -128,7 +128,7 @@ Result<std::shared_ptr<Array>> GenerateRandomDate64Array(int64_t size,
 }
 
 Result<std::shared_ptr<Array>> GenerateRandomTimestampArray(
-    int64_t size, std::shared_ptr<TimestampType> type, double null_probability) {
+    int64_t size, const std::shared_ptr<TimestampType>& type, double null_probability) {
   random::RandomArrayGenerator rand(kRandomSeed);
   switch (type->unit()) {
     case TimeUnit::type::SECOND: {
@@ -1049,7 +1049,7 @@ namespace {
 // read them back and compare equality in the unit test). Because the orc reader
 // fills unselected values to nulls when reading from the file. So flattening
 // the SparseUnionArray before writing makes it easy for the array equality check.
-std::shared_ptr<Array> FlattenSparseUnionArray(std::shared_ptr<Array> array) {
+std::shared_ptr<Array> FlattenSparseUnionArray(const std::shared_ptr<Array>& array) {
   auto union_array = checked_pointer_cast<SparseUnionArray>(array);
   ArrayVector children;
   for (int i = 0; i < array->num_fields(); ++i) {
@@ -1061,7 +1061,7 @@ std::shared_ptr<Array> FlattenSparseUnionArray(std::shared_ptr<Array> array) {
                                             union_array->type_codes(), array->offset());
 }
 
-void TestUnionConversion(std::shared_ptr<Array> array) {
+void TestUnionConversion(const std::shared_ptr<Array>& array) {
   auto length = array->length();
   auto orc_type = liborc::Type::buildTypeFromString("uniontype<string,int>");
 

--- a/cpp/src/arrow/adapters/tensorflow/convert.h
+++ b/cpp/src/arrow/adapters/tensorflow/convert.h
@@ -77,7 +77,7 @@ Status GetArrowType(::tensorflow::DataType dtype, std::shared_ptr<DataType>* out
   return Status::OK();
 }
 
-Status GetTensorFlowType(std::shared_ptr<DataType> dtype, ::tensorflow::DataType* out) {
+Status GetTensorFlowType(const std::shared_ptr<DataType>& dtype, ::tensorflow::DataType* out) {
   switch (dtype->id()) {
     case Type::BOOL:
       *out = ::tensorflow::DT_BOOL;

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -517,7 +517,7 @@ struct RecursiveUnifier {
 }  // namespace
 
 Result<std::unique_ptr<DictionaryUnifier>> DictionaryUnifier::Make(
-    std::shared_ptr<DataType> value_type, MemoryPool* pool) {
+    const std::shared_ptr<DataType>& value_type, MemoryPool* pool) {
   MakeUnifier maker(pool, value_type);
   RETURN_NOT_OK(VisitTypeInline(*value_type, &maker));
   return std::move(maker.result);

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -134,7 +134,7 @@ class ARROW_EXPORT DictionaryUnifier {
   /// \param[in] value_type the data type of the dictionaries
   /// \param[in] pool MemoryPool to use for memory allocations
   static Result<std::unique_ptr<DictionaryUnifier>> Make(
-      std::shared_ptr<DataType> value_type, MemoryPool* pool = default_memory_pool());
+      const std::shared_ptr<DataType>& value_type, MemoryPool* pool = default_memory_pool());
 
   /// \brief Unify dictionaries across array chunks
   ///

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -873,7 +873,7 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, AppendArrayInvalidType) {
 #endif
 
 template <typename DecimalValue>
-void TestDecimalDictionaryBuilderBasic(std::shared_ptr<DataType> decimal_type) {
+void TestDecimalDictionaryBuilderBasic(const std::shared_ptr<DataType>& decimal_type) {
   // Build the dictionary Array
   DictionaryBuilder<FixedSizeBinaryType> builder(decimal_type);
 
@@ -903,7 +903,7 @@ TEST(TestDecimal256DictionaryBuilder, Basic) {
 }
 
 void TestDecimalDictionaryBuilderDoubleTableSize(
-    std::shared_ptr<DataType> decimal_type, FixedSizeBinaryBuilder& decimal_builder) {
+    const std::shared_ptr<DataType>& decimal_type, FixedSizeBinaryBuilder& decimal_builder) {
   // Build the dictionary Array
   DictionaryBuilder<FixedSizeBinaryType> dict_builder(decimal_type);
 
@@ -1488,8 +1488,8 @@ TEST(TestDictionary, ListOfDictionary) {
 }
 
 TEST(TestDictionary, CanCompareIndices) {
-  auto make_dict = [](std::shared_ptr<DataType> index_type,
-                      std::shared_ptr<DataType> value_type, std::string dictionary_json) {
+  auto make_dict = [](const std::shared_ptr<DataType>& index_type,
+                      const std::shared_ptr<DataType>& value_type, std::string dictionary_json) {
     std::shared_ptr<Array> out;
     ARROW_EXPECT_OK(
         DictionaryArray::FromArrays(dictionary(index_type, value_type),

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -262,7 +262,7 @@ class TestListArray : public ::testing::Test {
  private:
   Result<std::shared_ptr<Array>> FromArrays(const Array& offsets, const Array& sizes,
                                             const Array& values,
-                                            std::shared_ptr<Buffer> null_bitmap = NULLPTR,
+                                            const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
                                             int64_t null_count = kUnknownNullCount) {
     if constexpr (kTypeClassIsListView) {
       return ArrayType::FromArrays(offsets, sizes, values, pool_, null_bitmap,

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -102,7 +102,7 @@ Result<BufferVector> CleanListOffsets(const std::shared_ptr<Buffer>& validity_bu
 
 template <typename TYPE>
 Result<std::shared_ptr<typename TypeTraits<TYPE>::ArrayType>> ListArrayFromArrays(
-    std::shared_ptr<DataType> type, const Array& offsets, const Array& values,
+    const std::shared_ptr<DataType>& type, const Array& offsets, const Array& values,
     MemoryPool* pool, std::shared_ptr<Buffer> null_bitmap = NULLPTR,
     int64_t null_count = kUnknownNullCount) {
   using offset_type = typename TYPE::offset_type;
@@ -145,7 +145,7 @@ Result<std::shared_ptr<typename TypeTraits<TYPE>::ArrayType>> ListArrayFromArray
 
 template <typename TYPE>
 Result<std::shared_ptr<typename TypeTraits<TYPE>::ArrayType>> ListViewArrayFromArrays(
-    std::shared_ptr<DataType> type, const Array& offsets, const Array& sizes,
+    const std::shared_ptr<DataType>& type, const Array& offsets, const Array& sizes,
     const Array& values, MemoryPool* pool, std::shared_ptr<Buffer> null_bitmap = NULLPTR,
     int64_t null_count = kUnknownNullCount) {
   using offset_type = typename TYPE::offset_type;
@@ -524,7 +524,7 @@ ListArray::ListArray(std::shared_ptr<ArrayData> data) {
 }
 
 ListArray::ListArray(std::shared_ptr<DataType> type, int64_t length,
-                     std::shared_ptr<Buffer> value_offsets, std::shared_ptr<Array> values,
+                     std::shared_ptr<Buffer> value_offsets, const std::shared_ptr<Array>& values,
                      std::shared_ptr<Buffer> null_bitmap, int64_t null_count,
                      int64_t offset) {
   ARROW_CHECK_EQ(type->id(), Type::LIST);
@@ -644,7 +644,7 @@ ListViewArray::ListViewArray(std::shared_ptr<ArrayData> data) {
 ListViewArray::ListViewArray(std::shared_ptr<DataType> type, int64_t length,
                              std::shared_ptr<Buffer> value_offsets,
                              std::shared_ptr<Buffer> value_sizes,
-                             std::shared_ptr<Array> values,
+                             const std::shared_ptr<Array>& values,
                              std::shared_ptr<Buffer> null_bitmap, int64_t null_count,
                              int64_t offset) {
   ListViewArray::SetData(ArrayData::Make(
@@ -719,7 +719,7 @@ LargeListViewArray::LargeListViewArray(std::shared_ptr<ArrayData> data) {
 LargeListViewArray::LargeListViewArray(std::shared_ptr<DataType> type, int64_t length,
                                        std::shared_ptr<Buffer> value_offsets,
                                        std::shared_ptr<Buffer> value_sizes,
-                                       std::shared_ptr<Array> values,
+                                       const std::shared_ptr<Array>& values,
                                        std::shared_ptr<Buffer> null_bitmap,
                                        int64_t null_count, int64_t offset) {
   LargeListViewArray::SetData(ArrayData::Make(

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -160,7 +160,7 @@ class ARROW_EXPORT ListArray : public BaseListArray<ListType> {
   explicit ListArray(std::shared_ptr<ArrayData> data);
 
   ListArray(std::shared_ptr<DataType> type, int64_t length,
-            std::shared_ptr<Buffer> value_offsets, std::shared_ptr<Array> values,
+            std::shared_ptr<Buffer> value_offsets, const std::shared_ptr<Array>& values,
             std::shared_ptr<Buffer> null_bitmap = NULLPTR,
             int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 
@@ -319,7 +319,7 @@ class ARROW_EXPORT ListViewArray : public BaseListViewArray<ListViewType> {
 
   ListViewArray(std::shared_ptr<DataType> type, int64_t length,
                 std::shared_ptr<Buffer> value_offsets,
-                std::shared_ptr<Buffer> value_sizes, std::shared_ptr<Array> values,
+                std::shared_ptr<Buffer> value_sizes, const std::shared_ptr<Array>& values,
                 std::shared_ptr<Buffer> null_bitmap = NULLPTR,
                 int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 
@@ -407,7 +407,7 @@ class ARROW_EXPORT LargeListViewArray : public BaseListViewArray<LargeListViewTy
 
   LargeListViewArray(std::shared_ptr<DataType> type, int64_t length,
                      std::shared_ptr<Buffer> value_offsets,
-                     std::shared_ptr<Buffer> value_sizes, std::shared_ptr<Array> values,
+                     std::shared_ptr<Buffer> value_sizes, const std::shared_ptr<Array>& values,
                      std::shared_ptr<Buffer> null_bitmap = NULLPTR,
                      int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 

--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -68,7 +68,7 @@ class TestRunEndEncodedArray
   }
 
   std::shared_ptr<RunEndEncodedArray> RunEndEncodedArrayFromJSON(
-      int64_t logical_length, std::shared_ptr<DataType> value_type,
+      int64_t logical_length, const std::shared_ptr<DataType>& value_type,
       std::string_view run_ends_json, std::string_view values_json,
       int64_t logical_offset = 0) {
     auto run_ends = ArrayFromJSON(run_end_type, run_ends_json);

--- a/cpp/src/arrow/array/array_union_test.cc
+++ b/cpp/src/arrow/array/array_union_test.cc
@@ -39,7 +39,7 @@ TEST(TestUnionArray, TestSliceEquals) {
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(ipc::test::MakeUnion(&batch));
 
-  auto CheckUnion = [](std::shared_ptr<Array> array) {
+  auto CheckUnion = [](const std::shared_ptr<Array>& array) {
     const int64_t size = array->length();
     std::shared_ptr<Array> slice, slice2;
     slice = array->Slice(2);

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -34,7 +34,7 @@ namespace internal {
 
 RunCompressorBuilder::RunCompressorBuilder(MemoryPool* pool,
                                            std::shared_ptr<ArrayBuilder> inner_builder,
-                                           std::shared_ptr<DataType> type)
+                                           const std::shared_ptr<DataType>& type)
     : ArrayBuilder(pool), inner_builder_(std::move(inner_builder)) {}
 
 RunCompressorBuilder::~RunCompressorBuilder() = default;
@@ -166,7 +166,7 @@ RunEndEncodedBuilder::ValueRunBuilder::ValueRunBuilder(
 
 RunEndEncodedBuilder::RunEndEncodedBuilder(
     MemoryPool* pool, const std::shared_ptr<ArrayBuilder>& run_end_builder,
-    const std::shared_ptr<ArrayBuilder>& value_builder, std::shared_ptr<DataType> type)
+    const std::shared_ptr<ArrayBuilder>& value_builder, const std::shared_ptr<DataType>& type)
     : ArrayBuilder(pool), type_(internal::checked_pointer_cast<RunEndEncodedType>(type)) {
   auto value_run_builder =
       std::make_shared<ValueRunBuilder>(pool, value_builder, type_->value_type(), *this);

--- a/cpp/src/arrow/array/builder_run_end.h
+++ b/cpp/src/arrow/array/builder_run_end.h
@@ -60,7 +60,7 @@ namespace internal {
 class RunCompressorBuilder : public ArrayBuilder {
  public:
   RunCompressorBuilder(MemoryPool* pool, std::shared_ptr<ArrayBuilder> inner_builder,
-                       std::shared_ptr<DataType> type);
+                       const std::shared_ptr<DataType>& type);
 
   ~RunCompressorBuilder() override;
 
@@ -202,7 +202,7 @@ class ARROW_EXPORT RunEndEncodedBuilder : public ArrayBuilder {
   RunEndEncodedBuilder(MemoryPool* pool,
                        const std::shared_ptr<ArrayBuilder>& run_end_builder,
                        const std::shared_ptr<ArrayBuilder>& value_builder,
-                       std::shared_ptr<DataType> type);
+                       const std::shared_ptr<DataType>& type);
 
   /// \brief Allocate enough memory for a given number of array elements.
   ///

--- a/cpp/src/arrow/array/builder_time.h
+++ b/cpp/src/arrow/array/builder_time.h
@@ -38,7 +38,7 @@ class ARROW_EXPORT DayTimeIntervalBuilder : public NumericBuilder<DayTimeInterva
                                   int64_t alignment = kDefaultBufferAlignment)
       : DayTimeIntervalBuilder(day_time_interval(), pool, alignment) {}
 
-  explicit DayTimeIntervalBuilder(std::shared_ptr<DataType> type,
+  explicit DayTimeIntervalBuilder(const std::shared_ptr<DataType>& type,
                                   MemoryPool* pool = default_memory_pool(),
                                   int64_t alignment = kDefaultBufferAlignment)
       : NumericBuilder<DayTimeIntervalType>(type, pool, alignment) {}
@@ -53,7 +53,7 @@ class ARROW_EXPORT MonthDayNanoIntervalBuilder
                                        int64_t alignment = kDefaultBufferAlignment)
       : MonthDayNanoIntervalBuilder(month_day_nano_interval(), pool, alignment) {}
 
-  explicit MonthDayNanoIntervalBuilder(std::shared_ptr<DataType> type,
+  explicit MonthDayNanoIntervalBuilder(const std::shared_ptr<DataType>& type,
                                        MemoryPool* pool = default_memory_pool(),
                                        int64_t alignment = kDefaultBufferAlignment)
       : NumericBuilder<MonthDayNanoIntervalType>(type, pool, alignment) {}

--- a/cpp/src/arrow/array/diff_test.cc
+++ b/cpp/src/arrow/array/diff_test.cc
@@ -115,7 +115,7 @@ class DiffTest : public ::testing::Test {
                       /*verbose=*/true);
   }
 
-  void BaseAndTargetFromRandomFilter(std::shared_ptr<Array> values,
+  void BaseAndTargetFromRandomFilter(const std::shared_ptr<Array>& values,
                                      double filter_probability) {
     std::shared_ptr<Array> base_filter, target_filter;
     do {

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -124,7 +124,7 @@ Result<std::shared_ptr<io::OutputStream>> Buffer::GetWriter(std::shared_ptr<Buff
   return buf->memory_manager_->GetBufferWriter(std::move(buf));
 }
 
-Result<std::shared_ptr<Buffer>> Buffer::Copy(std::shared_ptr<Buffer> source,
+Result<std::shared_ptr<Buffer>> Buffer::Copy(const std::shared_ptr<Buffer>& source,
                                              const std::shared_ptr<MemoryManager>& to) {
   return MemoryManager::CopyBuffer(source, to);
 }
@@ -134,13 +134,13 @@ Result<std::unique_ptr<Buffer>> Buffer::CopyNonOwned(
   return MemoryManager::CopyNonOwned(source, to);
 }
 
-Result<std::shared_ptr<Buffer>> Buffer::View(std::shared_ptr<Buffer> source,
+Result<std::shared_ptr<Buffer>> Buffer::View(const std::shared_ptr<Buffer>& source,
                                              const std::shared_ptr<MemoryManager>& to) {
   return MemoryManager::ViewBuffer(source, to);
 }
 
 Result<std::shared_ptr<Buffer>> Buffer::ViewOrCopy(
-    std::shared_ptr<Buffer> source, const std::shared_ptr<MemoryManager>& to) {
+    const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to) {
   auto maybe_buffer = MemoryManager::ViewBuffer(source, to);
   if (maybe_buffer.ok()) {
     return maybe_buffer;

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -328,7 +328,7 @@ class ARROW_EXPORT Buffer {
   ///
   /// The buffer contents will be copied into a new buffer allocated by the
   /// given MemoryManager.  This function supports cross-device copies.
-  static Result<std::shared_ptr<Buffer>> Copy(std::shared_ptr<Buffer> source,
+  static Result<std::shared_ptr<Buffer>> Copy(const std::shared_ptr<Buffer>& source,
                                               const std::shared_ptr<MemoryManager>& to);
 
   /// \brief Copy a non-owned buffer
@@ -349,7 +349,7 @@ class ARROW_EXPORT Buffer {
   /// If a non-copy view is unsupported for the buffer on the given device,
   /// nullptr is returned.  An error can be returned if some low-level
   /// operation fails (such as an out-of-memory condition).
-  static Result<std::shared_ptr<Buffer>> View(std::shared_ptr<Buffer> source,
+  static Result<std::shared_ptr<Buffer>> View(const std::shared_ptr<Buffer>& source,
                                               const std::shared_ptr<MemoryManager>& to);
 
   /// \brief View or copy buffer
@@ -357,7 +357,7 @@ class ARROW_EXPORT Buffer {
   /// Try to view buffer contents on the given MemoryManager's device, but
   /// fall back to copying if a no-copy view isn't supported.
   static Result<std::shared_ptr<Buffer>> ViewOrCopy(
-      std::shared_ptr<Buffer> source, const std::shared_ptr<MemoryManager>& to);
+      const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
 
   virtual std::shared_ptr<Device::SyncEvent> device_sync_event() const { return NULLPTR; }
 

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -87,7 +87,7 @@ class MyDevice : public Device {
 
 class MyMemoryManager : public MemoryManager {
  public:
-  explicit MyMemoryManager(std::shared_ptr<Device> device) : MemoryManager(device) {}
+  explicit MyMemoryManager(const std::shared_ptr<Device>& device) : MemoryManager(device) {}
 
   bool allow_copy() const {
     return checked_cast<const MyDevice&>(*device()).allow_copy();
@@ -132,7 +132,7 @@ class MyMemoryManager : public MemoryManager {
 
 class MyBuffer : public Buffer {
  public:
-  MyBuffer(std::shared_ptr<MemoryManager> mm, const std::shared_ptr<Buffer>& parent)
+  MyBuffer(const std::shared_ptr<MemoryManager>& mm, const std::shared_ptr<Buffer>& parent)
       : Buffer(parent->data(), parent->size()) {
     parent_ = parent;
     SetMemoryManager(mm);

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1506,7 +1506,7 @@ class ImportedBuffer : public Buffer {
                  std::shared_ptr<ImportedArrayData> import)
       : Buffer(data, size), import_(std::move(import)) {}
 
-  ImportedBuffer(const uint8_t* data, int64_t size, std::shared_ptr<MemoryManager> mm,
+  ImportedBuffer(const uint8_t* data, int64_t size, const std::shared_ptr<MemoryManager>& mm,
                  DeviceAllocationType device_type,
                  std::shared_ptr<ImportedArrayData> import)
       : Buffer(data, size, mm, nullptr, device_type), import_(std::move(import)) {}
@@ -1960,7 +1960,7 @@ struct ArrayImporter {
 }  // namespace
 
 Result<std::shared_ptr<Array>> ImportArray(struct ArrowArray* array,
-                                           std::shared_ptr<DataType> type) {
+                                           const std::shared_ptr<DataType>& type) {
   ArrayImporter importer(type);
   RETURN_NOT_OK(importer.Import(array));
   return importer.MakeArray();
@@ -2002,7 +2002,7 @@ Result<std::shared_ptr<MemoryManager>> DefaultDeviceMemoryMapper(
 }
 
 Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
-                                                 std::shared_ptr<DataType> type,
+                                                 const std::shared_ptr<DataType>& type,
                                                  const DeviceMemoryMapper& mapper) {
   ArrayImporter importer(type);
   RETURN_NOT_OK(importer.Import(array, mapper));
@@ -2287,22 +2287,22 @@ class ArrayStreamReader {
   }
 
   Result<std::shared_ptr<RecordBatch>> ImportRecordBatchInternal(
-      struct ArrowArray* array, std::shared_ptr<Schema> schema) {
+      struct ArrowArray* array, const std::shared_ptr<Schema>& schema) {
     return ImportRecordBatch(array, schema);
   }
 
   Result<std::shared_ptr<RecordBatch>> ImportRecordBatchInternal(
-      struct ArrowDeviceArray* array, std::shared_ptr<Schema> schema) {
+      struct ArrowDeviceArray* array, const std::shared_ptr<Schema>& schema) {
     return ImportDeviceRecordBatch(array, schema, mapper_);
   }
 
   Result<std::shared_ptr<Array>> ImportArrayInternal(
-      struct ArrowArray* array, std::shared_ptr<arrow::DataType> type) {
+      struct ArrowArray* array, const std::shared_ptr<arrow::DataType>& type) {
     return ImportArray(array, type);
   }
 
   Result<std::shared_ptr<Array>> ImportArrayInternal(
-      struct ArrowDeviceArray* array, std::shared_ptr<arrow::DataType> type) {
+      struct ArrowDeviceArray* array, const std::shared_ptr<arrow::DataType>& type) {
     return ImportDeviceArray(array, type, mapper_);
   }
 
@@ -2835,7 +2835,7 @@ Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
 }
 
 Future<> ExportAsyncRecordBatchReader(
-    std::shared_ptr<Schema> schema,
+    const std::shared_ptr<Schema>& schema,
     AsyncGenerator<std::shared_ptr<RecordBatch>> generator,
     DeviceAllocationType device_type, struct ArrowAsyncDeviceStreamHandler* handler) {
   if (!schema) {

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -126,7 +126,7 @@ Result<std::shared_ptr<Schema>> ImportSchema(struct ArrowSchema* schema);
 /// \return Imported array object
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportArray(struct ArrowArray* array,
-                                           std::shared_ptr<DataType> type);
+                                           const std::shared_ptr<DataType>& type);
 
 /// \brief Import C++ array and its type from the C data interface.
 ///
@@ -236,7 +236,7 @@ Result<std::shared_ptr<MemoryManager>> DefaultDeviceMemoryMapper(
 /// \return Imported array object
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportDeviceArray(
-    struct ArrowDeviceArray* array, std::shared_ptr<DataType> type,
+    struct ArrowDeviceArray* array, const std::shared_ptr<DataType>& type,
     const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper);
 
 /// \brief EXPERIMENTAL: Import C++ device array and its type from the C data interface.
@@ -480,7 +480,7 @@ Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
 /// \return Future that will resolve once the generator is exhausted or an error occurs
 ARROW_EXPORT
 Future<> ExportAsyncRecordBatchReader(
-    std::shared_ptr<Schema> schema,
+    const std::shared_ptr<Schema>& schema,
     AsyncGenerator<std::shared_ptr<RecordBatch>> generator,
     DeviceAllocationType device_type, struct ArrowAsyncDeviceStreamHandler* handler);
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -681,7 +681,7 @@ class TestArrayExport : public ::testing::Test {
   void SetUp() override { pool_ = default_memory_pool(); }
 
   static std::function<Result<std::shared_ptr<Array>>()> JSONArrayFactory(
-      std::shared_ptr<DataType> type, const char* json) {
+      const std::shared_ptr<DataType>& type, const char* json) {
     return [=]() { return ArrayFromJSON(type, json); };
   }
 
@@ -1458,7 +1458,7 @@ class TestDeviceArrayExport : public ::testing::Test {
   }
 
   static std::function<Result<std::shared_ptr<Array>>()> JSONArrayFactory(
-      const std::shared_ptr<MemoryManager>& mm, std::shared_ptr<DataType> type,
+      const std::shared_ptr<MemoryManager>& mm, const std::shared_ptr<DataType>& type,
       const char* json) {
     return [=]() { return ToDevice(mm, *ArrayFromJSON(type, json)->data()); };
   }
@@ -3912,7 +3912,7 @@ class TestArrayRoundtrip : public ::testing::Test {
 
   void SetUp() override { pool_ = default_memory_pool(); }
 
-  static ArrayFactory JSONArrayFactory(std::shared_ptr<DataType> type, const char* json) {
+  static ArrayFactory JSONArrayFactory(const std::shared_ptr<DataType>& type, const char* json) {
     return [=]() { return ArrayFromJSON(type, json); };
   }
 
@@ -4015,11 +4015,11 @@ class TestArrayRoundtrip : public ::testing::Test {
     ASSERT_EQ(pool_->bytes_allocated(), orig_bytes);
   }
 
-  void TestWithJSON(std::shared_ptr<DataType> type, const char* json) {
+  void TestWithJSON(const std::shared_ptr<DataType>& type, const char* json) {
     TestWithArrayFactory(JSONArrayFactory(type, json));
   }
 
-  void TestWithJSONSliced(std::shared_ptr<DataType> type, const char* json) {
+  void TestWithJSONSliced(const std::shared_ptr<DataType>& type, const char* json) {
     TestWithArrayFactory(SlicedArrayFactory(JSONArrayFactory(type, json)));
   }
 
@@ -4352,7 +4352,7 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
   }
 
   static ArrayFactory JSONArrayFactory(const std::shared_ptr<MemoryManager>& mm,
-                                       std::shared_ptr<DataType> type, const char* json) {
+                                       const std::shared_ptr<DataType>& type, const char* json) {
     return [=]() { return ToDevice(mm, *ArrayFromJSON(type, json)->data()); };
   }
 
@@ -4463,12 +4463,12 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
   }
 
   void TestWithJSON(const std::shared_ptr<MemoryManager>& mm,
-                    std::shared_ptr<DataType> type, const char* json) {
+                    const std::shared_ptr<DataType>& type, const char* json) {
     TestWithArrayFactory(JSONArrayFactory(mm, type, json));
   }
 
   void TestWithJSONSliced(const std::shared_ptr<MemoryManager>& mm,
-                          std::shared_ptr<DataType> type, const char* json) {
+                          const std::shared_ptr<DataType>& type, const char* json) {
     TestWithArrayFactory(SlicedArrayFactory(JSONArrayFactory(mm, type, json)));
   }
 
@@ -4519,7 +4519,7 @@ class BaseArrayStreamTest : public ::testing::Test {
 
   void TearDown() override { ASSERT_EQ(pool_->bytes_allocated(), orig_allocated_); }
 
-  RecordBatchVector MakeBatches(std::shared_ptr<Schema> schema, ArrayVector arrays) {
+  RecordBatchVector MakeBatches(const std::shared_ptr<Schema>& schema, ArrayVector arrays) {
     DCHECK_EQ(schema->num_fields(), 1);
     RecordBatchVector batches;
     for (const auto& array : arrays) {

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -1220,7 +1220,7 @@ void TestCallScalarFunctionPreallocationCases::DoTest(FunctionCallerMaker caller
 
   auto arr = GetUInt8Array(100, null_prob);
 
-  auto CheckFunction = [&](std::shared_ptr<FunctionCaller> test_copy) {
+  auto CheckFunction = [&](const std::shared_ptr<FunctionCaller>& test_copy) {
     ResetContexts();
 
     // The default should be a single array output
@@ -1307,7 +1307,7 @@ void TestCallScalarFunctionBasicNonStandardCases::DoTest(
   auto arr = GetUInt8Array(1000, null_prob);
   std::vector<Datum> args = {Datum(arr)};
 
-  auto CheckFunction = [&](std::shared_ptr<FunctionCaller> test_nopre) {
+  auto CheckFunction = [&](const std::shared_ptr<FunctionCaller>& test_nopre) {
     ResetContexts();
 
     // The default should be a single array output

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -177,7 +177,7 @@ TEST(ExpressionUtils, StripOrderPreservingCasts) {
 }
 
 TEST(ExpressionUtils, MakeExecBatch) {
-  auto Expect = [](std::shared_ptr<RecordBatch> partial_batch) {
+  auto Expect = [](const std::shared_ptr<RecordBatch>& partial_batch) {
     SCOPED_TRACE(partial_batch->ToString());
     ASSERT_OK_AND_ASSIGN(auto batch, MakeExecBatch(*kBoringSchema, partial_batch));
 
@@ -696,9 +696,9 @@ TEST(Expression, BindWithDecimalArithmeticOps) {
 
 TEST(Expression, BindWithDecimalDivision) {
   auto expect_decimal_division_type = [](std::string name,
-                                         std::shared_ptr<DataType> dividend,
-                                         std::shared_ptr<DataType> divisor,
-                                         std::shared_ptr<DataType> expected) {
+                                         const std::shared_ptr<DataType>& dividend,
+                                         const std::shared_ptr<DataType>& divisor,
+                                         const std::shared_ptr<DataType>& expected) {
     auto schema = arrow::schema({field("dividend", dividend), field("divisor", divisor)});
     auto expr = call(name, {field_ref("dividend"), field_ref("divisor")});
     ASSERT_OK_AND_ASSIGN(auto bound, expr.Bind(*schema));
@@ -1920,7 +1920,7 @@ TEST(Expression, SimplifyWithComparisonAndNullableCaveat) {
 }
 
 TEST(Expression, SimplifyIsIn) {
-  auto is_in = [](Expression field, std::shared_ptr<DataType> value_set_type,
+  auto is_in = [](Expression field, const std::shared_ptr<DataType>& value_set_type,
                   std::string json_array,
                   SetLookupOptions::NullMatchingBehavior null_matching_behavior) {
     SetLookupOptions options{ArrayFromJSON(value_set_type, json_array),

--- a/cpp/src/arrow/compute/function_benchmark.cc
+++ b/cpp/src/arrow/compute/function_benchmark.cc
@@ -37,7 +37,7 @@ namespace compute {
 constexpr int32_t kSeed = 0xfede4a7e;
 constexpr int64_t kScalarCount = 1 << 10;
 
-inline ScalarVector ToScalars(std::shared_ptr<Array> arr) {
+inline ScalarVector ToScalars(const std::shared_ptr<Array>& arr) {
   ScalarVector scalars{static_cast<size_t>(arr->length())};
   int64_t i = 0;
   for (auto& scalar : scalars) {

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -316,7 +316,7 @@ struct ProductImpl : public ScalarAggregator {
   using ProductType = typename TypeTraits<AccType>::CType;
   using OutputType = typename TypeTraits<AccType>::ScalarType;
 
-  explicit ProductImpl(std::shared_ptr<DataType> out_type,
+  explicit ProductImpl(const std::shared_ptr<DataType>& out_type,
                        const ScalarAggregateOptions& options)
       : out_type(out_type),
         options(options),
@@ -398,7 +398,7 @@ struct ProductInit {
   std::shared_ptr<DataType> type;
   const ScalarAggregateOptions& options;
 
-  ProductInit(KernelContext* ctx, std::shared_ptr<DataType> type,
+  ProductInit(KernelContext* ctx, const std::shared_ptr<DataType>& type,
               const ScalarAggregateOptions& options)
       : ctx(ctx), type(type), options(options) {}
 
@@ -844,7 +844,7 @@ struct IndexInit {
 
 void AddBasicAggKernels(KernelInit init,
                         const std::vector<std::shared_ptr<DataType>>& types,
-                        std::shared_ptr<DataType> out_ty, ScalarAggregateFunction* func,
+                        const std::shared_ptr<DataType>& out_ty, ScalarAggregateFunction* func,
                         SimdLevel::type simd_level) {
   for (const auto& ty : types) {
     // array[InT] -> scalar[OutT]
@@ -857,7 +857,7 @@ namespace {
 
 void AddScalarAggKernels(KernelInit init,
                          const std::vector<std::shared_ptr<DataType>>& types,
-                         std::shared_ptr<DataType> out_ty,
+                         const std::shared_ptr<DataType>& out_ty,
                          ScalarAggregateFunction* func) {
   for (const auto& ty : types) {
     auto sig = KernelSignature::Make({ty->id()}, out_ty);
@@ -867,7 +867,7 @@ void AddScalarAggKernels(KernelInit init,
 
 void AddArrayScalarAggKernels(KernelInit init,
                               const std::vector<std::shared_ptr<DataType>>& types,
-                              std::shared_ptr<DataType> out_ty,
+                              const std::shared_ptr<DataType>& out_ty,
                               ScalarAggregateFunction* func,
                               SimdLevel::type simd_level = SimdLevel::NONE) {
   AddBasicAggKernels(init, types, out_ty, func, simd_level);

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.inc.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.inc.cc
@@ -164,7 +164,7 @@ struct SumLikeInit {
   std::shared_ptr<DataType> type;
   const ScalarAggregateOptions& options;
 
-  SumLikeInit(KernelContext* ctx, std::shared_ptr<DataType> type,
+  SumLikeInit(KernelContext* ctx, const std::shared_ptr<DataType>& type,
               const ScalarAggregateOptions& options)
       : ctx(ctx), type(type), options(options) {}
 
@@ -287,7 +287,7 @@ struct MeanImpl<ArrowType, SimdLevel,
 
 template <template <typename> class KernelClass>
 struct MeanKernelInit : public SumLikeInit<KernelClass> {
-  MeanKernelInit(KernelContext* ctx, std::shared_ptr<DataType> type,
+  MeanKernelInit(KernelContext* ctx, const std::shared_ptr<DataType>& type,
                  const ScalarAggregateOptions& options)
       : SumLikeInit<KernelClass>(ctx, type, options) {}
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -31,7 +31,7 @@ namespace arrow::compute::internal {
 
 void AddBasicAggKernels(KernelInit init,
                         const std::vector<std::shared_ptr<DataType>>& types,
-                        std::shared_ptr<DataType> out_ty, ScalarAggregateFunction* func,
+                        const std::shared_ptr<DataType>& out_ty, ScalarAggregateFunction* func,
                         SimdLevel::type simd_level = SimdLevel::NONE);
 
 void AddMinMaxKernels(KernelInit init,

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -545,7 +545,7 @@ Status CastDecimalArgs(TypeHolder* begin, size_t count) {
 }
 
 Result<std::shared_ptr<DataType>> WidenDecimalToMaxPrecision(
-    std::shared_ptr<DataType> type) {
+    const std::shared_ptr<DataType>& type) {
   DCHECK(is_decimal(type->id()));
   auto cast_type = checked_pointer_cast<DecimalType>(type);
   switch (type->id()) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1481,7 +1481,7 @@ Status CastDecimalArgs(TypeHolder* begin, size_t count);
 /// and the maximum precision for that DecimalType.
 ARROW_EXPORT
 Result<std::shared_ptr<DataType>> WidenDecimalToMaxPrecision(
-    std::shared_ptr<DataType> type);
+    const std::shared_ptr<DataType>& type);
 
 ARROW_EXPORT
 bool HasDecimal(const std::vector<TypeHolder>& types);

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_pivot.cc
@@ -333,7 +333,7 @@ struct GroupedPivotAccumulator {
     return Status::OK();
   }
 
-  Status MergeColumn(std::shared_ptr<Array>* column, std::shared_ptr<Array> other_column,
+  Status MergeColumn(std::shared_ptr<Array>* column, const std::shared_ptr<Array>& other_column,
                      const ColumnTransform& transform = {}) {
     if (other_column->null_count() == other_column->length()) {
       // Avoid paying for the transform step below, since merging will be a no-op anyway.

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1059,7 +1059,7 @@ std::shared_ptr<ScalarFunction> MakeArithmeticFunctionFloatingPointNotNull(
 }
 
 template <template <int64_t> class Op>
-void AddArithmeticFunctionTimeDuration(std::shared_ptr<ScalarFunction> func) {
+void AddArithmeticFunctionTimeDuration(const std::shared_ptr<ScalarFunction>& func) {
   // Add Op(time32, duration) -> time32
   TimeUnit::type unit = TimeUnit::SECOND;
   auto exec_1 = ScalarBinary<Time32Type, Time32Type, DurationType, Op<86400>>::Exec;
@@ -1085,7 +1085,7 @@ void AddArithmeticFunctionTimeDuration(std::shared_ptr<ScalarFunction> func) {
 }
 
 template <template <int64_t> class Op>
-void AddArithmeticFunctionDurationTime(std::shared_ptr<ScalarFunction> func) {
+void AddArithmeticFunctionDurationTime(const std::shared_ptr<ScalarFunction>& func) {
   // Add Op(duration, time32) -> time32
   TimeUnit::type unit = TimeUnit::SECOND;
   auto exec_1 = ScalarBinary<Time32Type, DurationType, Time32Type, Op<86400>>::Exec;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_benchmark.cc
@@ -31,7 +31,7 @@ constexpr auto kSeed = 0x94378165;
 
 template <typename InputType, typename CType = typename InputType::c_type>
 static void BenchmarkNumericCast(benchmark::State& state,
-                                 std::shared_ptr<DataType> to_type,
+                                 const std::shared_ptr<DataType>& to_type,
                                  const CastOptions& options, CType min, CType max) {
   GenericItemsArgs args(state);
   random::RandomArrayGenerator rand(kSeed);
@@ -43,8 +43,8 @@ static void BenchmarkNumericCast(benchmark::State& state,
 
 template <typename InputType, typename CType = typename InputType::c_type>
 static void BenchmarkFloatingToIntegerCast(benchmark::State& state,
-                                           std::shared_ptr<DataType> from_type,
-                                           std::shared_ptr<DataType> to_type,
+                                           const std::shared_ptr<DataType>& from_type,
+                                           const std::shared_ptr<DataType>& to_type,
                                            const CastOptions& options, CType min,
                                            CType max) {
   GenericItemsArgs args(state);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -56,11 +56,11 @@ using internal::checked_pointer_cast;
 
 namespace compute {
 
-static std::shared_ptr<Array> InvalidUtf8(std::shared_ptr<DataType> type) {
+static std::shared_ptr<Array> InvalidUtf8(const std::shared_ptr<DataType>& type) {
   return BinaryArrayFromStrings(type, {"Hi", "olá mundo", "你好世界", "", "\xa0\xa1"});
 }
 
-static std::shared_ptr<Array> FixedSizeInvalidUtf8(std::shared_ptr<DataType> type) {
+static std::shared_ptr<Array> FixedSizeInvalidUtf8(const std::shared_ptr<DataType>& type) {
   if (type->id() == Type::FIXED_SIZE_BINARY) {
     // Assume a particular width for testing
     EXPECT_EQ(3, checked_cast<const FixedSizeBinaryType&>(*type).byte_width());
@@ -88,13 +88,13 @@ static void AssertBufferSame(const Array& left, const Array& right, size_t buffe
             right.data()->buffers[buffer_index].get());
 }
 
-static void CheckCast(std::shared_ptr<Array> input, std::shared_ptr<Array> expected,
+static void CheckCast(const std::shared_ptr<Array>& input, const std::shared_ptr<Array>& expected,
                       CastOptions options = CastOptions{}) {
   options.to_type = expected->type();
   CheckScalarUnary("cast", input, expected, &options);
 }
 
-static void CheckCastFails(std::shared_ptr<Array> input, CastOptions options) {
+static void CheckCastFails(const std::shared_ptr<Array>& input, CastOptions options) {
   ASSERT_RAISES(Invalid, Cast(input, options))
       << "\n  to_type:   " << options.to_type.ToString()
       << "\n  from_type: " << input->type()->ToString()
@@ -111,8 +111,8 @@ static void CheckCastFails(std::shared_ptr<Array> input, CastOptions options) {
   ASSERT_GT(num_failing, 0);
 }
 
-static void CheckCastZeroCopy(std::shared_ptr<Array> input,
-                              std::shared_ptr<DataType> to_type,
+static void CheckCastZeroCopy(const std::shared_ptr<Array>& input,
+                              const std::shared_ptr<DataType>& to_type,
                               CastOptions options = CastOptions::Safe()) {
   ASSERT_OK_AND_ASSIGN(auto converted, Cast(*input, to_type, options));
   ValidateOutput(*converted);
@@ -123,7 +123,7 @@ static void CheckCastZeroCopy(std::shared_ptr<Array> input,
   }
 }
 
-static std::shared_ptr<Array> MaskArrayWithNullsAt(std::shared_ptr<Array> input,
+static std::shared_ptr<Array> MaskArrayWithNullsAt(const std::shared_ptr<Array>& input,
                                                    std::vector<int> indices_to_mask) {
   auto masked = input->data()->Copy();
   masked->buffers[0] = *AllocateEmptyBitmap(input->length());
@@ -144,7 +144,7 @@ static std::shared_ptr<Array> MaskArrayWithNullsAt(std::shared_ptr<Array> input,
 }
 
 TEST(Cast, CanCast) {
-  auto ExpectCanCast = [](std::shared_ptr<DataType> from,
+  auto ExpectCanCast = [](const std::shared_ptr<DataType>& from,
                           std::vector<std::shared_ptr<DataType>> to_set,
                           bool expected = true) {
     for (auto to : to_set) {
@@ -153,7 +153,7 @@ TEST(Cast, CanCast) {
     }
   };
 
-  auto ExpectCannotCast = [ExpectCanCast](std::shared_ptr<DataType> from,
+  auto ExpectCannotCast = [ExpectCanCast](const std::shared_ptr<DataType>& from,
                                           std::vector<std::shared_ptr<DataType>> to_set) {
     ExpectCanCast(from, to_set, /*expected=*/false);
   };
@@ -3205,7 +3205,7 @@ TEST(Cast, StringToDate) {
   }
 }
 
-static void AssertBinaryZeroCopy(std::shared_ptr<Array> lhs, std::shared_ptr<Array> rhs) {
+static void AssertBinaryZeroCopy(const std::shared_ptr<Array>& lhs, const std::shared_ptr<Array>& rhs) {
   EXPECT_TRUE(is_base_binary_like(lhs->type_id()) || is_binary_view_like(lhs->type_id()));
   EXPECT_EQ(is_base_binary_like(lhs->type_id()), is_base_binary_like(rhs->type_id()));
   // null bitmap and data buffers are always zero-copied
@@ -4281,7 +4281,7 @@ TEST(Cast, StructToDifferentNullabilityStruct) {
 
 TEST(Cast, IdentityCasts) {
   // ARROW-4102
-  auto CheckIdentityCast = [](std::shared_ptr<DataType> type, const std::string& json) {
+  auto CheckIdentityCast = [](const std::shared_ptr<DataType>& type, const std::string& json) {
     CheckCastZeroCopy(ArrayFromJSON(type, json), type);
   };
 
@@ -4311,7 +4311,7 @@ TEST(Cast, IdentityCasts) {
 
 TEST(Cast, EmptyCasts) {
   // ARROW-4766: 0-length arrays should not segfault
-  auto CheckCastEmpty = [](std::shared_ptr<DataType> from, std::shared_ptr<DataType> to) {
+  auto CheckCastEmpty = [](const std::shared_ptr<DataType>& from, const std::shared_ptr<DataType>& to) {
     // Python creates array with nullptr instead of 0-length (valid) buffers.
     auto data = ArrayData::Make(from, /* length */ 0, /* buffers */ {nullptr, nullptr});
     CheckCast(MakeArray(data), ArrayFromJSON(to, "[]"));

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -501,7 +501,7 @@ struct ScalarMinMax {
 
   static Result<std::shared_ptr<Scalar>> ExecScalar(
       const ExecSpan& batch, const ElementWiseAggregateOptions& options,
-      std::shared_ptr<DataType> type) {
+      const std::shared_ptr<DataType>& type) {
     // All arguments are scalar
     OutValue value{};
     bool valid = false;
@@ -523,9 +523,9 @@ struct ScalarMinMax {
       }
     }
     if (valid) {
-      return MakeScalar(std::move(type), std::move(value));
+      return MakeScalar(type, std::move(value));
     } else {
-      return MakeNullScalar(std::move(type));
+      return MakeNullScalar(type);
     }
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -428,7 +428,7 @@ TEST(TestCompareTimestamps, Basics) {
   const char* example1_json = R"(["1970-01-01","2000-02-29","1900-02-28"])";
   const char* example2_json = R"(["1970-01-02","2000-02-01","1900-02-28"])";
 
-  auto CheckArrayCase = [&](std::shared_ptr<DataType> type, CompareOperator op,
+  auto CheckArrayCase = [&](const std::shared_ptr<DataType>& type, CompareOperator op,
                             const char* expected_json) {
     auto lhs = ArrayFromJSON(type, example1_json);
     auto rhs = ArrayFromJSON(type, example2_json);
@@ -510,8 +510,8 @@ TEST(TestCompareTimestamps, ScalarArray) {
   struct ArrayCase {
     Datum side1, side2, expected;
   };
-  auto CheckArrayCase = [&](std::shared_ptr<DataType> scalar_type,
-                            std::shared_ptr<DataType> array_type, CompareOperator op,
+  auto CheckArrayCase = [&](const std::shared_ptr<DataType>& scalar_type,
+                            const std::shared_ptr<DataType>& array_type, CompareOperator op,
                             const std::string& expected_json,
                             const std::string& flip_expected_json) {
     auto scalar_side = ScalarFromJSON(scalar_type, scalar_json);

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -1957,8 +1957,8 @@ TEST(TestCaseWhen, Decimal) {
 
 TEST(TestCaseWhen, DecimalPromotion) {
   auto check_case_when_decimal_promotion =
-      [](std::shared_ptr<Scalar> body_true, std::shared_ptr<Scalar> body_false,
-         std::shared_ptr<Scalar> promoted_true, std::shared_ptr<Scalar> promoted_false) {
+      [](const std::shared_ptr<Scalar>& body_true, const std::shared_ptr<Scalar>& body_false,
+         const std::shared_ptr<Scalar>& promoted_true, const std::shared_ptr<Scalar>& promoted_false) {
         auto cond_true = ScalarFromJSON(boolean(), "true");
         auto cond_false = ScalarFromJSON(boolean(), "false");
         CheckScalar("case_when", {MakeStruct({cond_true}), body_true, body_false},

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -48,7 +48,7 @@ namespace compute {
 // ----------------------------------------------------------------------
 // IsIn tests
 
-void CheckIsIn(const std::shared_ptr<Array> input,
+void CheckIsIn(const std::shared_ptr<Array>& input,
                const std::shared_ptr<Array>& value_set, const std::string& expected_json,
                SetLookupOptions::NullMatchingBehavior null_matching_behavior =
                    SetLookupOptions::MATCH) {
@@ -108,7 +108,7 @@ void CheckIsInDictionary(const std::shared_ptr<DataType>& type,
   AssertArraysEqual(*expected, *actual, /*verbose=*/true);
 }
 
-void CheckIsIn(const std::shared_ptr<Array> input,
+void CheckIsIn(const std::shared_ptr<Array>& input,
                const std::shared_ptr<Array>& value_set, const std::string& expected_json,
                bool skip_nulls) {
   auto expected = ArrayFromJSON(boolean(), expected_json);

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -55,13 +55,13 @@ class BaseTestStringKernels : public ::testing::Test {
   using ScalarType = typename TypeTraits<TestType>::ScalarType;
 
   void CheckUnary(std::string func_name, std::string json_input,
-                  std::shared_ptr<DataType> out_ty, std::string json_expected,
+                  const std::shared_ptr<DataType>& out_ty, std::string json_expected,
                   const FunctionOptions* options = nullptr) {
     CheckScalarUnary(func_name, type(), json_input, out_ty, json_expected, options);
   }
 
   void CheckUnary(std::string func_name, const std::shared_ptr<Array>& input,
-                  std::shared_ptr<DataType> out_ty, std::string json_expected,
+                  const std::shared_ptr<DataType>& out_ty, std::string json_expected,
                   const FunctionOptions* options = nullptr) {
     CheckScalar(func_name, {Datum(input)}, Datum(ArrayFromJSON(out_ty, json_expected)),
                 options);
@@ -74,7 +74,7 @@ class BaseTestStringKernels : public ::testing::Test {
   }
 
   void CheckVarArgsScalar(std::string func_name, std::string json_input,
-                          std::shared_ptr<DataType> out_ty, std::string json_expected,
+                          const std::shared_ptr<DataType>& out_ty, std::string json_expected,
                           const FunctionOptions* options = nullptr) {
     // CheckScalar (on arrays) checks scalar arguments individually,
     // but this lets us test the all-scalar case explicitly
@@ -88,7 +88,7 @@ class BaseTestStringKernels : public ::testing::Test {
   }
 
   void CheckVarArgs(std::string func_name, const DatumVector& inputs,
-                    std::shared_ptr<DataType> out_ty, std::string json_expected,
+                    const std::shared_ptr<DataType>& out_ty, std::string json_expected,
                     const FunctionOptions* options = nullptr) {
     CheckScalar(func_name, inputs, ArrayFromJSON(out_ty, json_expected), options);
   }
@@ -794,7 +794,7 @@ TYPED_TEST(TestBaseBinaryKernels, BinaryJoinElementWise) {
 class TestFixedSizeBinaryKernels : public ::testing::Test {
  protected:
   void CheckUnary(std::string func_name, std::string json_input,
-                  std::shared_ptr<DataType> out_ty, std::string json_expected,
+                  const std::shared_ptr<DataType>& out_ty, std::string json_expected,
                   const FunctionOptions* options = nullptr) {
     CheckScalarUnary(func_name, type(), json_input, out_ty, json_expected, options);
     // Ensure the equivalent binary kernel does the same thing

--- a/cpp/src/arrow/compute/kernels/select_k_test.cc
+++ b/cpp/src/arrow/compute/kernels/select_k_test.cc
@@ -83,7 +83,7 @@ class TestSelectKBase : public ::testing::Test {
 
  protected:
   template <SortOrder order>
-  void AssertSelectKArray(const std::shared_ptr<Array> values, int k) {
+  void AssertSelectKArray(const std::shared_ptr<Array>& values, int k) {
     std::shared_ptr<Array> select_k;
     ASSERT_OK_AND_ASSIGN(select_k, SelectK<order>(Datum(*values), k));
     ASSERT_EQ(select_k->data()->null_count, 0);
@@ -91,10 +91,10 @@ class TestSelectKBase : public ::testing::Test {
     ValidateSelectK(Datum(*values), *select_k, order);
   }
 
-  void AssertTopKArray(const std::shared_ptr<Array> values, int n) {
+  void AssertTopKArray(const std::shared_ptr<Array>& values, int n) {
     AssertSelectKArray<SortOrder::Descending>(values, n);
   }
-  void AssertBottomKArray(const std::shared_ptr<Array> values, int n) {
+  void AssertBottomKArray(const std::shared_ptr<Array>& values, int n) {
     AssertSelectKArray<SortOrder::Ascending>(values, n);
   }
 

--- a/cpp/src/arrow/compute/kernels/test_util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/test_util_internal.cc
@@ -83,7 +83,7 @@ void CheckScalarNonRecursive(const std::string& func_name, const DatumVector& in
 }
 
 void CheckScalar(std::string func_name, const ScalarVector& inputs,
-                 std::shared_ptr<Scalar> expected, const FunctionOptions* options) {
+                 const std::shared_ptr<Scalar>& expected, const FunctionOptions* options) {
   ASSERT_OK_AND_ASSIGN(Datum out, CallFunction(func_name, GetDatums(inputs), options));
   ValidateOutput(out);
   if (!out.scalar()->Equals(*expected)) {
@@ -259,8 +259,8 @@ void CheckScalarUnary(std::string func_name, Datum input, Datum expected,
   CheckScalar(std::move(func_name), input_vector, expected, options);
 }
 
-void CheckScalarUnary(std::string func_name, std::shared_ptr<DataType> in_ty,
-                      std::string json_input, std::shared_ptr<DataType> out_ty,
+void CheckScalarUnary(std::string func_name, const std::shared_ptr<DataType>& in_ty,
+                      std::string json_input, const std::shared_ptr<DataType>& out_ty,
                       std::string json_expected, const FunctionOptions* options) {
   CheckScalarUnary(std::move(func_name), ArrayFromJSON(in_ty, json_input),
                    ArrayFromJSON(out_ty, json_expected), options);

--- a/cpp/src/arrow/compute/kernels/test_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/test_util_internal.h
@@ -95,7 +95,7 @@ inline std::shared_ptr<Scalar> DecimalScalarFromJSON(
 // Call the function with the given arguments, as well as slices of
 // the arguments and scalars extracted from the arguments.
 void CheckScalar(std::string func_name, const ScalarVector& inputs,
-                 std::shared_ptr<Scalar> expected,
+                 const std::shared_ptr<Scalar>& expected,
                  const FunctionOptions* options = nullptr);
 
 void CheckScalar(std::string func_name, const DatumVector& inputs, Datum expected,
@@ -114,8 +114,8 @@ void CheckScalarNonRecursive(const std::string& func_name, const DatumVector& in
                              const Datum& expected,
                              const FunctionOptions* options = nullptr);
 
-void CheckScalarUnary(std::string func_name, std::shared_ptr<DataType> in_ty,
-                      std::string json_input, std::shared_ptr<DataType> out_ty,
+void CheckScalarUnary(std::string func_name, const std::shared_ptr<DataType>& in_ty,
+                      std::string json_input, const std::shared_ptr<DataType>& out_ty,
                       std::string json_expected,
                       const FunctionOptions* options = nullptr);
 

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -76,7 +76,7 @@ struct CumulativeBinaryOp {
 
   CumulativeBinaryOp() { current_value = Identity<Op>::template value<OutValue>(); }
 
-  explicit CumulativeBinaryOp(const std::shared_ptr<Scalar> start) {
+  explicit CumulativeBinaryOp(const std::shared_ptr<Scalar>& start) {
     current_value = UnboxScalar<OutType>::Unbox(*start);
   }
 
@@ -97,7 +97,7 @@ struct CumulativeMean {
   CumulativeMean() = default;
 
   // start value is ignored for CumulativeMean
-  explicit CumulativeMean(const std::shared_ptr<Scalar> start) {}
+  explicit CumulativeMean(const std::shared_ptr<Scalar>& start) {}
 
   double Call(KernelContext* ctx, ArgValue arg, Status* st) {
     sum += static_cast<double>(arg);

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -148,7 +148,7 @@ class TestReplaceKernel : public ::testing::Test {
   }
 
   void AssertFillNullChunkedArray(FillNullFunction func,
-                                  const std::shared_ptr<ChunkedArray> array,
+                                  const std::shared_ptr<ChunkedArray>& array,
                                   const std::shared_ptr<ChunkedArray>& expected) {
     ASSERT_OK_AND_ASSIGN(auto actual, func(Datum(*array), nullptr));
     AssertChunkedEquivalent(*expected, *actual.chunked_array());

--- a/cpp/src/arrow/compute/kernels/vector_run_end_encode_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_run_end_encode_test.cc
@@ -49,7 +49,7 @@ struct REETestData {
   }
 
  public:
-  static REETestData JSON(std::shared_ptr<DataType> data_type, std::string input_json,
+  static REETestData JSON(const std::shared_ptr<DataType>& data_type, std::string input_json,
                           std::string expected_values_json,
                           std::string expected_run_ends_json, int64_t input_offset = 0) {
     auto input_array = ArrayFromJSON(data_type, input_json);
@@ -69,7 +69,7 @@ struct REETestData {
         "[null * " + std::to_string(input_slice_length) + "]");
   }
 
-  static REETestData JSONChunked(std::shared_ptr<DataType> data_type,
+  static REETestData JSONChunked(const std::shared_ptr<DataType>& data_type,
                                  std::vector<std::string> inputs_json,
                                  std::vector<std::string> expected_values_json,
                                  std::vector<std::string> expected_run_ends_json,

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1305,7 +1305,7 @@ void CheckTakeXA(const std::shared_ptr<DataType>& type, const std::string& value
   }
 }
 
-void CheckTakeXADictionary(std::shared_ptr<DataType> value_type,
+void CheckTakeXADictionary(const std::shared_ptr<DataType>& value_type,
                            const std::string& dictionary_values,
                            const std::string& dictionary_indices,
                            const std::string& indices,
@@ -1489,7 +1489,7 @@ class TestTakeKernel : public ::testing::Test {
  public:
   void DoTestNoValidityBitmapButUnknownNullCount(
       const std::shared_ptr<DataType>& type, const std::string& values,
-      const std::string& indices, std::shared_ptr<DataType> index_type = int8()) {
+      const std::string& indices, const std::shared_ptr<DataType>& index_type = int8()) {
     DoTestNoValidityBitmapButUnknownNullCount(ArrayFromJSON(type, values),
                                               ArrayFromJSON(index_type, indices));
   }

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -345,7 +345,7 @@ class ConcreteRecordBatchColumnSorter : public RecordBatchColumnSorter {
 template <>
 class ConcreteRecordBatchColumnSorter<NullType> : public RecordBatchColumnSorter {
  public:
-  ConcreteRecordBatchColumnSorter(std::shared_ptr<Array> array, SortOrder order,
+  ConcreteRecordBatchColumnSorter(const std::shared_ptr<Array>& array, SortOrder order,
                                   NullPlacement null_placement,
                                   RecordBatchColumnSorter* next_column = nullptr)
       : RecordBatchColumnSorter(next_column), null_placement_(null_placement) {}

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -2396,7 +2396,7 @@ class TestRank : public BaseTestRank {
     AssertRank(datums_, order, null_placement, tiebreaker, expected);
   }
 
-  static void AssertRankEmpty(std::shared_ptr<DataType> type, SortOrder order,
+  static void AssertRankEmpty(const std::shared_ptr<DataType>& type, SortOrder order,
                               NullPlacement null_placement,
                               RankOptions::Tiebreaker tiebreaker) {
     AssertRank({ArrayFromJSON(type, "[]")}, order, null_placement, tiebreaker,
@@ -2708,7 +2708,7 @@ class TestRankQuantile : public BaseTestRank {
     AssertRankQuantileGeneric("rank_normal", std::forward<Args>(args)...);
   }
 
-  void AssertRankQuantileEmpty(std::shared_ptr<DataType> type) {
+  void AssertRankQuantileEmpty(const std::shared_ptr<DataType>& type) {
     for (auto null_placement : AllNullPlacements()) {
       for (auto order : AllOrders()) {
         AssertRankQuantile(ArrayFromJSON(type, "[]"), order, null_placement, "[]");
@@ -2765,7 +2765,7 @@ class TestRankQuantile : public BaseTestRank {
                      "-1.2815515655446004, 0.5244005127080407]");
   }
 
-  void AssertRankQuantileNumeric(std::shared_ptr<DataType> type) {
+  void AssertRankQuantileNumeric(const std::shared_ptr<DataType>& type) {
     ARROW_SCOPED_TRACE("type = ", type->ToString());
     AssertRankQuantileEmpty(type);
 
@@ -2794,7 +2794,7 @@ class TestRankQuantile : public BaseTestRank {
     AssertRankQuantile_N1N2N();
   }
 
-  void AssertRankQuantileBinaryLike(std::shared_ptr<DataType> type) {
+  void AssertRankQuantileBinaryLike(const std::shared_ptr<DataType>& type) {
     ARROW_SCOPED_TRACE("type = ", type->ToString());
     AssertRankQuantileEmpty(type);
 

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -39,14 +39,14 @@ class FunctionRegistry::FunctionRegistryImpl {
       : parent_(parent) {}
   ~FunctionRegistryImpl() {}
 
-  Status CanAddFunction(std::shared_ptr<Function> function, bool allow_overwrite) {
+  Status CanAddFunction(const std::shared_ptr<Function>& function, bool allow_overwrite) {
     if (parent_ != nullptr) {
       RETURN_NOT_OK(parent_->CanAddFunction(function, allow_overwrite));
     }
     return DoAddFunction(function, allow_overwrite, /*add=*/false);
   }
 
-  Status AddFunction(std::shared_ptr<Function> function, bool allow_overwrite) {
+  Status AddFunction(const std::shared_ptr<Function>& function, bool allow_overwrite) {
     if (parent_ != nullptr) {
       RETURN_NOT_OK(parent_->CanAddFunction(function, allow_overwrite));
     }

--- a/cpp/src/arrow/cpp-review-procedure.md
+++ b/cpp/src/arrow/cpp-review-procedure.md
@@ -1,0 +1,152 @@
+
+You are performing a review of C++ code.
+
+By default, operate in read-only mode and only generate a report of violations and recommendations. Do not make changes to existing files or create a PR unless the user explicitly requests that action.
+
+
+## Scope
+
+Review C++ source files (`.cpp`, `.cc`, `.cxx`, `.h`, `.hpp`) only. Skip `.c` files (plain C).
+
+If the user provides file paths or folder names, look for violations in those. Otherwise, report violations in the current git diff for the user's local working copy. To determine violations in this code usually requires reading more context in surrounding code (e.g., the enclosing function, the class definition).
+
+First probe for `compile_commands.json`, `clangd`, or `clang-query` to try to find an accurate language service that can reliably verify characteristics about an object's type (e.g., whether the object's type has a user-defined `operator*`). If you cannot use an accurate language service, then ignore (heuristic) bullets and use only (allow-list) bullets.
+
+Report a result from a header file only once even if it is included in multiple TUs. For a given definition in a header file: if the definition parses cleanly using an accurate language service in one TU and badly in another, or resolves overloads more cleanly in one TU than another, keep the results from the cleanest version and discard the others.
+
+Do not report violations or fixes not mentioned in the skill.
+
+Do not report suppressed violations: On a line or statement that has a violation of two different rules labeled X and Y, and X (but not Y) was explicitly suppressed such as "// suppress rule X" or "[[suppress(X)]]" or similar, do not report the violation of X but do report the violation of Y. So that suppressions remain stable, rule labels in each skill are intended to not be reused; if a rule is deleted, its label subheading should be left with a body of "(Rule deleted)."
+
+
+## Procedure
+
+Do the work in two passes under different roles. Finish pass 1 completely and write its findings to a file. Then begin pass 2 as a reviewer whose assignment is to find defects in that file, working from the file and the repository source rather than from pass 1's reasoning. No report is printed and no change is suggested until pass 2 is complete.
+
+### Pass 1 — analysis
+
+Emit interim findings as a machine-readable file with one record per candidate violation, each carrying the rule ID, path, line, the fix chosen, the evidence for that fix, and details that are referred to in the rule (e.g., if the rule is about a parameter and its use in the body, include the parameter name, declared type, canonical type, every use of the parameter with its line and classification). Write no prose about the findings during this pass.
+
+### Pass 2 — review
+
+Run each of the following checks and state, for each, what was checked, what came back, and what changed as a result. A check whose result is reported as clean must name the evidence that makes it clean; "no issues found" on its own is not a result.
+
+1. **Sample audit.** Draw a random sample of the greater of ten findings or five percent of them, spread across subsystems and across every fix category the sweep produced. For each, re-derive the verdict from the source rather than from the interim record: read the enclosing function in full, the declarations of any callees involved, and the definition of any type the rule turns on. Then record three separate judgments: whether the violation is real, whether the prescribed fix is the one the skill prescribes, and whether the stated justification matches what the code does. Report a defect rate for each judgment across the sample.
+
+2. **Escalation.** If the sample audit finds real-violation defects above one in ten, or fix defects above one in five, stop; the sweep is not reportable. Diagnose the cause, fix it, rerun, and audit a fresh sample.
+
+3. **Named failure hypotheses.** Test each of these against the interim file rather than reasoning about whether it applies: failures hidden by a degraded parse of one translation unit while another parsed the same header cleanly; a violation reported at a macro expansion site rather than at the macro body; a violation reported at a point of instantiation rather than at the template definition; the same violation reported twice through different paths to the same header; a parameter reported as unused because its only use sits in an inactive preprocessor branch; a use classified as a read only because the callee could not be resolved.
+
+4. **Fix interactions.** Group findings by function and by caller-callee pairs within the finding set. Where fixing one changes the evidence for another, say which to apply first and what the second becomes afterward.
+
+5. **Severity re-derivation.** For every finding whose severity is based on being on a hot path, name the caller or user annotation that puts it on a hot path.
+
+6. **Compilation check.** Where the environment permits, apply each reported fix and compile the affected translation unit. Where it does not, say so rather than implying the fixes were tested.
+
+## Generated, vendored, macro-expanded, templated, and conditionally compiled code
+
+More than one of the following may apply to a given code location.
+
+  - **Generated code**: A file produced by a code generator, identified by a banner comment such as `DO NOT EDIT`, `@generated`, or `Generated by ...` within the first 40 lines, by a conventional name (`*.pb.h`, `*.pb.cc`, `moc_*.cpp`, `ui_*.h`, `*_generated.h`, `*.pas.h`), or by residence in a build output directory. Do not report violations in generated code; instead, report a single aggregate note giving the count and naming the generator, so that the user can decide whether to take the fix upstream into the generator or its input schema.
+  
+  - **Vendored third-party code**: A file under a dependency tree such as `third_party/`, `thirdparty/`, `vendor/`, `external/`, `extern/`, `deps/`, or `contrib/`, or outside the repository root (including system headers). Do not report violations in vendored code by default; report an aggregate count instead. If the user names a vendored path explicitly, review it as normal and classify every finding in it as non-locally fixable.
+  
+  - **Macro-expanded code**: A violation whose offending construct originates in a macro body rather than at the expansion site. Report it once, at the location of the macro definition, and state that the fix applies to the macro body; do not report it separately at each expansion site. If the macro body is not visible, do not report the violation at all.
+  
+  - **Template-instantiated code**: A violation whose offending construct originates in a template body rather than at the point of instantiation. Report it once, at the location of the template definition, and state that the fix applies to the template body; do not report it separately at each point of instantiation. If the template body is not visible, do not report the violation at all.
+  
+  - **Conditionally compiled code**: Consider only the code that the active configuration compiles; where no configuration is known, consider the code that survives with no macros defined beyond the compiler's own, and say so in the report.
+  
+
+## Definitions
+
+### Severity order
+
+Within the same severity level (e.g., "high"), consider the annotations in the following order from highest to lowest sub-severity:
+  - "(correctness)"
+  - "(performance)"
+  - "(design)"
+  - no annotation
+
+### Function body
+
+Consider the member initializer list as part of the function body.
+
+### Locally fixable violations
+
+  - **Non-locally fixable violation**: A violation whose fix would require
+    changing a parameter's declared type on a function whose signature cannot
+    be changed locally, including: a function marked `virtual`, `override`,
+    and/or `final`; a function whose address is taken; a callback bound to a
+    fixed signature; a published API boundary; a template instantiation
+    constrained by a concept.
+
+  - **Locally fixable violation**: A violation that is not non-locally fixable.
+
+### Local object
+
+  - **Local object**:
+    - A function parameter
+    - OR a non-`static` non-`thread_local` variable declared in the function body
+    - OR a lambda capture by value, including an init-capture, whatever its
+      initializer, since the closure holds its own copy and its own reference count
+    - OR a lambda capture by reference whose referent is a local object
+
+A variable that is a reference or a raw pointer bound to a non-local object is itself non-local, since it aliases rather than copies. A SharedPtr that is a _copy_ of a non-local SharedPtr is a local object; the copy is what makes it safe.
+
+### Function's call tree
+
+  - **Function's call tree**: A function `f`'s call tree is the set of code that is transitively called by `f`. Consider the known call tree of called functions whose definitions are available; ignore unknowable parts of the call tree that are hidden by opaque calls, including but not limited to: calls to forward-declared functions; calls to virtual functions; calls through pointers to function; calls through `std::function`.
+
+### Hot path
+
+  - **Hot path**: A code sequence that is likely to be executed frequently in production (not tests). Examples include but are not limited to: an override of a known per-request interface; a caller inside a loop in the same translation unit; an explicit hot-path annotation or profile file supplied by the user.
+
+### Definite last use
+
+  - **Definite last use**: A definite last use of local object `x` means a use of `x` in an expression E where `x` appears only once in E AND `x` is not referred to again after E on any local control flow path that includes E. (Reminder: In a constructor, all control flow paths begin with the member-initializers in declaration order.)
+
+### Moved from
+
+  - **Moved from**: An object `x` is moved from if any of the following operations are performed: `std::move(x)`, `std::exchange(x, /*...*/)`, `x.swap(y)`, `static_cast<T&&>(x)`, `return x;` if returned by value, or code that causes `x` to be passed as an argument to the parameter of a move constructor or move assignment operator.
+
+### Potentially modified
+
+  - **Potentially modified**: An object `x` is potentially modified if it is assigned to or used as an argument to a non-`const` paramter (including the implicit `this` parameter by calling a non-`const` member function `x.may_modify()`).
+
+### Namespaces and type names
+
+"Under namespaces `X` and `Y`" includes named or anonymous subnamespaces such as `X::X2::X3` and inline namespaces. For example, "Under namespaces `std` or `boost`" includes for example under namespaces `std::tr1` and `boost::interprocess`.
+
+Any specific _unqualified_ named type, such as `shared_ptr`, means any type having that name as a suffix in the global namespace or under namespaces `std` and `boost` OR any typedef/aliases of such a type. For example, `shared_ptr` includes (but is not limited to) `std::tr1::shared_ptr`, `boost::local_shared_ptr`,`boost::interprocess::shared_ptr`.
+
+
+## Output contract
+
+State up front:
+  - Whether an accurate language service was used
+  - A count of suppressed violations
+  - The verification results: the outcome of each Pass 2 check, plus the sample size (absolute) and the defect rate (percentage) for each of the three judgments, and every adjustment the review pass caused.
+
+Where the evidence for a fix rests on a callee the language service could not resolve, say so at that finding and use an alternative fix that does not rely on knowing the unresolved callee.
+
+The main findings report should be divided into two sections:
+  - Locally fixable violations
+  - Non-locally fixable violations
+
+In each section:
+  - Report one finding per violation with `path:line`, a stable rule ID,
+    the severity string, a quoted snippet that shows the violation, the
+    concrete fix(es), and a copy of the same quoted snippet with the
+    fix(es) applied
+  - Order findings by severity descending, then path.
+  - If there are no findings in the section, print "None found."
+  - By default show only the 30 most severe violations in the section,
+    if the user does not specify a different number. If the limit is
+    reached, add a line stating how many items were withheld.
+
+Report a count of violations skipped in generated or vendored code, with the paths or trees they came from.
+
+Report conditionally compiled code that was skipped because it was not in the active configuration.
+
+Report the same violation only once, even if it is in a header file.

--- a/cpp/src/arrow/csv/column_builder_test.cc
+++ b/cpp/src/arrow/csv/column_builder_test.cc
@@ -77,7 +77,7 @@ class ColumnBuilderTest : public ::testing::Test {
 
   void CheckInferred(const std::shared_ptr<TaskGroup>& tg, const ChunkData& csv_data,
                      const ConvertOptions& options,
-                     std::shared_ptr<ChunkedArray> expected, bool validate_full = true) {
+                     const std::shared_ptr<ChunkedArray>& expected, bool validate_full = true) {
     std::shared_ptr<ColumnBuilder> builder;
     std::shared_ptr<ChunkedArray> actual;
     ASSERT_OK_AND_ASSIGN(
@@ -97,7 +97,7 @@ class ColumnBuilderTest : public ::testing::Test {
   void CheckFixedType(const std::shared_ptr<TaskGroup>& tg,
                       const std::shared_ptr<DataType>& type, const ChunkData& csv_data,
                       const ConvertOptions& options,
-                      std::shared_ptr<ChunkedArray> expected) {
+                      const std::shared_ptr<ChunkedArray>& expected) {
     std::shared_ptr<ColumnBuilder> builder;
     std::shared_ptr<ChunkedArray> actual;
     ASSERT_OK_AND_ASSIGN(builder, ColumnBuilder::Make(default_memory_pool(), type, 0,

--- a/cpp/src/arrow/csv/column_decoder_test.cc
+++ b/cpp/src/arrow/csv/column_decoder_test.cc
@@ -103,7 +103,7 @@ class ColumnDecoderTest : public ::testing::Test {
     return decoded_chunks_[read_ptr_++].result();
   }
 
-  void AssertChunk(std::vector<std::string> chunk, std::shared_ptr<Array> expected) {
+  void AssertChunk(std::vector<std::string> chunk, const std::shared_ptr<Array>& expected) {
     std::shared_ptr<BlockParser> parser;
     MakeColumnParser(chunk, &parser);
     ASSERT_FINISHES_OK_AND_ASSIGN(auto decoded, decoder_->Decode(parser));
@@ -116,7 +116,7 @@ class ColumnDecoderTest : public ::testing::Test {
     ASSERT_FINISHES_AND_RAISES(Invalid, decoder_->Decode(parser));
   }
 
-  void AssertFetch(std::shared_ptr<Array> expected_chunk) {
+  void AssertFetch(const std::shared_ptr<Array>& expected_chunk) {
     ASSERT_OK_AND_ASSIGN(auto chunk, NextChunk());
     ASSERT_NE(chunk, nullptr);
     AssertArraysEqual(*expected_chunk, *chunk);
@@ -140,7 +140,7 @@ class NullColumnDecoderTest : public ColumnDecoderTest {
  public:
   NullColumnDecoderTest() {}
 
-  void MakeDecoder(std::shared_ptr<DataType> type) {
+  void MakeDecoder(const std::shared_ptr<DataType>& type) {
     ASSERT_OK_AND_ASSIGN(auto decoder,
                          ColumnDecoder::MakeNull(default_memory_pool(), type));
     SetDecoder(decoder);

--- a/cpp/src/arrow/csv/fuzz.cc
+++ b/cpp/src/arrow/csv/fuzz.cc
@@ -58,7 +58,7 @@ Status FuzzCsvReader(const uint8_t* data, int64_t size) {
 
   // TODO should we also test non-inferring table read?
 
-  auto read_table_serial = [=](std::shared_ptr<InputStream> input) mutable -> Status {
+  auto read_table_serial = [=](const std::shared_ptr<InputStream>& input) mutable -> Status {
     read_options.use_threads = false;
     ARROW_ASSIGN_OR_RAISE(auto table_reader,
                           TableReader::Make(io_context, input, read_options,
@@ -67,7 +67,7 @@ Status FuzzCsvReader(const uint8_t* data, int64_t size) {
     return table->ValidateFull();
   };
 
-  auto read_table_threaded = [=](std::shared_ptr<InputStream> input) mutable -> Status {
+  auto read_table_threaded = [=](const std::shared_ptr<InputStream>& input) mutable -> Status {
     read_options.use_threads = true;
     ARROW_ASSIGN_OR_RAISE(auto table_reader,
                           TableReader::Make(io_context, input, read_options,
@@ -76,7 +76,7 @@ Status FuzzCsvReader(const uint8_t* data, int64_t size) {
     return table->ValidateFull();
   };
 
-  auto read_streaming = [=](std::shared_ptr<InputStream> input) mutable -> Status {
+  auto read_streaming = [=](const std::shared_ptr<InputStream>& input) mutable -> Status {
     read_options.use_threads = true;
     ARROW_ASSIGN_OR_RAISE(
         auto reader, StreamingReader::Make(io_context, input, read_options, parse_options,
@@ -85,7 +85,7 @@ Status FuzzCsvReader(const uint8_t* data, int64_t size) {
     return table->ValidateFull();
   };
 
-  auto count_rows = [=](std::shared_ptr<InputStream> input) mutable -> Status {
+  auto count_rows = [=](const std::shared_ptr<InputStream>& input) mutable -> Status {
     read_options.use_threads = true;
     parse_options.newlines_in_values = false;
     auto fut = CountRowsAsync(io_context, input, GetCpuThreadPool(), read_options,
@@ -94,7 +94,7 @@ Status FuzzCsvReader(const uint8_t* data, int64_t size) {
   };
 
   auto count_rows_allow_newlines =
-      [=](std::shared_ptr<InputStream> input) mutable -> Status {
+      [=](const std::shared_ptr<InputStream>& input) mutable -> Status {
     read_options.use_threads = true;
     parse_options.newlines_in_values = true;
     auto fut = CountRowsAsync(io_context, input, GetCpuThreadPool(), read_options,

--- a/cpp/src/arrow/csv/inference_internal.h
+++ b/cpp/src/arrow/csv/inference_internal.h
@@ -102,12 +102,12 @@ class InferStatus {
 
   Result<std::shared_ptr<Converter>> MakeConverter(MemoryPool* pool) {
     auto make_converter =
-        [&](std::shared_ptr<DataType> type) -> Result<std::shared_ptr<Converter>> {
+        [&](const std::shared_ptr<DataType>& type) -> Result<std::shared_ptr<Converter>> {
       return Converter::Make(type, options_, pool);
     };
 
     auto make_dict_converter =
-        [&](std::shared_ptr<DataType> type) -> Result<std::shared_ptr<Converter>> {
+        [&](const std::shared_ptr<DataType>& type) -> Result<std::shared_ptr<Converter>> {
       ARROW_ASSIGN_OR_RAISE(auto dict_converter,
                             DictionaryConverter::Make(type, options_, pool));
       dict_converter->SetMaxCardinality(options_.auto_dict_max_cardinality);

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -1220,19 +1220,19 @@ class CSVRowCounter : public ReaderMixin,
 // Factory functions
 
 Result<std::shared_ptr<TableReader>> TableReader::Make(
-    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    io::IOContext io_context, const std::shared_ptr<io::InputStream>& input,
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
-  return MakeTableReader(io_context.pool(), io_context, std::move(input), read_options,
+  return MakeTableReader(io_context.pool(), io_context, input, read_options,
                          parse_options, convert_options);
 }
 
 Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
-    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    io::IOContext io_context, const std::shared_ptr<io::InputStream>& input,
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
   auto cpu_executor = arrow::internal::GetCpuThreadPool();
-  auto reader_fut = MakeStreamingReader(io_context, std::move(input), cpu_executor,
+  auto reader_fut = MakeStreamingReader(io_context, input, cpu_executor,
                                         read_options, parse_options, convert_options);
   auto reader_result = reader_fut.result();
   ARROW_ASSIGN_OR_RAISE(auto reader, reader_result);
@@ -1240,10 +1240,10 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
 }
 
 Future<std::shared_ptr<StreamingReader>> StreamingReader::MakeAsync(
-    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    io::IOContext io_context, const std::shared_ptr<io::InputStream>& input,
     Executor* cpu_executor, const ReadOptions& read_options,
     const ParseOptions& parse_options, const ConvertOptions& convert_options) {
-  return MakeStreamingReader(io_context, std::move(input), cpu_executor, read_options,
+  return MakeStreamingReader(io_context, input, cpu_executor, read_options,
                              parse_options, convert_options);
 }
 

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -195,7 +195,7 @@ class SerialBlockReader : public BlockReader {
 
   static Iterator<CSVBlock> MakeIterator(
       Iterator<std::shared_ptr<Buffer>> buffer_iterator, std::unique_ptr<Chunker> chunker,
-      std::shared_ptr<Buffer> first_buffer, int64_t skip_rows) {
+      const std::shared_ptr<Buffer>& first_buffer, int64_t skip_rows) {
     auto block_reader =
         std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer, skip_rows);
     // Wrap shared pointer in callable
@@ -208,7 +208,7 @@ class SerialBlockReader : public BlockReader {
 
   static AsyncGenerator<CSVBlock> MakeAsyncIterator(
       AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
-      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
+      std::unique_ptr<Chunker> chunker, const std::shared_ptr<Buffer>& first_buffer,
       int64_t skip_rows) {
     auto block_reader =
         std::make_shared<SerialBlockReader>(std::move(chunker), first_buffer, skip_rows);
@@ -283,13 +283,13 @@ class ThreadedBlockReader : public BlockReader {
 
   static AsyncGenerator<CSVBlock> MakeAsyncIterator(
       AsyncGenerator<std::shared_ptr<Buffer>> buffer_generator,
-      std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer,
+      std::unique_ptr<Chunker> chunker, const std::shared_ptr<Buffer>& first_buffer,
       int64_t skip_rows) {
     auto block_reader = std::make_shared<ThreadedBlockReader>(std::move(chunker),
                                                               first_buffer, skip_rows);
     // Wrap shared pointer in callable
     Transformer<std::shared_ptr<Buffer>, CSVBlock> block_reader_fn =
-        [block_reader](std::shared_ptr<Buffer> next) { return (*block_reader)(next); };
+        [block_reader](const std::shared_ptr<Buffer>& next) { return (*block_reader)(next); };
     return MakeTransformedGenerator(std::move(buffer_generator), block_reader_fn);
   }
 
@@ -1024,7 +1024,7 @@ class AsyncThreadedTableReader
   using BaseTableReader::BaseTableReader;
 
   AsyncThreadedTableReader(io::IOContext io_context,
-                           std::shared_ptr<io::InputStream> input,
+                           const std::shared_ptr<io::InputStream>& input,
                            const ReadOptions& read_options,
                            const ParseOptions& parse_options,
                            const ConvertOptions& convert_options, Executor* cpu_executor)
@@ -1115,7 +1115,7 @@ class AsyncThreadedTableReader
 };
 
 Result<std::shared_ptr<TableReader>> MakeTableReader(
-    MemoryPool* pool, io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    MemoryPool* pool, io::IOContext io_context, const std::shared_ptr<io::InputStream>& input,
     const ReadOptions& read_options, const ParseOptions& parse_options,
     const ConvertOptions& convert_options) {
   RETURN_NOT_OK(parse_options.Validate());
@@ -1136,7 +1136,7 @@ Result<std::shared_ptr<TableReader>> MakeTableReader(
 }
 
 Future<std::shared_ptr<StreamingReader>> MakeStreamingReader(
-    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    io::IOContext io_context, const std::shared_ptr<io::InputStream>& input,
     Executor* cpu_executor, const ReadOptions& read_options,
     const ParseOptions& parse_options, const ConvertOptions& convert_options) {
   RETURN_NOT_OK(parse_options.Validate());

--- a/cpp/src/arrow/csv/reader_test.cc
+++ b/cpp/src/arrow/csv/reader_test.cc
@@ -192,7 +192,7 @@ void StressInvalidTableReader(TableReaderFactory reader_factory) {
   }
 }
 
-void TestNestedParallelism(std::shared_ptr<internal::ThreadPool> thread_pool,
+void TestNestedParallelism(const std::shared_ptr<internal::ThreadPool>& thread_pool,
                            TableReaderFactory reader_factory) {
   const int NROWS = 1000;
   ASSERT_OK_AND_ASSIGN(auto table_buffer, MakeSampleCsvBuffer(NROWS));
@@ -245,7 +245,7 @@ void TestInvalidRowsSkipped(TableReaderFactory reader_factory, bool async) {
 }
 
 TableReaderFactory MakeSerialFactory() {
-  return [](std::shared_ptr<io::InputStream> input_stream, ParseOptions parse_options,
+  return [](const std::shared_ptr<io::InputStream>& input_stream, ParseOptions parse_options,
             std::optional<int32_t> block_size) {
     auto read_options = ReadOptions::Defaults();
     read_options.block_size = block_size.value_or(1 << 10);
@@ -269,12 +269,12 @@ TEST(SerialReaderTests, InvalidRowsSkipped) {
 }
 
 Result<TableReaderFactory> MakeAsyncFactory(
-    std::shared_ptr<internal::ThreadPool> thread_pool = nullptr) {
+    const std::shared_ptr<internal::ThreadPool>& thread_pool = nullptr) {
   if (!thread_pool) {
     ARROW_ASSIGN_OR_RAISE(thread_pool, internal::ThreadPool::Make(1));
   }
   return [thread_pool](
-             std::shared_ptr<io::InputStream> input_stream, ParseOptions parse_options,
+             const std::shared_ptr<io::InputStream>& input_stream, ParseOptions parse_options,
              std::optional<int32_t> block_size) -> Result<std::shared_ptr<TableReader>> {
     ReadOptions read_options = ReadOptions::Defaults();
     read_options.use_threads = true;
@@ -318,7 +318,7 @@ TEST(AsyncReaderTests, InvalidRowsSkipped) {
 
 TableReaderFactory MakeStreamingFactory(bool use_threads = true) {
   return [use_threads](
-             std::shared_ptr<io::InputStream> input_stream, ParseOptions parse_options,
+             const std::shared_ptr<io::InputStream>& input_stream, ParseOptions parse_options,
              std::optional<int32_t> block_size) -> Result<std::shared_ptr<TableReader>> {
     auto read_options = ReadOptions::Defaults();
     read_options.block_size = block_size.value_or(1 << 10);
@@ -332,7 +332,7 @@ TableReaderFactory MakeStreamingFactory(bool use_threads = true) {
 }
 
 Result<StreamingReaderFactory> MakeStreamingReaderFactory() {
-  return [](std::shared_ptr<io::InputStream> input_stream)
+  return [](const std::shared_ptr<io::InputStream>& input_stream)
              -> Result<std::shared_ptr<StreamingReader>> {
     auto read_options = ReadOptions::Defaults();
     read_options.block_size = 1 << 10;

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -746,7 +746,7 @@ Status WriteCSV(const std::shared_ptr<RecordBatchReader>& reader,
 
 ARROW_EXPORT
 Result<std::shared_ptr<ipc::RecordBatchWriter>> MakeCSVWriter(
-    std::shared_ptr<io::OutputStream> sink, const std::shared_ptr<Schema>& schema,
+    const std::shared_ptr<io::OutputStream>& sink, const std::shared_ptr<Schema>& schema,
     const WriteOptions& options) {
   return CSVWriterImpl::Make(sink.get(), sink, schema, options);
 }

--- a/cpp/src/arrow/csv/writer.h
+++ b/cpp/src/arrow/csv/writer.h
@@ -70,7 +70,7 @@ ARROW_EXPORT Status WriteCSV(const std::shared_ptr<RecordBatchReader>& reader,
 /// \return Result<std::shared_ptr<RecordBatchWriter>>
 ARROW_EXPORT
 Result<std::shared_ptr<ipc::RecordBatchWriter>> MakeCSVWriter(
-    std::shared_ptr<io::OutputStream> sink, const std::shared_ptr<Schema>& schema,
+    const std::shared_ptr<io::OutputStream>& sink, const std::shared_ptr<Schema>& schema,
     const WriteOptions& options = WriteOptions::Defaults());
 
 /// \brief Create a new CSV writer.

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -43,7 +43,7 @@ inline Result<FragmentIterator> GetFragmentsFromDatasets(const DatasetVector& da
   auto datasets_it = MakeVectorIterator(datasets);
 
   // Dataset -> Iterator<Fragment>
-  auto fn = [predicate](std::shared_ptr<Dataset> dataset) -> Result<FragmentIterator> {
+  auto fn = [predicate](const std::shared_ptr<Dataset>& dataset) -> Result<FragmentIterator> {
     return dataset->GetFragments(predicate);
   };
 

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -599,7 +599,7 @@ class TestSchemaUnification : public TestUnionDataset {
   }
 
   template <typename TupleType>
-  void AssertScanEquals(std::shared_ptr<Scanner> scanner,
+  void AssertScanEquals(const std::shared_ptr<Scanner>& scanner,
                         const std::vector<TupleType>& expected_rows) {
     std::vector<std::string> columns;
     for (const auto& field : scanner->options()->projected_schema->fields()) {
@@ -614,7 +614,7 @@ class TestSchemaUnification : public TestUnionDataset {
   }
 
   template <typename TupleType>
-  void AssertBuilderEquals(std::shared_ptr<ScannerBuilder> builder,
+  void AssertBuilderEquals(const std::shared_ptr<ScannerBuilder>& builder,
                            const std::vector<TupleType>& expected_rows) {
     ASSERT_OK_AND_ASSIGN(auto scanner, builder->Finish());
     AssertScanEquals(scanner, expected_rows);

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -70,7 +70,7 @@ Result<std::shared_ptr<Dataset>> DatasetFactory::Finish() {
   return Finish(options);
 }
 
-Result<std::shared_ptr<Dataset>> DatasetFactory::Finish(std::shared_ptr<Schema> schema) {
+Result<std::shared_ptr<Dataset>> DatasetFactory::Finish(const std::shared_ptr<Schema>& schema) {
   FinishOptions options;
   options.schema = schema;
   return Finish(std::move(options));

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -94,7 +94,7 @@ class ARROW_DS_EXPORT DatasetFactory {
   /// \brief Create a Dataset
   Result<std::shared_ptr<Dataset>> Finish();
   /// \brief Create a Dataset with the given schema (see \a InspectOptions::schema)
-  Result<std::shared_ptr<Dataset>> Finish(std::shared_ptr<Schema> schema);
+  Result<std::shared_ptr<Dataset>> Finish(const std::shared_ptr<Schema>& schema);
   /// \brief Create a Dataset with the given options
   virtual Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) = 0;
 

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -45,7 +45,7 @@ void AssertSchemasAre(std::vector<std::shared_ptr<Schema>> actual,
 
 class DatasetFactoryTest : public TestFileSystemDataset {
  public:
-  void AssertInspect(std::shared_ptr<Schema> expected, InspectOptions options = {}) {
+  void AssertInspect(const std::shared_ptr<Schema>& expected, InspectOptions options = {}) {
     ASSERT_OK_AND_ASSIGN(auto actual, factory_->Inspect(options));
     EXPECT_EQ(*actual, *expected);
   }
@@ -137,7 +137,7 @@ class FileSystemDatasetFactoryTest : public DatasetFactoryTest {
   }
 
   void AssertFinishWithPaths(std::vector<std::string> paths,
-                             std::shared_ptr<Schema> schema = nullptr,
+                             const std::shared_ptr<Schema>& schema = nullptr,
                              InspectOptions options = {}) {
     if (schema == nullptr) {
       ASSERT_OK_AND_ASSIGN(schema, factory_->Inspect(options));

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -59,7 +59,7 @@ using internal::checked_pointer_cast;
 
 namespace dataset {
 
-FileSource::FileSource(std::shared_ptr<io::RandomAccessFile> file,
+FileSource::FileSource(const std::shared_ptr<io::RandomAccessFile>& file,
                        Compression::type compression)
     : custom_open_([=] { return ToResult(file); }),
       custom_size_(-1),
@@ -439,7 +439,7 @@ class DatasetWritingSinkNodeConsumer : public acero::SinkNodeConsumer {
   }
 
  private:
-  Status WriteNextBatch(std::shared_ptr<RecordBatch> batch,
+  Status WriteNextBatch(const std::shared_ptr<RecordBatch>& batch,
                         compute::Expression guarantee) {
     return WriteBatch(batch, guarantee, write_options_,
                       [this](std::shared_ptr<RecordBatch> next_batch,
@@ -461,7 +461,7 @@ class DatasetWritingSinkNodeConsumer : public acero::SinkNodeConsumer {
 }  // namespace
 
 Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_options,
-                                std::shared_ptr<Scanner> scanner) {
+                                const std::shared_ptr<Scanner>& scanner) {
   auto exprs = scanner->options()->projection.call()->arguments;
   auto names = checked_cast<const compute::MakeStructOptions*>(
                    scanner->options()->projection.call()->options.get())
@@ -629,10 +629,10 @@ class TeeNode : public acero::MapNode,
     return batch;
   }
 
-  Status WriteNextBatch(std::shared_ptr<RecordBatch> batch,
+  Status WriteNextBatch(const std::shared_ptr<RecordBatch>& batch,
                         compute::Expression guarantee) {
     return WriteBatch(batch, guarantee, write_options_,
-                      [this](std::shared_ptr<RecordBatch> next_batch,
+                      [this](const std::shared_ptr<RecordBatch>& next_batch,
                              const PartitionPathFormat& destination) {
                         dataset_writer_->WriteRecordBatch(
                             next_batch, destination.directory, destination.filename);

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -77,13 +77,13 @@ class ARROW_DS_EXPORT FileSource : public util::EqualityComparable<FileSource> {
         custom_size_(size),
         compression_(compression) {}
 
-  FileSource(std::shared_ptr<io::RandomAccessFile> file, int64_t size,
+  FileSource(const std::shared_ptr<io::RandomAccessFile>& file, int64_t size,
              Compression::type compression = Compression::UNCOMPRESSED)
       : custom_open_([=] { return ToResult(file); }),
         custom_size_(size),
         compression_(compression) {}
 
-  explicit FileSource(std::shared_ptr<io::RandomAccessFile> file,
+  explicit FileSource(const std::shared_ptr<io::RandomAccessFile>& file,
                       Compression::type compression = Compression::UNCOMPRESSED);
 
   FileSource() : custom_open_(CustomOpen{&InvalidOpen}) {}
@@ -283,7 +283,7 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
 
   /// \brief Write a dataset.
   static Status Write(const FileSystemDatasetWriteOptions& write_options,
-                      std::shared_ptr<Scanner> scanner);
+                      const std::shared_ptr<Scanner>& scanner);
 
   /// \brief Return the type name of the dataset.
   std::string type_name() const override { return "filesystem"; }

--- a/cpp/src/arrow/dataset/file_benchmark.cc
+++ b/cpp/src/arrow/dataset/file_benchmark.cc
@@ -63,7 +63,7 @@ static void GetAllFragments(benchmark::State& state) {
   auto dataset = GetDataset();
   for (auto _ : state) {
     ASSERT_OK_AND_ASSIGN(auto fragments, dataset.dataset->GetFragments());
-    ABORT_NOT_OK(fragments.Visit([](std::shared_ptr<Fragment>) { return Status::OK(); }));
+    ABORT_NOT_OK(fragments.Visit([](const std::shared_ptr<Fragment>&) { return Status::OK(); }));
   }
   state.SetItemsProcessed(state.iterations() * dataset.num_fragments);
   state.counters["num_fragments"] = static_cast<double>(dataset.num_fragments);
@@ -76,7 +76,7 @@ static void GetFilteredFragments(benchmark::State& state, compute::Expression fi
   for (auto _ : state) {
     num_filtered_fragments = 0;
     ASSERT_OK_AND_ASSIGN(auto fragments, dataset.dataset->GetFragments(filter));
-    ABORT_NOT_OK(fragments.Visit([&](std::shared_ptr<Fragment>) {
+    ABORT_NOT_OK(fragments.Visit([&](const std::shared_ptr<Fragment>&) {
       ++num_filtered_fragments;
       return Status::OK();
     }));

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -143,7 +143,7 @@ Result<RecordBatchGenerator> IpcFileFormat::ScanBatchesAsync(
   auto source = file->source();
   auto open_reader = OpenReaderAsync(source);
   auto reopen_reader = [self, options,
-                        source](std::shared_ptr<ipc::RecordBatchFileReader> reader)
+                        source](const std::shared_ptr<ipc::RecordBatchFileReader>& reader)
       -> Future<std::shared_ptr<ipc::RecordBatchFileReader>> {
     ARROW_ASSIGN_OR_RAISE(auto options,
                           GetReadOptions(*reader->schema(), *self, *options));

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -66,7 +66,7 @@ namespace {
 
 parquet::ReaderProperties MakeReaderProperties(
     const ParquetFileFormat& format, ParquetFragmentScanOptions* parquet_scan_options,
-    const std::string& path = "", std::shared_ptr<fs::FileSystem> filesystem = nullptr,
+    const std::string& path = "", const std::shared_ptr<fs::FileSystem>& filesystem = nullptr,
     MemoryPool* pool = default_memory_pool()) {
   // Can't mutate pool after construction
   parquet::ReaderProperties properties(pool);
@@ -1064,7 +1064,7 @@ Result<std::shared_ptr<Schema>> GetSchema(
 }  // namespace
 
 Result<std::shared_ptr<DatasetFactory>> ParquetDatasetFactory::Make(
-    const std::string& metadata_path, std::shared_ptr<fs::FileSystem> filesystem,
+    const std::string& metadata_path, const std::shared_ptr<fs::FileSystem>& filesystem,
     std::shared_ptr<ParquetFileFormat> format, ParquetFactoryOptions options) {
   // Paths in ColumnChunk are relative to the `_metadata` file. Thus, the base
   // directory of all parquet files is `dirname(metadata_path)`.

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -346,7 +346,7 @@ class ARROW_DS_EXPORT ParquetDatasetFactory : public DatasetFactory {
   /// \param[in] format to read the file with.
   /// \param[in] options see ParquetFactoryOptions
   static Result<std::shared_ptr<DatasetFactory>> Make(
-      const std::string& metadata_path, std::shared_ptr<fs::FileSystem> filesystem,
+      const std::string& metadata_path, const std::shared_ptr<fs::FileSystem>& filesystem,
       std::shared_ptr<ParquetFileFormat> format, ParquetFactoryOptions options);
 
   /// \brief Create a ParquetDatasetFactory from a metadata source.

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -115,7 +115,7 @@ class ParquetFormatHelper {
     }
 
     return MakeFunctionIterator([reader] { return reader->Next(); })
-        .Visit([&](std::shared_ptr<RecordBatch> batch) {
+        .Visit([&](const std::shared_ptr<RecordBatch>& batch) {
           return WriteRecordBatch(*batch, writer);
         });
   }
@@ -537,13 +537,13 @@ TEST_F(TestParquetFileSystemDataset, WriteWithEncryptionConfigNotSupported) {
 
 class TestParquetFileFormatScan : public FileFormatScanMixin<ParquetFormatHelper> {
  public:
-  std::shared_ptr<RecordBatch> SingleBatch(std::shared_ptr<Fragment> fragment) {
+  std::shared_ptr<RecordBatch> SingleBatch(const std::shared_ptr<Fragment>& fragment) {
     auto batches = IteratorToVector(PhysicalBatches(fragment));
     EXPECT_EQ(batches.size(), 1);
     return batches.front();
   }
 
-  void CountRowsAndBatchesInScan(std::shared_ptr<Fragment> fragment,
+  void CountRowsAndBatchesInScan(const std::shared_ptr<Fragment>& fragment,
                                  int64_t expected_rows, int64_t expected_batches) {
     int64_t actual_rows = 0;
     int64_t actual_batches = 0;
@@ -767,7 +767,7 @@ TEST_P(TestParquetFileFormatScan, ExplicitRowGroupSelection) {
   // select all row groups
   EXPECT_OK_AND_ASSIGN(auto all_row_groups_fragment,
                        format_->MakeFragment(*source, literal(true))
-                           .Map([](std::shared_ptr<FileFragment> f) {
+                           .Map([](const std::shared_ptr<FileFragment>& f) {
                              return checked_pointer_cast<ParquetFileFragment>(f);
                            }));
 

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -90,8 +90,8 @@ class TestPartitioning : public ::testing::Test {
     ASSERT_OK_AND_ASSIGN(partitioning_, factory_->Finish(actual));
   }
 
-  void AssertPartition(const std::shared_ptr<Partitioning> partitioning,
-                       const std::shared_ptr<RecordBatch> full_batch,
+  void AssertPartition(const std::shared_ptr<Partitioning>& partitioning,
+                       const std::shared_ptr<RecordBatch>& full_batch,
                        const RecordBatchVector& expected_batches,
                        const std::vector<compute::Expression>& expected_expressions) {
     ASSERT_OK_AND_ASSIGN(auto partition_results, partitioning->Partition(full_batch));
@@ -116,10 +116,10 @@ class TestPartitioning : public ::testing::Test {
     }
   }
 
-  void AssertPartition(const std::shared_ptr<Partitioning> partitioning,
-                       const std::shared_ptr<Schema> schema,
+  void AssertPartition(const std::shared_ptr<Partitioning>& partitioning,
+                       const std::shared_ptr<Schema>& schema,
                        const std::string& record_batch_json,
-                       const std::shared_ptr<Schema> partitioned_schema,
+                       const std::shared_ptr<Schema>& partitioned_schema,
                        const std::vector<std::string>& expected_record_batch_strs,
                        const std::vector<compute::Expression>& expected_expressions) {
     auto record_batch = RecordBatchFromJSON(schema, record_batch_json);

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -900,7 +900,7 @@ ScannerBuilder::ScannerBuilder(std::shared_ptr<Schema> schema,
                      std::move(scan_options)) {}
 
 std::shared_ptr<ScannerBuilder> ScannerBuilder::FromRecordBatchReader(
-    std::shared_ptr<RecordBatchReader> reader) {
+    const std::shared_ptr<RecordBatchReader>& reader) {
   auto batch_it = MakeIteratorFromReader(reader);
   auto fragment =
       std::make_shared<OneShotFragment>(reader->schema(), std::move(batch_it));

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -489,7 +489,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// to support writing data from streaming sources or other sources
   /// that can be iterated only once.
   static std::shared_ptr<ScannerBuilder> FromRecordBatchReader(
-      std::shared_ptr<RecordBatchReader> reader);
+      const std::shared_ptr<RecordBatchReader>& reader);
 
   /// \brief Set the subset of columns to materialize.
   ///

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -528,7 +528,7 @@ class TestScannerBase : public ::testing::TestWithParam<ScannerTestParams> {
     return as_one_batch;
   }
 
-  acero::Declaration MakeScanNode(std::shared_ptr<Dataset> dataset) {
+  acero::Declaration MakeScanNode(const std::shared_ptr<Dataset>& dataset) {
     ScanV2Options options(dataset);
     options.columns = ScanV2Options::AllColumns(*dataset->schema());
     return acero::Declaration("scan2", options);
@@ -582,7 +582,7 @@ INSTANTIATE_TEST_SUITE_P(BasicNewScannerTests, TestScannerBase,
                            return std::to_string(info.index) + info.param.ToString();
                          });
 
-void CheckScannerBackpressure(std::shared_ptr<MockDataset> dataset, ScanV2Options options,
+void CheckScannerBackpressure(const std::shared_ptr<MockDataset>& dataset, ScanV2Options options,
                               int maxConcurrentFragments, int maxConcurrentBatches,
                               ::arrow::internal::ThreadPool* thread_pool) {
   // Start scanning
@@ -878,8 +878,8 @@ TEST(TestNewScanner, MissingColumn) {
 }
 
 void WriteIpcData(const std::string& path,
-                  const std::shared_ptr<fs::FileSystem> file_system,
-                  const std::shared_ptr<Table> input) {
+                  const std::shared_ptr<fs::FileSystem>& file_system,
+                  const std::shared_ptr<Table>& input) {
   EXPECT_OK_AND_ASSIGN(auto out_stream, file_system->OpenOutputStream(path));
   ASSERT_OK_AND_ASSIGN(
       auto file_writer,
@@ -949,7 +949,7 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
     return scanner;
   }
 
-  std::shared_ptr<Scanner> MakeScanner(std::shared_ptr<RecordBatch> batch) {
+  std::shared_ptr<Scanner> MakeScanner(const std::shared_ptr<RecordBatch>& batch) {
     RecordBatchVector batches{static_cast<size_t>(GetParam().num_batches), batch};
 
     DatasetVector children{static_cast<size_t>(GetParam().num_child_datasets),
@@ -960,7 +960,7 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
   }
 
   void AssertScannerEqualsRepetitionsOf(
-      std::shared_ptr<Scanner> scanner, std::shared_ptr<RecordBatch> batch,
+      const std::shared_ptr<Scanner>& scanner, const std::shared_ptr<RecordBatch>& batch,
       const int64_t total_batches = GetParam().num_child_datasets *
                                     GetParam().num_batches) {
     auto expected = ConstantArrayGenerator::Repeat(total_batches, batch);
@@ -971,7 +971,7 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
   }
 
   void AssertScanBatchesEqualRepetitionsOf(
-      std::shared_ptr<Scanner> scanner, std::shared_ptr<RecordBatch> batch,
+      const std::shared_ptr<Scanner>& scanner, const std::shared_ptr<RecordBatch>& batch,
       const int64_t total_batches = GetParam().num_child_datasets *
                                     GetParam().num_batches) {
     auto expected = ConstantArrayGenerator::Repeat(total_batches, batch);
@@ -979,7 +979,7 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
     AssertScanBatchesEquals(expected.get(), scanner.get());
   }
 
-  void AssertNoAugmentedFields(std::shared_ptr<Scanner> scanner) {
+  void AssertNoAugmentedFields(const std::shared_ptr<Scanner>& scanner) {
     ASSERT_OK_AND_ASSIGN(auto table, scanner.get()->ToTable());
     auto columns = table.get()->ColumnNames();
     EXPECT_TRUE(std::none_of(columns.begin(), columns.end(), [](std::string& x) {
@@ -989,7 +989,7 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
   }
 
   void AssertScanBatchesUnorderedEqualRepetitionsOf(
-      std::shared_ptr<Scanner> scanner, std::shared_ptr<RecordBatch> batch,
+      const std::shared_ptr<Scanner>& scanner, const std::shared_ptr<RecordBatch>& batch,
       const int64_t total_batches = GetParam().num_child_datasets *
                                     GetParam().num_batches) {
     auto expected = ConstantArrayGenerator::Repeat(total_batches, batch);

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -145,8 +145,8 @@ using compute::project;
 using fs::internal::GetAbstractPathExtension;
 
 /// \brief Assert a dataset produces data with the schema
-inline void AssertDatasetHasSchema(std::shared_ptr<Dataset> ds,
-                                   std::shared_ptr<Schema> schema) {
+inline void AssertDatasetHasSchema(const std::shared_ptr<Dataset>& ds,
+                                   const std::shared_ptr<Schema>& schema) {
   ASSERT_OK_AND_ASSIGN(auto scanner_builder, ds->NewScan());
   ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
   ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
@@ -177,12 +177,12 @@ class GeneratedRecordBatch : public RecordBatchReader {
 
 template <typename Gen>
 std::unique_ptr<GeneratedRecordBatch<Gen>> MakeGeneratedRecordBatch(
-    std::shared_ptr<Schema> schema, Gen&& gen) {
+    const std::shared_ptr<Schema>& schema, Gen&& gen) {
   return std::make_unique<GeneratedRecordBatch<Gen>>(schema, std::forward<Gen>(gen));
 }
 
 inline std::unique_ptr<RecordBatchReader> MakeGeneratedRecordBatch(
-    std::shared_ptr<Schema> schema, int64_t batch_size, int64_t batch_repetitions) {
+    const std::shared_ptr<Schema>& schema, int64_t batch_size, int64_t batch_repetitions) {
   auto batch = random::GenerateBatch(schema->fields(), batch_size, /*seed=*/0);
   int64_t i = 0;
   return MakeGeneratedRecordBatch(
@@ -204,7 +204,7 @@ class DatasetFixtureMixin : public ::testing::Test {
   void AssertScanTaskEquals(RecordBatchReader* expected, RecordBatchGenerator batch_gen,
                             bool ensure_drained = true) {
     ASSERT_FINISHES_OK(VisitAsyncGenerator(
-        batch_gen, [expected](std::shared_ptr<RecordBatch> rhs) -> Status {
+        batch_gen, [expected](const std::shared_ptr<RecordBatch>& rhs) -> Status {
           std::shared_ptr<RecordBatch> lhs;
           RETURN_NOT_OK(expected->ReadNext(&lhs));
           EXPECT_NE(lhs, nullptr);
@@ -244,7 +244,7 @@ class DatasetFixtureMixin : public ::testing::Test {
     ASSERT_OK_AND_ASSIGN(auto predicate, options_->filter.Bind(*dataset->schema()));
     ASSERT_OK_AND_ASSIGN(auto it, dataset->GetFragments(predicate));
 
-    ARROW_EXPECT_OK(it.Visit([&](std::shared_ptr<Fragment> fragment) -> Status {
+    ARROW_EXPECT_OK(it.Visit([&](const std::shared_ptr<Fragment>& fragment) -> Status {
       AssertFragmentEquals(expected, fragment.get(), false);
       return Status::OK();
     }));
@@ -598,7 +598,7 @@ class FileFormatFixtureMixin : public ::testing::Test {
     EXPECT_EQ(supported, true);
   }
   std::shared_ptr<Buffer> WriteToBuffer(
-      std::shared_ptr<Schema> schema,
+      const std::shared_ptr<Schema>& schema,
       std::shared_ptr<FileWriteOptions> options = nullptr) {
     auto format = format_;
     SetSchema(schema->fields());
@@ -683,7 +683,7 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<FormatHelper>,
   }
 
   // Scan the fragment through the scanner.
-  RecordBatchIterator Batches(std::shared_ptr<Fragment> fragment,
+  RecordBatchIterator Batches(const std::shared_ptr<Fragment>& fragment,
                               bool use_readahead = true) {
     auto dataset = std::make_shared<FragmentDataset>(opts_->dataset_schema,
                                                      FragmentVector{fragment});
@@ -700,7 +700,7 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<FormatHelper>,
   }
 
   // Scan the fragment directly, without using the scanner.
-  RecordBatchIterator PhysicalBatches(std::shared_ptr<Fragment> fragment) {
+  RecordBatchIterator PhysicalBatches(const std::shared_ptr<Fragment>& fragment) {
     opts_->use_threads = GetParam().use_threads;
     EXPECT_OK_AND_ASSIGN(auto batch_gen, fragment->ScanBatchesAsync(opts_));
     auto batch_it = MakeGeneratorIterator(std::move(batch_gen));
@@ -1170,7 +1170,7 @@ class FileFormatFixtureMixinV2 : public ::testing::Test {
   }
 
   std::shared_ptr<Buffer> WriteToBuffer(
-      std::shared_ptr<Schema> schema,
+      const std::shared_ptr<Schema>& schema,
       std::shared_ptr<FileWriteOptions> options = nullptr) {
     auto format = format_;
     SetDatasetSchema(schema->fields());
@@ -1260,7 +1260,7 @@ class FileFormatScanNodeMixin : public FileFormatFixtureMixinV2<FormatHelper>,
   }
 
   // Scan the fragment through the scanner.
-  Result<std::unique_ptr<RecordBatchReader>> Scan(std::shared_ptr<Fragment> fragment,
+  Result<std::unique_ptr<RecordBatchReader>> Scan(const std::shared_ptr<Fragment>& fragment,
                                                   bool add_filter_fields = true) {
     opts_->dataset =
         std::make_shared<FragmentDataset>(dataset_schema_, FragmentVector{fragment});
@@ -1774,7 +1774,7 @@ static std::vector<compute::Expression> PartitionExpressionsOf(
 }
 
 inline void AssertFragmentsHavePartitionExpressions(
-    std::shared_ptr<Dataset> dataset, std::vector<compute::Expression> expected) {
+    const std::shared_ptr<Dataset>& dataset, std::vector<compute::Expression> expected) {
   ASSERT_OK_AND_ASSIGN(auto fragment_it, dataset->GetFragments());
   // Ordering is not guaranteed.
   EXPECT_THAT(PartitionExpressionsOf(IteratorToVector(std::move(fragment_it))),
@@ -1932,7 +1932,7 @@ class WriteFileSystemDatasetMixin : public MakeFileSystemDatasetMixin {
     SetProjection(scan_options_.get(), std::move(projection));
   }
 
-  void SetWriteOptions(std::shared_ptr<FileWriteOptions> file_write_options) {
+  void SetWriteOptions(const std::shared_ptr<FileWriteOptions>& file_write_options) {
     write_options_.file_write_options = file_write_options;
     write_options_.filesystem = fs_;
     write_options_.base_dir = "/new_root/";
@@ -1943,7 +1943,7 @@ class WriteFileSystemDatasetMixin : public MakeFileSystemDatasetMixin {
     };
   }
 
-  void DoWrite(std::shared_ptr<Partitioning> desired_partitioning) {
+  void DoWrite(const std::shared_ptr<Partitioning>& desired_partitioning) {
     write_options_.partitioning = desired_partitioning;
     auto scanner_builder = ScannerBuilder(dataset_, scan_options_);
     ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder.Finish());

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -257,7 +257,7 @@ ConfigurableSingleton<NamedTapProvider>& default_named_tap_provider_singleton() 
   static ConfigurableSingleton<NamedTapProvider> singleton(
       [](const std::string& tap_kind, std::vector<acero::Declaration::Input> inputs,
          const std::string& tap_name,
-         std::shared_ptr<Schema> tap_schema) -> Result<acero::Declaration> {
+         const std::shared_ptr<Schema>& tap_schema) -> Result<acero::Declaration> {
         return Status::NotImplemented(
             "Plan contained a NamedTapRel but no provider configured");
       });

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -302,7 +302,7 @@ namespace internal {
 Result<compute::Aggregate> ParseAggregateMeasure(
     const substrait::AggregateRel::Measure& agg_measure, const ExtensionSet& ext_set,
     const ConversionOptions& conversion_options, bool is_hash,
-    const std::shared_ptr<Schema> input_schema) {
+    const std::shared_ptr<Schema>& input_schema) {
   if (agg_measure.has_measure()) {
     if (agg_measure.has_filter()) {
       return Status::NotImplemented("Aggregate filters are not supported.");
@@ -326,7 +326,7 @@ Result<compute::Aggregate> ParseAggregateMeasure(
 }
 
 ARROW_ENGINE_EXPORT Result<DeclarationInfo> MakeAggregateDeclaration(
-    acero::Declaration input_decl, std::shared_ptr<Schema> aggregate_schema,
+    acero::Declaration input_decl, const std::shared_ptr<Schema>& aggregate_schema,
     std::vector<compute::Aggregate> aggregates, std::vector<FieldRef> keys,
     std::vector<FieldRef> segment_keys) {
   return DeclarationInfo{

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -65,7 +65,7 @@ ARROW_ENGINE_EXPORT
 Result<compute::Aggregate> ParseAggregateMeasure(
     const substrait::AggregateRel::Measure& agg_measure, const ExtensionSet& ext_set,
     const ConversionOptions& conversion_options, bool is_hash,
-    const std::shared_ptr<Schema> input_schema);
+    const std::shared_ptr<Schema>& input_schema);
 
 /// \brief Make an aggregate declaration info
 ///
@@ -75,7 +75,7 @@ Result<compute::Aggregate> ParseAggregateMeasure(
 /// \param[in] keys the field-refs for grouping keys to use
 /// \param[in] segment_keys the field-refs for segment keys to use
 ARROW_ENGINE_EXPORT Result<DeclarationInfo> MakeAggregateDeclaration(
-    acero::Declaration input_decl, std::shared_ptr<Schema> output_schema,
+    acero::Declaration input_decl, const std::shared_ptr<Schema>& output_schema,
     std::vector<compute::Aggregate> aggregates, std::vector<FieldRef> keys,
     std::vector<FieldRef> segment_keys);
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -106,7 +106,7 @@ Status AddPassFactory(
     }
 
     PassNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-             std::shared_ptr<Schema> output_schema)
+             const std::shared_ptr<Schema>& output_schema)
         : MapNode(plan, inputs, output_schema) {}
 
     const char* kind_name() const override { return "PassNode"; }
@@ -118,8 +118,8 @@ Status AddPassFactory(
 const auto kNullConsumer = std::make_shared<acero::NullSinkNodeConsumer>();
 
 void WriteIpcData(const std::string& path,
-                  const std::shared_ptr<fs::FileSystem> file_system,
-                  const std::shared_ptr<Table> input) {
+                  const std::shared_ptr<fs::FileSystem>& file_system,
+                  const std::shared_ptr<Table>& input) {
   EXPECT_OK_AND_ASSIGN(auto out_stream, file_system->OpenOutputStream(path));
   ASSERT_OK_AND_ASSIGN(
       auto file_writer,
@@ -128,7 +128,7 @@ void WriteIpcData(const std::string& path,
   ASSERT_OK(file_writer->Close());
 }
 
-void CheckRoundTripResult(const std::shared_ptr<Table> expected_table,
+void CheckRoundTripResult(const std::shared_ptr<Table>& expected_table,
                           std::shared_ptr<Buffer>& buf,
                           const std::vector<int>& include_columns = {},
                           const ConversionOptions& conversion_options = {},
@@ -233,7 +233,7 @@ void ValidateNumProjectNodes(int expected_projections, const std::shared_ptr<Buf
 }
 
 TEST(Substrait, SupportedTypes) {
-  auto ExpectEq = [](std::string_view json, std::shared_ptr<DataType> expected_type) {
+  auto ExpectEq = [](std::string_view json, const std::shared_ptr<DataType>& expected_type) {
     ARROW_SCOPED_TRACE(json);
 
     ExtensionSet empty;
@@ -6142,7 +6142,7 @@ TEST(Substrait, PlanWithNamedTapExtension) {
   conversion_options.named_tap_provider =
       [](const std::string& tap_kind, std::vector<acero::Declaration::Input> inputs,
          const std::string& tap_name,
-         std::shared_ptr<Schema> tap_schema) -> Result<acero::Declaration> {
+         const std::shared_ptr<Schema>& tap_schema) -> Result<acero::Declaration> {
     return acero::Declaration{tap_kind, std::move(inputs), acero::ExecNodeOptions{}};
   };
 
@@ -6269,7 +6269,7 @@ TEST(Substrait, PlanWithSegmentedAggregateExtension) {
   conversion_options.named_tap_provider =
       [](const std::string& tap_kind, std::vector<acero::Declaration::Input> inputs,
          const std::string& tap_name,
-         std::shared_ptr<Schema> tap_schema) -> Result<acero::Declaration> {
+         const std::shared_ptr<Schema>& tap_schema) -> Result<acero::Declaration> {
     return acero::Declaration{tap_kind, std::move(inputs), acero::ExecNodeOptions{}};
   };
 

--- a/cpp/src/arrow/extension/parquet_variant.cc
+++ b/cpp/src/arrow/extension/parquet_variant.cc
@@ -63,7 +63,7 @@ std::shared_ptr<Array> VariantExtensionType::MakeArray(
 }
 
 namespace {
-bool IsBinaryField(const std::shared_ptr<Field> field) {
+bool IsBinaryField(const std::shared_ptr<Field>& field) {
   return field->type()->storage_id() == Type::BINARY ||
          field->type()->storage_id() == Type::LARGE_BINARY;
 }

--- a/cpp/src/arrow/extension/tensor_extension_array_test.cc
+++ b/cpp/src/arrow/extension/tensor_extension_array_test.cc
@@ -385,7 +385,7 @@ TEST_F(TestFixedShapeTensorType, CreateFromTensor) {
 }
 
 void CheckFromTensorType(const std::shared_ptr<Tensor>& tensor,
-                         std::shared_ptr<DataType> expected_ext_type) {
+                         const std::shared_ptr<DataType>& expected_ext_type) {
   auto ext_type = internal::checked_pointer_cast<FixedShapeTensorType>(expected_ext_type);
   ASSERT_OK_AND_ASSIGN(auto ext_arr, FixedShapeTensorArray::FromTensor(tensor));
   auto generated_ext_type =
@@ -426,7 +426,7 @@ TEST_F(TestFixedShapeTensorType, TestFromTensorType) {
 }
 
 template <typename T>
-void CheckToTensor(const std::vector<T>& values, const std::shared_ptr<DataType> typ,
+void CheckToTensor(const std::vector<T>& values, const std::shared_ptr<DataType>& typ,
                    const int32_t& element_size, const std::vector<int64_t>& element_shape,
                    const std::vector<int64_t>& element_permutation,
                    const std::vector<std::string>& element_dim_names,

--- a/cpp/src/arrow/extension_type.cc
+++ b/cpp/src/arrow/extension_type.cc
@@ -172,7 +172,7 @@ std::shared_ptr<ExtensionTypeRegistry> ExtensionTypeRegistry::GetGlobalRegistry(
   return g_registry;
 }
 
-Status RegisterExtensionType(std::shared_ptr<ExtensionType> type) {
+Status RegisterExtensionType(const std::shared_ptr<ExtensionType>& type) {
   auto registry = ExtensionTypeRegistry::GetGlobalRegistry();
   return registry->RegisterType(type);
 }

--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -147,7 +147,7 @@ class ARROW_EXPORT ExtensionTypeRegistry {
 /// \param[in] type an instance of the extension type
 /// \return Status
 ARROW_EXPORT
-Status RegisterExtensionType(std::shared_ptr<ExtensionType> type);
+Status RegisterExtensionType(const std::shared_ptr<ExtensionType>& type);
 
 /// \brief Delete an extension type from the global registry. This method is
 /// thread-safe

--- a/cpp/src/arrow/extension_type_test.cc
+++ b/cpp/src/arrow/extension_type_test.cc
@@ -259,7 +259,7 @@ TEST_F(TestExtensionType, UnrecognizedExtension) {
   CompareBatch(*batch_no_ext, *read_batch);
 }
 
-std::shared_ptr<Array> ExampleParametric(std::shared_ptr<DataType> type,
+std::shared_ptr<Array> ExampleParametric(const std::shared_ptr<DataType>& type,
                                          const std::string& json_data) {
   auto arr = ArrayFromJSON(int32(), json_data);
   auto ext_data = arr->data()->Copy();

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -965,7 +965,7 @@ Status CreateEmptyBlockBlob(const Blobs::BlockBlobClient& block_blob_client) {
 }
 
 Result<Blobs::Models::GetBlockListResult> GetBlockList(
-    std::shared_ptr<Blobs::BlockBlobClient> block_blob_client) {
+    const std::shared_ptr<Blobs::BlockBlobClient>& block_blob_client) {
   try {
     return block_blob_client->GetBlockList().Value;
   } catch (Core::RequestFailedException& exception) {
@@ -975,7 +975,7 @@ Result<Blobs::Models::GetBlockListResult> GetBlockList(
   }
 }
 
-Status CommitBlockList(std::shared_ptr<Storage::Blobs::BlockBlobClient> block_blob_client,
+Status CommitBlockList(const std::shared_ptr<Storage::Blobs::BlockBlobClient>& block_blob_client,
                        const std::vector<std::string>& block_ids,
                        const Blobs::CommitBlockListOptions& options) {
   try {
@@ -1230,7 +1230,7 @@ class ObjectAppendStream final : public io::OutputStream {
   }
 
   Status DoWrite(const void* data, int64_t nbytes,
-                 std::shared_ptr<Buffer> owned_buffer = nullptr) {
+                 const std::shared_ptr<Buffer>& owned_buffer = nullptr) {
     if (closed_) {
       return Status::Invalid("Operation on closed stream");
     }
@@ -1324,7 +1324,7 @@ class ObjectAppendStream final : public io::OutputStream {
   }
 
   Status AppendBlock(const void* data, int64_t nbytes,
-                     std::shared_ptr<Buffer> owned_buffer = nullptr) {
+                     const std::shared_ptr<Buffer>& owned_buffer = nullptr) {
     RETURN_NOT_OK(CheckClosed("append"));
 
     if (nbytes == 0) {
@@ -1363,7 +1363,7 @@ class ObjectAppendStream final : public io::OutputStream {
     return Status::OK();
   }
 
-  Status AppendBlock(std::shared_ptr<Buffer> buffer) {
+  Status AppendBlock(const std::shared_ptr<Buffer>& buffer) {
     return AppendBlock(buffer->data(), buffer->size(), buffer);
   }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -2937,7 +2937,7 @@ TEST_F(TestAzuriteFileSystem, OpenInputStreamTrailingSlash) {
 
 namespace {
 std::shared_ptr<const KeyValueMetadata> NormalizerKeyValueMetadata(
-    std::shared_ptr<const KeyValueMetadata> metadata) {
+    const std::shared_ptr<const KeyValueMetadata>& metadata) {
   auto normalized = std::make_shared<KeyValueMetadata>();
   for (int64_t i = 0; i < metadata->size(); ++i) {
     auto key = metadata->key(i);

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -167,13 +167,13 @@ Future<std::vector<FileInfo>> FileSystem::GetFileInfoAsync(
     const std::vector<std::string>& paths) {
   return FileSystemDefer(
       this, default_async_is_sync_,
-      [paths](std::shared_ptr<FileSystem> self) { return self->GetFileInfo(paths); });
+      [paths](const std::shared_ptr<FileSystem>& self) { return self->GetFileInfo(paths); });
 }
 
 FileInfoGenerator FileSystem::GetFileInfoGenerator(const FileSelector& select) {
   auto fut = FileSystemDefer(
       this, default_async_is_sync_,
-      [select](std::shared_ptr<FileSystem> self) { return self->GetFileInfo(select); });
+      [select](const std::shared_ptr<FileSystem>& self) { return self->GetFileInfo(select); });
   return MakeSingleFutureGenerator(std::move(fut));
 }
 
@@ -202,7 +202,7 @@ Status ValidateInputFileInfo(const FileInfo& info) {
 Future<> FileSystem::DeleteDirContentsAsync(const std::string& path,
                                             bool missing_dir_ok) {
   return FileSystemDefer(this, default_async_is_sync_,
-                         [path, missing_dir_ok](std::shared_ptr<FileSystem> self) {
+                         [path, missing_dir_ok](const std::shared_ptr<FileSystem>& self) {
                            return self->DeleteDirContents(path, missing_dir_ok);
                          });
 }
@@ -227,7 +227,7 @@ Future<std::shared_ptr<io::InputStream>> FileSystem::OpenInputStreamAsync(
     const std::string& path) {
   return FileSystemDefer(
       this, default_async_is_sync_,
-      [path](std::shared_ptr<FileSystem> self) { return self->OpenInputStream(path); });
+      [path](const std::shared_ptr<FileSystem>& self) { return self->OpenInputStream(path); });
 }
 
 Future<std::shared_ptr<io::InputStream>> FileSystem::OpenInputStreamAsync(
@@ -235,14 +235,14 @@ Future<std::shared_ptr<io::InputStream>> FileSystem::OpenInputStreamAsync(
   RETURN_NOT_OK(ValidateInputFileInfo(info));
   return FileSystemDefer(
       this, default_async_is_sync_,
-      [info](std::shared_ptr<FileSystem> self) { return self->OpenInputStream(info); });
+      [info](const std::shared_ptr<FileSystem>& self) { return self->OpenInputStream(info); });
 }
 
 Future<std::shared_ptr<io::RandomAccessFile>> FileSystem::OpenInputFileAsync(
     const std::string& path) {
   return FileSystemDefer(
       this, default_async_is_sync_,
-      [path](std::shared_ptr<FileSystem> self) { return self->OpenInputFile(path); });
+      [path](const std::shared_ptr<FileSystem>& self) { return self->OpenInputFile(path); });
 }
 
 Future<std::shared_ptr<io::RandomAccessFile>> FileSystem::OpenInputFileAsync(
@@ -250,7 +250,7 @@ Future<std::shared_ptr<io::RandomAccessFile>> FileSystem::OpenInputFileAsync(
   RETURN_NOT_OK(ValidateInputFileInfo(info));
   return FileSystemDefer(
       this, default_async_is_sync_,
-      [info](std::shared_ptr<FileSystem> self) { return self->OpenInputFile(info); });
+      [info](const std::shared_ptr<FileSystem>& self) { return self->OpenInputFile(info); });
 }
 
 Result<std::shared_ptr<io::OutputStream>> FileSystem::OpenOutputStream(
@@ -287,7 +287,7 @@ Status ValidateSubPath(std::string_view s) {
 }  // namespace
 
 SubTreeFileSystem::SubTreeFileSystem(const std::string& base_path,
-                                     std::shared_ptr<FileSystem> base_fs)
+                                     const std::shared_ptr<FileSystem>& base_fs)
     : FileSystem(base_fs->io_context()),
       base_path_(NormalizeBasePath(base_path, base_fs).ValueOrDie()),
       base_fs_(base_fs) {}
@@ -515,13 +515,13 @@ SlowFileSystem::SlowFileSystem(std::shared_ptr<FileSystem> base_fs,
       base_fs_(std::move(base_fs)),
       latencies_(std::move(latencies)) {}
 
-SlowFileSystem::SlowFileSystem(std::shared_ptr<FileSystem> base_fs,
+SlowFileSystem::SlowFileSystem(const std::shared_ptr<FileSystem>& base_fs,
                                double average_latency)
     : FileSystem(base_fs->io_context()),
       base_fs_(base_fs),
       latencies_(io::LatencyGenerator::Make(average_latency)) {}
 
-SlowFileSystem::SlowFileSystem(std::shared_ptr<FileSystem> base_fs,
+SlowFileSystem::SlowFileSystem(const std::shared_ptr<FileSystem>& base_fs,
                                double average_latency, int32_t seed)
     : FileSystem(base_fs->io_context()),
       base_fs_(base_fs),

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -421,7 +421,7 @@ class ARROW_EXPORT SubTreeFileSystem : public FileSystem {
  public:
   // This constructor may abort if base_path is invalid.
   explicit SubTreeFileSystem(const std::string& base_path,
-                             std::shared_ptr<FileSystem> base_fs);
+                             const std::shared_ptr<FileSystem>& base_fs);
   ~SubTreeFileSystem() override;
 
   std::string type_name() const override { return "subtree"; }
@@ -503,8 +503,8 @@ class ARROW_EXPORT SlowFileSystem : public FileSystem {
  public:
   SlowFileSystem(std::shared_ptr<FileSystem> base_fs,
                  std::shared_ptr<io::LatencyGenerator> latencies);
-  SlowFileSystem(std::shared_ptr<FileSystem> base_fs, double average_latency);
-  SlowFileSystem(std::shared_ptr<FileSystem> base_fs, double average_latency,
+  SlowFileSystem(const std::shared_ptr<FileSystem>& base_fs, double average_latency);
+  SlowFileSystem(const std::shared_ptr<FileSystem>& base_fs, double average_latency,
                  int32_t seed);
 
   std::string type_name() const override { return "slow"; }

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -212,7 +212,7 @@ class GcsIntegrationTest : public ::testing::Test {
     std::vector<FileInfo> contents;
   };
 
-  Result<Hierarchy> CreateHierarchy(std::shared_ptr<arrow::fs::FileSystem> fs) {
+  Result<Hierarchy> CreateHierarchy(const std::shared_ptr<arrow::fs::FileSystem>& fs) {
     const char* const kTestFolders[] = {
         "b",
         "b/0",

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -520,7 +520,7 @@ class AsyncStatSelector {
   /// the producer is closed automatically.
   static Status DoDiscovery(const PlatformFilename& dir_fn, int32_t nesting_depth,
                             FileSelector selector,
-                            std::shared_ptr<DiscoveryState> discovery_state,
+                            const std::shared_ptr<DiscoveryState>& discovery_state,
                             const io::IOContext& io_context,
                             int32_t file_info_batch_size) {
     ARROW_RETURN_IF(discovery_state->producer.is_closed(),

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -93,7 +93,7 @@ struct ConcreteTypedOption : ExampleTypedOption {
 
 class SlowFileSystemPublicProps : public SlowFileSystem {
  public:
-  SlowFileSystemPublicProps(std::shared_ptr<FileSystem> base_fs, double average_latency,
+  SlowFileSystemPublicProps(const std::shared_ptr<FileSystem>& base_fs, double average_latency,
                             int32_t seed)
       : SlowFileSystem(base_fs, average_latency, seed),
         average_latency{average_latency},

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1887,7 +1887,7 @@ class ObjectOutputStream final : public io::OutputStream {
   }
 
   Status DoWrite(const void* data, int64_t nbytes,
-                 std::shared_ptr<Buffer> owned_buffer = nullptr) {
+                 const std::shared_ptr<Buffer>& owned_buffer = nullptr) {
     if (closed_) {
       return Status::Invalid("Operation on closed stream");
     }
@@ -2002,7 +2002,7 @@ class ObjectOutputStream final : public io::OutputStream {
       RequestType&& req,
       UploadResultCallbackFunction<RequestType, OutcomeType> sync_result_callback,
       UploadResultCallbackFunction<RequestType, OutcomeType> async_result_callback,
-      const void* data, int64_t nbytes, std::shared_ptr<Buffer> owned_buffer = nullptr) {
+      const void* data, int64_t nbytes, const std::shared_ptr<Buffer>& owned_buffer = nullptr) {
     req.SetBucket(ToAwsString(path_.bucket));
     req.SetKey(ToAwsString(path_.key));
     req.SetContentLength(nbytes);
@@ -2065,14 +2065,14 @@ class ObjectOutputStream final : public io::OutputStream {
         "PutObject", outcome.GetError());
   }
 
-  Status UploadUsingSingleRequest(std::shared_ptr<Buffer> buffer) {
+  Status UploadUsingSingleRequest(const std::shared_ptr<Buffer>& buffer) {
     return UploadUsingSingleRequest(buffer->data(), buffer->size(), buffer);
   }
 
   Status UploadUsingSingleRequest(const void* data, int64_t nbytes,
                                   std::shared_ptr<Buffer> owned_buffer = nullptr) {
     auto sync_result_callback = [](const Aws::S3::Model::PutObjectRequest& request,
-                                   std::shared_ptr<UploadState> state,
+                                   const std::shared_ptr<UploadState>& state,
                                    int32_t part_number,
                                    Aws::S3::Model::PutObjectOutcome outcome) {
       if (!outcome.IsSuccess()) {
@@ -2082,7 +2082,7 @@ class ObjectOutputStream final : public io::OutputStream {
     };
 
     auto async_result_callback = [](const Aws::S3::Model::PutObjectRequest& request,
-                                    std::shared_ptr<UploadState> state,
+                                    const std::shared_ptr<UploadState>& state,
                                     int32_t part_number,
                                     Aws::S3::Model::PutObjectOutcome outcome) {
       HandleUploadUsingSingleRequestOutcome(state, request, outcome);
@@ -2097,7 +2097,7 @@ class ObjectOutputStream final : public io::OutputStream {
         data, nbytes, std::move(owned_buffer));
   }
 
-  Status UploadPart(std::shared_ptr<Buffer> buffer) {
+  Status UploadPart(const std::shared_ptr<Buffer>& buffer) {
     return UploadPart(buffer->data(), buffer->size(), buffer);
   }
 
@@ -2120,7 +2120,7 @@ class ObjectOutputStream final : public io::OutputStream {
     req.SetUploadId(multipart_upload_id_);
 
     auto sync_result_callback = [](const Aws::S3::Model::UploadPartRequest& request,
-                                   std::shared_ptr<UploadState> state,
+                                   const std::shared_ptr<UploadState>& state,
                                    int32_t part_number,
                                    Aws::S3::Model::UploadPartOutcome outcome) {
       if (!outcome.IsSuccess()) {
@@ -2133,7 +2133,7 @@ class ObjectOutputStream final : public io::OutputStream {
     };
 
     auto async_result_callback = [](const Aws::S3::Model::UploadPartRequest& request,
-                                    std::shared_ptr<UploadState> state,
+                                    const std::shared_ptr<UploadState>& state,
                                     int32_t part_number,
                                     Aws::S3::Model::UploadPartOutcome outcome) {
       HandleUploadPartOutcome(state, part_number, request, outcome);

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -126,7 +126,7 @@ arrow::Result<std::shared_ptr<Table>> FlightStreamReader::ToTable(
 class IpcMessageReader : public ipc::MessageReader {
  public:
   IpcMessageReader(std::shared_ptr<internal::ClientDataStream> stream,
-                   std::shared_ptr<internal::PeekableFlightDataReader> peekable_reader,
+                   const std::shared_ptr<internal::PeekableFlightDataReader>& peekable_reader,
                    std::shared_ptr<MemoryManager> memory_manager,
                    std::shared_ptr<Buffer>* app_metadata)
       : stream_(std::move(stream)),

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -58,7 +58,7 @@ const char* ColumnMetadata::kIsSearchable = "ARROW:FLIGHT:SQL:IS_SEARCHABLE";
 const char* ColumnMetadata::kRemarks = "ARROW:FLIGHT:SQL:REMARKS";
 
 ColumnMetadata::ColumnMetadata(
-    std::shared_ptr<const arrow::KeyValueMetadata> metadata_map) {
+    const std::shared_ptr<const arrow::KeyValueMetadata>& metadata_map) {
   metadata_map_ =
       metadata_map ? metadata_map : std::make_shared<arrow::KeyValueMetadata>();
 }

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -34,7 +34,7 @@ class ARROW_FLIGHT_SQL_EXPORT ColumnMetadata {
  public:
   class ColumnMetadataBuilder;
 
-  explicit ColumnMetadata(std::shared_ptr<const arrow::KeyValueMetadata> metadata_map);
+  explicit ColumnMetadata(const std::shared_ptr<const arrow::KeyValueMetadata>& metadata_map);
 
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/record_batch_transformer.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/record_batch_transformer.cc
@@ -29,7 +29,7 @@
 
 namespace arrow::flight::sql::odbc {
 namespace {
-arrow::Result<std::shared_ptr<Array>> MakeEmptyArray(std::shared_ptr<DataType> type,
+arrow::Result<std::shared_ptr<Array>> MakeEmptyArray(const std::shared_ptr<DataType>& type,
                                                      MemoryPool* memory_pool,
                                                      int64_t array_size) {
   std::unique_ptr<ArrayBuilder> builder;

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -244,7 +244,7 @@ class ExchangeDataStream final : public internal::ServerDataStream {
 class GrpcServiceHandler final : public FlightService::Service {
  public:
   GrpcServiceHandler(
-      std::shared_ptr<ServerAuthHandler> auth_handler,
+      const std::shared_ptr<ServerAuthHandler>& auth_handler,
       std::vector<std::pair<std::string, std::shared_ptr<ServerMiddlewareFactory>>>
           middleware,
       internal::ServerTransport* impl)

--- a/cpp/src/arrow/flight/transport_server.cc
+++ b/cpp/src/arrow/flight/transport_server.cc
@@ -40,7 +40,7 @@ namespace {
 class TransportIpcMessageReader : public ipc::MessageReader {
  public:
   TransportIpcMessageReader(
-      std::shared_ptr<internal::PeekableFlightDataReader> peekable_reader,
+      const std::shared_ptr<internal::PeekableFlightDataReader>& peekable_reader,
       std::shared_ptr<MemoryManager> memory_manager,
       std::shared_ptr<Buffer>* app_metadata)
       : peekable_reader_(peekable_reader),

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -764,7 +764,7 @@ class TestCudaDeviceArrayRoundtrip : public ::testing::Test {
  public:
   using ArrayFactory = std::function<Result<std::shared_ptr<Array>>()>;
 
-  static ArrayFactory JSONArrayFactory(std::shared_ptr<DataType> type, const char* json) {
+  static ArrayFactory JSONArrayFactory(const std::shared_ptr<DataType>& type, const char* json) {
     return [=]() { return ArrayFromJSON(type, json); };
   }
 
@@ -833,7 +833,7 @@ class TestCudaDeviceArrayRoundtrip : public ::testing::Test {
     }
   }
 
-  void TestWithJSON(std::shared_ptr<DataType> type, const char* json) {
+  void TestWithJSON(const std::shared_ptr<DataType>& type, const char* json) {
     TestWithArrayFactory(JSONArrayFactory(type, json));
   }
 };

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -113,11 +113,11 @@ class ARROW_EXPORT ReadRangeCache {
   static constexpr int64_t kDefaultRangeSizeLimit = 32 * 1024 * 1024;
 
   /// Construct a read cache with default
-  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file, IOContext ctx)
+  explicit ReadRangeCache(const std::shared_ptr<RandomAccessFile>& file, IOContext ctx)
       : ReadRangeCache(file, file.get(), std::move(ctx), CacheOptions::Defaults()) {}
 
   /// Construct a read cache with given options
-  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file, IOContext ctx,
+  explicit ReadRangeCache(const std::shared_ptr<RandomAccessFile>& file, IOContext ctx,
                           CacheOptions options)
       : ReadRangeCache(file, file.get(), std::move(ctx), options) {}
 

--- a/cpp/src/arrow/io/compressed_test.cc
+++ b/cpp/src/arrow/io/compressed_test.cc
@@ -80,7 +80,7 @@ std::shared_ptr<Buffer> CompressDataOneShot(Codec* codec,
   return compressed;
 }
 
-Status RunCompressedInputStream(Codec* codec, std::shared_ptr<Buffer> compressed,
+Status RunCompressedInputStream(Codec* codec, const std::shared_ptr<Buffer>& compressed,
                                 int64_t* stream_pos, std::vector<uint8_t>* out) {
   // Create compressed input stream
   auto buffer_reader = std::make_shared<BufferReader>(compressed);
@@ -106,7 +106,7 @@ Status RunCompressedInputStream(Codec* codec, std::shared_ptr<Buffer> compressed
   return Status::OK();
 }
 
-Status RunCompressedInputStream(Codec* codec, std::shared_ptr<Buffer> compressed,
+Status RunCompressedInputStream(Codec* codec, const std::shared_ptr<Buffer>& compressed,
                                 std::vector<uint8_t>* out) {
   return RunCompressedInputStream(codec, compressed, nullptr, out);
 }

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -133,7 +133,7 @@ Future<std::shared_ptr<const KeyValueMetadata>> InputStream::ReadMetadataAsync()
 }
 
 Result<Iterator<std::shared_ptr<Buffer>>> MakeInputStreamIterator(
-    std::shared_ptr<InputStream> stream, int64_t block_size) {
+    const std::shared_ptr<InputStream>& stream, int64_t block_size) {
   if (stream->closed()) {
     return Status::Invalid("Cannot take iterator on closed stream");
   }

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -389,7 +389,7 @@ class ARROW_EXPORT ReadWriteFileInterface : public RandomAccessFile, public Writ
 /// (unlike InputStream::Read() which returns an empty buffer).
 ARROW_EXPORT
 Result<Iterator<std::shared_ptr<Buffer>>> MakeInputStreamIterator(
-    std::shared_ptr<InputStream> stream, int64_t block_size);
+    const std::shared_ptr<InputStream>& stream, int64_t block_size);
 
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -95,7 +95,7 @@ class TestFeatherBase {
     }
   }
 
-  void CheckSlices(std::shared_ptr<RecordBatch> batch) {
+  void CheckSlices(const std::shared_ptr<RecordBatch>& batch) {
     std::vector<int> starts = {0, 1, 300, 301, 302, 303, 304, 305, 306, 307};
     std::vector<int> sizes = {0, 1, 7, 8, 30, 32, 100};
     for (auto start : starts) {
@@ -105,7 +105,7 @@ class TestFeatherBase {
     }
   }
 
-  void CheckRoundtrip(std::shared_ptr<RecordBatch> batch) {
+  void CheckRoundtrip(const std::shared_ptr<RecordBatch>& batch) {
     std::vector<std::shared_ptr<RecordBatch>> batches = {batch};
     ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatches(batches));
 

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -208,7 +208,7 @@ bool Message::Equals(const Message& other) const {
   }
 }
 
-Result<std::unique_ptr<Message>> Message::ReadFrom(std::shared_ptr<Buffer> metadata,
+Result<std::unique_ptr<Message>> Message::ReadFrom(const std::shared_ptr<Buffer>& metadata,
                                                    io::InputStream* stream) {
   std::unique_ptr<Message> result;
   auto listener = std::make_shared<AssignMessageDecoderListener>(&result);
@@ -225,7 +225,7 @@ Result<std::unique_ptr<Message>> Message::ReadFrom(std::shared_ptr<Buffer> metad
 }
 
 Result<std::unique_ptr<Message>> Message::ReadFrom(const int64_t offset,
-                                                   std::shared_ptr<Buffer> metadata,
+                                                   const std::shared_ptr<Buffer>& metadata,
                                                    io::RandomAccessFile* file) {
   std::unique_ptr<Message> result;
   auto listener = std::make_shared<AssignMessageDecoderListener>(&result);
@@ -335,7 +335,7 @@ struct ReadMessageState {
 // A common continuation callback for ReadMessage and ReadMessageAsync overloads
 static Result<std::unique_ptr<Message>> ReadMessageContinued(
     int64_t offset, int32_t metadata_length, std::optional<int64_t> body_length,
-    std::shared_ptr<Buffer> metadata, io::RandomAccessFile* file,
+    const std::shared_ptr<Buffer>& metadata, io::RandomAccessFile* file,
     const FieldsLoaderFunction& fields_loader, ReadMessageState* state) {
   MessageDecoder* decoder = state->decoder.get();
   if (body_length.has_value()) {
@@ -400,8 +400,8 @@ static Result<std::unique_ptr<Message>> ReadMessageContinued(
 
 }  // namespace
 
-Result<std::unique_ptr<Message>> ReadMessage(std::shared_ptr<Buffer> metadata,
-                                             std::shared_ptr<Buffer> body) {
+Result<std::unique_ptr<Message>> ReadMessage(const std::shared_ptr<Buffer>& metadata,
+                                             const std::shared_ptr<Buffer>& body) {
   std::unique_ptr<Message> result;
   auto listener = std::make_shared<AssignMessageDecoderListener>(&result);
   // If the user does not pass in a body buffer then we assume they are skipping it
@@ -501,7 +501,7 @@ Future<std::shared_ptr<Message>> ReadMessageAsync(int64_t offset, int32_t metada
   return file
       ->ReadAsync(context, offset, metadata_length + body_length,
                   /*allow_short_read=*/false)
-      .Then([=](std::shared_ptr<Buffer> metadata) -> Result<std::shared_ptr<Message>> {
+      .Then([=](const std::shared_ptr<Buffer>& metadata) -> Result<std::shared_ptr<Message>> {
         // Pass a nullptr file to ensure that no further IO occurs
         // (we have fetched all the required bytes).
         return ReadMessageContinued(offset, metadata_length, body_length, metadata,
@@ -1025,7 +1025,7 @@ Status MessageDecoder::Consume(const uint8_t* data, int64_t size) {
   return impl_->ConsumeData(data, size);
 }
 
-Status MessageDecoder::Consume(std::shared_ptr<Buffer> buffer) {
+Status MessageDecoder::Consume(const std::shared_ptr<Buffer>& buffer) {
   return impl_->ConsumeBuffer(buffer);
 }
 

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -67,7 +67,7 @@ class ARROW_EXPORT Message {
   /// \return the created Message
   ///
   /// \note If stream supports zero-copy, this is zero-copy
-  static Result<std::unique_ptr<Message>> ReadFrom(std::shared_ptr<Buffer> metadata,
+  static Result<std::unique_ptr<Message>> ReadFrom(const std::shared_ptr<Buffer>& metadata,
                                                    io::InputStream* stream);
 
   /// \brief Read message body from position in file, and create Message given
@@ -79,7 +79,7 @@ class ARROW_EXPORT Message {
   ///
   /// \note If file supports zero-copy, this is zero-copy
   static Result<std::unique_ptr<Message>> ReadFrom(const int64_t offset,
-                                                   std::shared_ptr<Buffer> metadata,
+                                                   const std::shared_ptr<Buffer>& metadata,
                                                    io::RandomAccessFile* file);
 
   /// \brief Return true if message type and contents are equal
@@ -321,7 +321,7 @@ class ARROW_EXPORT MessageDecoder {
   ///
   /// \param[in] buffer a Buffer to be processed.
   /// \return Status
-  Status Consume(std::shared_ptr<Buffer> buffer);
+  Status Consume(const std::shared_ptr<Buffer>& buffer);
 
   /// \brief Return the number of bytes needed to advance the state of
   /// the decoder.
@@ -515,7 +515,7 @@ Result<std::unique_ptr<Message>> ReadMessage(const int64_t offset,
 /// \param body The bytes for the body
 /// \return The message represented by the buffers
 ARROW_EXPORT Result<std::unique_ptr<Message>> ReadMessage(
-    std::shared_ptr<Buffer> metadata, std::shared_ptr<Buffer> body);
+    const std::shared_ptr<Buffer>& metadata, const std::shared_ptr<Buffer>& body);
 
 ARROW_EXPORT
 Future<std::shared_ptr<Message>> ReadMessageAsync(

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1004,7 +1004,7 @@ TEST_F(TestWriteRecordBatch, RoundtripPreservesBufferSizes) {
 }
 
 void TestGetRecordBatchSize(const IpcWriteOptions& options,
-                            std::shared_ptr<RecordBatch> batch) {
+                            const std::shared_ptr<RecordBatch>& batch) {
   io::MockOutputStream mock;
   ipc::IpcPayload payload;
   int32_t mock_metadata_length = -1;
@@ -2178,7 +2178,7 @@ TEST(TestRecordBatchStreamReader, EmptyStreamWithDictionaries) {
 // Delimit IPC stream messages and reassemble with the indicated messages
 // included. This way we can remove messages from an IPC stream to test
 // different failure modes or other difficult-to-test behaviors
-void SpliceMessages(std::shared_ptr<Buffer> stream,
+void SpliceMessages(const std::shared_ptr<Buffer>& stream,
                     const std::vector<int>& included_indices,
                     std::shared_ptr<Buffer>* spliced_stream) {
   ASSERT_OK_AND_ASSIGN(auto out, io::BufferOutputStream::Create(0));
@@ -2227,7 +2227,7 @@ TEST(TestRecordBatchStreamReader, NotEnoughDictionaries) {
   // error
   ASSERT_OK_AND_ASSIGN(auto buffer, out->Finish());
 
-  auto Read = [](std::shared_ptr<Buffer> stream) -> Status {
+  auto Read = [](const std::shared_ptr<Buffer>& stream) -> Status {
     io::BufferReader reader(stream);
     ARROW_ASSIGN_OR_RAISE(auto ipc_reader, RecordBatchStreamReader::Open(&reader));
     std::shared_ptr<RecordBatch> batch;
@@ -2780,7 +2780,7 @@ class TestDictionaryReplacement : public ::testing::Test {
   }
 
   // Make one-column batch
-  std::shared_ptr<RecordBatch> MakeBatch(std::shared_ptr<Array> column) {
+  std::shared_ptr<RecordBatch> MakeBatch(const std::shared_ptr<Array>& column) {
     return RecordBatch::Make(schema({field("f", column->type())}), column->length(),
                              {column});
   }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1620,7 +1620,7 @@ Result<std::unique_ptr<IpcPayloadWriter>> MakePayloadFileWriter(
 // Serialization public APIs
 
 Result<std::shared_ptr<Buffer>> SerializeRecordBatch(const RecordBatch& batch,
-                                                     std::shared_ptr<MemoryManager> mm) {
+                                                     const std::shared_ptr<MemoryManager>& mm) {
   auto options = IpcWriteOptions::Defaults();
   int64_t size = 0;
   RETURN_NOT_OK(GetRecordBatchSize(batch, options, &size));

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -218,7 +218,7 @@ Result<std::shared_ptr<Buffer>> SerializeRecordBatch(const RecordBatch& batch,
 /// \return the serialized message
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SerializeRecordBatch(const RecordBatch& batch,
-                                                     std::shared_ptr<MemoryManager> mm);
+                                                     const std::shared_ptr<MemoryManager>& mm);
 
 /// \brief Write record batch to OutputStream
 ///

--- a/cpp/src/arrow/json/chunker_test.cc
+++ b/cpp/src/arrow/json/chunker_test.cc
@@ -118,7 +118,7 @@ void AssertChunking(Chunker& chunker, std::shared_ptr<Buffer> buf, int total_cou
   }
 }
 
-void AssertChunkingBlockSize(Chunker& chunker, std::shared_ptr<Buffer> buf,
+void AssertChunkingBlockSize(Chunker& chunker, const std::shared_ptr<Buffer>& buf,
                              int64_t block_size, int expected_count) {
   std::shared_ptr<Buffer> partial = Buffer::FromString({});
   int64_t pos = 0;
@@ -210,7 +210,7 @@ TEST_P(BaseChunkerTest, Basics) {
 }
 
 TEST_P(BaseChunkerTest, BlockSizes) {
-  auto check_block_sizes = [&](std::shared_ptr<Buffer> data) {
+  auto check_block_sizes = [&](const std::shared_ptr<Buffer>& data) {
     for (int64_t block_size = min_block_size; block_size < min_block_size + 30;
          ++block_size) {
       AssertChunkingBlockSize(*chunker_, data, block_size, object_count);

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -75,7 +75,7 @@ Status VisitDictionaryEntries(const DictionaryArray& dict_array,
 // base class for types which accept and output non-nested types
 class PrimitiveConverter : public Converter {
  public:
-  PrimitiveConverter(MemoryPool* pool, std::shared_ptr<DataType> out_type)
+  PrimitiveConverter(MemoryPool* pool, const std::shared_ptr<DataType>& out_type)
       : Converter(pool, out_type) {}
 };
 

--- a/cpp/src/arrow/json/converter_test.cc
+++ b/cpp/src/arrow/json/converter_test.cc
@@ -28,8 +28,8 @@
 namespace arrow {
 namespace json {
 
-Result<std::shared_ptr<Array>> Convert(std::shared_ptr<DataType> type,
-                                       std::shared_ptr<Array> unconverted) {
+Result<std::shared_ptr<Array>> Convert(const std::shared_ptr<DataType>& type,
+                                       const std::shared_ptr<Array>& unconverted) {
   std::shared_ptr<Array> converted;
   // convert the array
   std::shared_ptr<Converter> converter;

--- a/cpp/src/arrow/json/from_string_test.cc
+++ b/cpp/src/arrow/json/from_string_test.cc
@@ -570,7 +570,7 @@ TEST(TestFixedSizeBinaryFromString, Dictionary) {
 }
 
 template <typename DecimalValue, typename DecimalBuilder>
-void TestDecimalBasic(std::shared_ptr<DataType> type) {
+void TestDecimalBasic(const std::shared_ptr<DataType>& type) {
   std::shared_ptr<Array> expected, actual;
 
   ASSERT_OK_AND_ASSIGN(actual, ArrayFromJSONString(type, "[]"));

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -245,7 +245,7 @@ class TableReaderImpl : public TableReader,
         read_options_(read_options),
         task_group_(std::move(task_group)) {}
 
-  Status Init(std::shared_ptr<io::InputStream> input) {
+  Status Init(const std::shared_ptr<io::InputStream>& input) {
     ARROW_ASSIGN_OR_RAISE(auto it,
                           io::MakeInputStreamIterator(input, read_options_.block_size));
     return MakeReadaheadIterator(std::move(it), task_group_->parallelism())
@@ -499,7 +499,7 @@ class StreamingReaderImpl : public StreamingReader {
 }  // namespace
 
 Result<std::shared_ptr<TableReader>> TableReader::Make(
-    MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+    MemoryPool* pool, const std::shared_ptr<io::InputStream>& input,
     const ReadOptions& read_options, const ParseOptions& parse_options) {
   std::shared_ptr<TableReaderImpl> ptr;
   if (read_options.use_threads) {
@@ -535,7 +535,7 @@ Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
 }
 
 Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
-                                              std::shared_ptr<Buffer> json) {
+                                              const std::shared_ptr<Buffer>& json) {
   DecodeContext context(std::move(options));
 
   std::unique_ptr<BlockParser> parser;

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -370,11 +370,11 @@ class StreamingReaderImpl : public StreamingReader {
   }
 
   static Future<std::shared_ptr<StreamingReaderImpl>> MakeAsync(
-      std::shared_ptr<DecodeContext> context, std::shared_ptr<io::InputStream> stream,
+      const std::shared_ptr<DecodeContext>& context, const std::shared_ptr<io::InputStream>& stream,
       io::IOContext io_context, Executor* cpu_executor, const ReadOptions& read_options) {
     ARROW_ASSIGN_OR_RAISE(
         auto buffer_it,
-        io::MakeInputStreamIterator(std::move(stream), read_options.block_size));
+        io::MakeInputStreamIterator(stream, read_options.block_size));
     ARROW_ASSIGN_OR_RAISE(
         auto buffer_gen,
         MakeBackgroundGenerator(std::move(buffer_it), io_context.executor()));
@@ -438,7 +438,7 @@ class StreamingReaderImpl : public StreamingReader {
     }
 
     return FirstBlock(decoding_gen)
-        .Then([source = std::move(decoding_gen), context = std::move(context),
+        .Then([source = std::move(decoding_gen), context = context,
                max_readahead](const DecodedBlock& block) {
           return std::make_shared<StreamingReaderImpl>(block, std::move(source), context,
                                                        max_readahead);

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -43,13 +43,13 @@ class ARROW_EXPORT TableReader {
 
   /// Create a TableReader instance
   static Result<std::shared_ptr<TableReader>> Make(MemoryPool* pool,
-                                                   std::shared_ptr<io::InputStream> input,
+                                                   const std::shared_ptr<io::InputStream>& input,
                                                    const ReadOptions&,
                                                    const ParseOptions&);
 };
 
 ARROW_EXPORT Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
-                                                           std::shared_ptr<Buffer> json);
+                                                           const std::shared_ptr<Buffer>& json);
 
 /// \brief A class that reads a JSON file incrementally
 ///

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -636,7 +636,7 @@ BaseListScalar::BaseListScalar(std::shared_ptr<Array> value,
   }
 }
 
-ListScalar::ListScalar(std::shared_ptr<Array> value, bool is_valid)
+ListScalar::ListScalar(const std::shared_ptr<Array>& value, bool is_valid)
     : ListScalar(value, list(value->type()), is_valid) {}
 
 void ListScalar::FillScratchSpace(uint8_t* scratch_space,
@@ -646,7 +646,7 @@ void ListScalar::FillScratchSpace(uint8_t* scratch_space,
       {int32_t(0), value ? static_cast<int32_t>(value->length()) : int32_t(0)});
 }
 
-LargeListScalar::LargeListScalar(std::shared_ptr<Array> value, bool is_valid)
+LargeListScalar::LargeListScalar(const std::shared_ptr<Array>& value, bool is_valid)
     : LargeListScalar(value, large_list(value->type()), is_valid) {}
 
 void LargeListScalar::FillScratchSpace(uint8_t* scratch_space,
@@ -655,7 +655,7 @@ void LargeListScalar::FillScratchSpace(uint8_t* scratch_space,
                          {int64_t(0), value ? value->length() : int64_t(0)});
 }
 
-ListViewScalar::ListViewScalar(std::shared_ptr<Array> value, bool is_valid)
+ListViewScalar::ListViewScalar(const std::shared_ptr<Array>& value, bool is_valid)
     : ListViewScalar(value, list_view(value->type()), is_valid) {}
 
 void ListViewScalar::FillScratchSpace(uint8_t* scratch_space,
@@ -665,7 +665,7 @@ void ListViewScalar::FillScratchSpace(uint8_t* scratch_space,
       {int32_t(0), value ? static_cast<int32_t>(value->length()) : int32_t(0)});
 }
 
-LargeListViewScalar::LargeListViewScalar(std::shared_ptr<Array> value, bool is_valid)
+LargeListViewScalar::LargeListViewScalar(const std::shared_ptr<Array>& value, bool is_valid)
     : LargeListViewScalar(value, large_list_view(value->type()), is_valid) {}
 
 void LargeListViewScalar::FillScratchSpace(uint8_t* scratch_space,
@@ -680,7 +680,7 @@ inline std::shared_ptr<DataType> MakeMapType(const std::shared_ptr<DataType>& pa
   return map(pair_type->field(0)->type(), pair_type->field(1)->type());
 }
 
-MapScalar::MapScalar(std::shared_ptr<Array> value, bool is_valid)
+MapScalar::MapScalar(const std::shared_ptr<Array>& value, bool is_valid)
     : MapScalar(value, MakeMapType(value->type()), is_valid) {}
 
 void MapScalar::FillScratchSpace(uint8_t* scratch_space,
@@ -699,7 +699,7 @@ FixedSizeListScalar::FixedSizeListScalar(std::shared_ptr<Array> value,
   }
 }
 
-FixedSizeListScalar::FixedSizeListScalar(std::shared_ptr<Array> value, bool is_valid)
+FixedSizeListScalar::FixedSizeListScalar(const std::shared_ptr<Array>& value, bool is_valid)
     : BaseListScalar(
           value, fixed_size_list(value->type(), static_cast<int32_t>(value->length())),
           is_valid) {}
@@ -1091,7 +1091,7 @@ std::shared_ptr<Buffer> FormatToBuffer(Formatter&& formatter, const ScalarType& 
 // error fallback
 template <typename To>
 Result<std::shared_ptr<Scalar>> CastImpl(const Scalar& from,
-                                         std::shared_ptr<DataType> to_type) {
+                                         const std::shared_ptr<DataType>& to_type) {
   return Status::NotImplemented("casting scalars of type ", *from.type, " to type ",
                                 *to_type);
 }

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -467,7 +467,7 @@ struct TemporalScalar : internal::PrimitiveScalar<T> {
   using internal::PrimitiveScalar<T>::PrimitiveScalar;
   using ValueType = typename internal::PrimitiveScalar<T>::ValueType;
 
-  TemporalScalar(ValueType value, std::shared_ptr<DataType> type)
+  TemporalScalar(ValueType value, const std::shared_ptr<DataType>& type)
       : internal::PrimitiveScalar<T>(std::move(value), type) {}
 };
 
@@ -630,7 +630,7 @@ struct ARROW_EXPORT ListScalar
       : BaseListScalar(std::move(value), std::move(type), is_valid),
         ArraySpanFillFromScalarScratchSpace(this->value) {}
 
-  explicit ListScalar(std::shared_ptr<Array> value, bool is_valid = true);
+  explicit ListScalar(const std::shared_ptr<Array>& value, bool is_valid = true);
 
  private:
   static void FillScratchSpace(uint8_t* scratch_space,
@@ -652,7 +652,7 @@ struct ARROW_EXPORT LargeListScalar
       : BaseListScalar(std::move(value), std::move(type), is_valid),
         ArraySpanFillFromScalarScratchSpace(this->value) {}
 
-  explicit LargeListScalar(std::shared_ptr<Array> value, bool is_valid = true);
+  explicit LargeListScalar(const std::shared_ptr<Array>& value, bool is_valid = true);
 
  private:
   static void FillScratchSpace(uint8_t* scratch_space,
@@ -674,7 +674,7 @@ struct ARROW_EXPORT ListViewScalar
       : BaseListScalar(std::move(value), std::move(type), is_valid),
         ArraySpanFillFromScalarScratchSpace(this->value) {}
 
-  explicit ListViewScalar(std::shared_ptr<Array> value, bool is_valid = true);
+  explicit ListViewScalar(const std::shared_ptr<Array>& value, bool is_valid = true);
 
  private:
   static void FillScratchSpace(uint8_t* scratch_space,
@@ -696,7 +696,7 @@ struct ARROW_EXPORT LargeListViewScalar
       : BaseListScalar(std::move(value), std::move(type), is_valid),
         ArraySpanFillFromScalarScratchSpace(this->value) {}
 
-  explicit LargeListViewScalar(std::shared_ptr<Array> value, bool is_valid = true);
+  explicit LargeListViewScalar(const std::shared_ptr<Array>& value, bool is_valid = true);
 
  private:
   static void FillScratchSpace(uint8_t* scratch_space,
@@ -718,7 +718,7 @@ struct ARROW_EXPORT MapScalar
       : BaseListScalar(std::move(value), std::move(type), is_valid),
         ArraySpanFillFromScalarScratchSpace(this->value) {}
 
-  explicit MapScalar(std::shared_ptr<Array> value, bool is_valid = true);
+  explicit MapScalar(const std::shared_ptr<Array>& value, bool is_valid = true);
 
  private:
   static void FillScratchSpace(uint8_t* scratch_space,
@@ -734,7 +734,7 @@ struct ARROW_EXPORT FixedSizeListScalar : public BaseListScalar {
   FixedSizeListScalar(std::shared_ptr<Array> value, std::shared_ptr<DataType> type,
                       bool is_valid = true);
 
-  explicit FixedSizeListScalar(std::shared_ptr<Array> value, bool is_valid = true);
+  explicit FixedSizeListScalar(const std::shared_ptr<Array>& value, bool is_valid = true);
 };
 
 struct ARROW_EXPORT StructScalar : public Scalar {
@@ -955,7 +955,7 @@ std::shared_ptr<Scalar> MakeNullScalar(std::shared_ptr<DataType> type);
 
 /// \brief Scalar factory for non-null scalars
 template <typename Value>
-Result<std::shared_ptr<Scalar>> MakeScalar(std::shared_ptr<DataType> type,
+Result<std::shared_ptr<Scalar>> MakeScalar(const std::shared_ptr<DataType>& type,
                                            Value&& value) {
   return MakeScalarImpl<Value&&>{type, std::forward<Value>(value), NULLPTR}.Finish();
 }

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -172,8 +172,8 @@ struct ArraySpanFillFromScalarScratchSpace {
 };
 
 struct ARROW_EXPORT PrimitiveScalarBase : public Scalar {
-  explicit PrimitiveScalarBase(std::shared_ptr<DataType> type)
-      : Scalar(std::move(type), false) {}
+  explicit PrimitiveScalarBase(const std::shared_ptr<DataType>& type)
+      : Scalar(type, false) {}
 
   using Scalar::Scalar;
   /// \brief Get a const pointer to the value of this scalar. May be null.
@@ -189,11 +189,11 @@ struct PrimitiveScalar : public PrimitiveScalarBase {
   using ValueType = CType;
 
   // Non-null constructor.
-  PrimitiveScalar(ValueType value, std::shared_ptr<DataType> type)
-      : PrimitiveScalarBase(std::move(type), true), value(value) {}
+  PrimitiveScalar(ValueType value, const std::shared_ptr<DataType>& type)
+      : PrimitiveScalarBase(type, true), value(value) {}
 
-  explicit PrimitiveScalar(std::shared_ptr<DataType> type)
-      : PrimitiveScalarBase(std::move(type), false) {}
+  explicit PrimitiveScalar(const std::shared_ptr<DataType>& type)
+      : PrimitiveScalarBase(type, false) {}
 
   ValueType value{};
 

--- a/cpp/src/arrow/smartptr-review.md
+++ b/cpp/src/arrow/smartptr-review.md
@@ -1,0 +1,259 @@
+---
+name: smartptr-review
+description: >-
+  Review C++ code (.cpp/.cc/.cxx/.h/.hpp) for four specific smart pointer
+  defects: useless shared_ptr copies, shared_ptr passed by value without a
+  move, unique_ptr passed by const&, and same-thread reentrancy hazards when
+  dereferencing a global, static, or member shared_ptr. Use when asked to
+  review or audit smart pointer usage, refcount overhead, unnecessary
+  shared_ptr copies, pass-by-value versus const&, or reentrancy and
+  use-after-free risk around shared_ptr — including for in-house pointer
+  types such as intrusive_ptr or ComPtr. Not for general C++ review, memory
+  leaks, raw new/delete, make_shared versus new, ownership design, or
+  non-C++ code.
+---
+
+You are performing a focused code review for C++ smart pointer usage patterns.
+
+Before beginning, read `cpp-review-procedure.md` in full. Its procedure, definitions, and output contract are mandatory and are not repeated here.
+
+
+## Definitions
+
+### Pointer type categories
+
+  - **OwningPtr type (heuristic)**: A type that is dereferenceable
+    AND whose name ends in `ptr` (case-insensitively)
+    AND has a user-defined destructor
+    AND has a user-defined dereferencing operator that does not spell out
+      `const` for the returned reference.
+
+> Note: This heuristic is intended to correctly detect owning smart pointer types including custom in-house types, but exclude non-owning indirection-like types (e.g., `std::observer_ptr`, STL iterators, `std::optional`). It may still misfire on non-owning handles named `*ptr` that happen to have a user-defined destructor and a non-`const`ified return for deference.
+
+  - **UniquePtr type**: A type that satisfies any of the following sub-bullets:
+    - **(heuristic)** is an OwningPtr type AND is movable AND is not copyable
+    - **(allow-list)** is specified as such by the user (e.g., in the prompt or in a config file) OR is any of { `unique_ptr` }
+
+  - **SharedPtr type**: A type that satisfies any of the following sub-bullets:
+    - **(heuristic)** is an OwningPtr type AND is copyable
+    - **(allow-list)** is specified as such by the user (e.g., in the prompt or in a config file) OR is any of { `shared_ptr`, `intrusive_ptr`, `ComPtr`, `CountedPtr`, `Ptr` }
+
+### Dereferences
+
+  - **Dereferencing operator**: Unary `*` or `->` or `[]`.
+  - **Dereference**: When a dereferencing operator is applied to an object.
+  - **Dereferenceable**: A type or object that provides a dereferencing operator.
+
+
+## Rules to check
+
+### Rule SP1: Useless SharedPtr local copies
+
+**Pattern**: A local non-parameter object `ptr` of SharedPtr type is copied to another local object `ptr_copy` AND `ptr` is not potentially modified during the lifetime of `ptr_copy` AND `ptr_copy` is not potentially modified during the lifetime of `ptr_copy` AND `ptr_copy` is not moved from during its lifetime.
+
+**Issue**: Unnecessary reference count increment/decrement overhead.
+
+**Severity**: Count a violation's severity as:
+  - "high (performance)" if it is very likely that the copy is happening on a hot path;
+  - otherwise, as "medium (performance)" if the copy is happening in a loop or the function is a commonly used library utility;
+  - otherwise, as "low (performance)".
+
+**Fix**: Use the original object instead of making a copy.
+
+**Example violation**:
+```cpp
+void foo() {
+    std::shared_ptr<Widget> ptr = getWidget();
+    for (/*...*/) {
+        auto copy = ptr; // ❌ Useless copy - just use ptr
+        copy->doSomething();
+    }
+}
+// Should be:
+//  void foo() {
+//      std::shared_ptr<Widget> ptr = getWidget();
+//      for (/*...*/) {
+//          ptr->doSomething();
+//      }
+//  }
+```
+
+**Example violation**:
+```cpp
+void foo() {
+    std::shared_ptr<Widget> ptr = getWidget();
+    std::shared_ptr<Widget> copy = ptr; // ❌ Useless copy - just use ptr
+    copy->doSomethingElse();
+}
+// Should be:
+//  void foo() {
+//      std::shared_ptr<Widget> ptr = getWidget();
+//      ptr->doSomethingElse();
+//  }
+```
+
+**Example non-violation**:
+```cpp
+void f() {
+    std::shared_ptr<Widget> const local = global_pointer; // ✅ OK - not a violation, global_pointer is not a local object
+    local->doWork();
+}
+```
+
+
+### Rule SP2: Useless SharedPtr pass by value
+
+**Pattern**: A parameter `ptr` of SharedPtr type is passed by value, but `ptr` is never moved from in the function body.
+
+**Issue**: Unnecessary reference count increment/decrement overhead at call site.
+
+**Severity**: Count a violation's severity as:
+  - "high (performance)" if it is very likely that the function is called on a hot path;
+  - otherwise, as "medium (performance)" if the function is called in a loop or the function is a commonly used library utility;
+  - otherwise, as "low (performance)".
+
+**Fix**:
+  - If any visible call site passes a non-local SharedPtr (namespace-scope, static, or a nonstatic data member) and the callee's call tree could reset it, ignore it as a violation of this rule.
+  - Otherwise, if the function would not compile if `ptr` was passed by `const&` instead, report that the parameter could not be changed to `const&` and report the specific use(s) in the body that would fail to compile. (Example: if `ptr` or `&ptr` is passed to a function that takes a reference or pointer to the non-`const` SharedPtr type.) For each definite last use of `ptr` that is a copy from `ptr` and for which writing `std::move(ptr)` instead of `ptr` would compile, write `std::move(ptr)` instead.
+  - Otherwise, pass `ptr` by `const&` instead.
+
+**Example violation**:
+```cpp
+void process( std::shared_ptr<Data> ptr ) { // ❌ Passed by value and never moved from
+    ptr->process();
+}
+// Should be:
+//  void process( std::shared_ptr<Data> const& ptr ) {
+//      ptr->process();
+//  }
+```
+
+**Example not-locally-fixable violation**:
+```cpp
+void takes_ptr_to_nonconst( std::shared_ptr<Data>* );
+void takes_copy( std::shared_ptr<Data> );
+
+void process( std::shared_ptr<Data> ptr ) { // ❌ Passed by value and never moved from, but cannot be changed to const& - report this instead, and suggest changing takes_ptr_to_nonconst to take by const*
+    takes_ptr_to_nonconst(&ptr);
+    takes_copy(ptr);
+}
+// Should be:
+//  void process( std::shared_ptr<Data> ptr ) {
+//      takes_ptr_to_nonconst(&ptr);  // should be reported as preventing a const& parameter
+//      takes_copy(std::move(ptr));   // change definite last use from copy to move
+//  }
+```
+
+**Example non-violation**:
+```cpp
+void process( std::shared_ptr<Data> ptr ) {  // ✅ OK - not a violation, ptr is moved from via .swap
+    ptr.swap(some->other->storage);
+}
+```
+
+
+### Rule SP3: UniquePtr passed by const&
+
+**Pattern**: A parameter `ptr` of UniquePtr type is passed by `const&`.
+
+**Issue**: Conceptual error -- there is no valid use for passing a UniquePtr by `const&`.
+
+**Severity**: Count a violation as "low (design)" severity.
+
+**Fix**: If the function body tests `ptr`'s nullness, pass a raw pointer to the owned object instead. Otherwise, pass a reference to the owned object instead.
+
+**Example violation**:
+```cpp
+void inspect1( std::unique_ptr<Widget> const& ptr ) { // ❌ Nonsensical pattern
+    ptr->process();
+}
+// Should be:
+//  void inspect1(Widget& w) {
+//      w.process();
+//  }
+```
+
+**Example violation**:
+```cpp
+void inspect2( std::unique_ptr<Widget> const& ptr ) { // ❌ Nonsensical pattern
+    if (ptr) {
+        ptr->process();
+    }
+}
+// Should be:
+//  void inspect2(Widget* ptr) {
+//      if (ptr) {
+//          ptr->process();
+//      }
+//  }
+```
+
+
+### Rule SP4: Same-thread-reentrancy-unsafe SharedPtr dereference
+
+**Pattern**: In a function body, a non-local object `ptr` of SharedPtr type is dereferenced AND the resulting pointer or reference is used as a function argument (including possibly to the implicit `this` parameter) AND ( either `ptr` is not a nonstatic data member OR the function does not assert that `ptr` still has the same pointer value at function exit that it had at function entry ).
+
+**Issue**: Same-thread reentrancy hazard -- if the function or its callees can trigger code that releases the last reference to the shared object, dereferencing becomes undefined behavior (use-after-free).
+
+**Severity**: Count a violation's severity as:
+  - "high (correctness)" if there is a code path in the called function's call tree that could modify `ptr`;
+  - otherwise, as "medium (correctness)" with a list of warnings that identify where the call tree could not be examined (e.g., "call tree was opaque at `Foo::onEvent` (virtual call)"), if any part of the called function's call tree is opaque and could not be inspected for modifications of `ptr`;
+  - otherwise, as "medium (correctness)" only.
+
+**Fix**:
+  - If `ptr` is a nonstatic data member AND there is no evidence that its value is likely to change during the function call, assert that `ptr` still has the same pointer value at function exit that it had on function entry. The assertion should use a scope guard object (e.g., using `gsl::finally` or `std::experimental::scope_exit`). (Note: This is a concession to avoid false positives; the ideal fix is still the second bullet which is correct by construction.)
+  - Otherwise, first take a local `const` copy of the SharedPtr to increment the reference count, and dereference the local copy instead; this single reference count protects the entire function body and its transitive call tree.
+
+**Example violation**:
+```cpp
+void f() {
+    global_state->doWork(); // ❌ Dereferencing global/static/heap SharedPtr
+    // What if doWork triggers code that resets global_state?
+}
+// Should be:
+//  void f() {
+//      auto const local = global_state; // Take local copy first
+//      local->doWork();                 // Now safe
+//  }
+```
+
+**Example violation**:
+```cpp
+class Handler {
+    std::shared_ptr<State> state_;
+
+    void process() {
+        state_->doWork(); // ❌ Dereferencing member SharedPtr without asserting value does not change
+        // What if doWork triggers code that resets state_?
+    }
+};
+// Should be this (if there is no evidence in the call tree that state_ is likely to change):
+//  void process() {
+//      auto guard = gsl::finally(
+//          [this, old = state_.get()]             // Remember original value
+//          { assert(old == this->state_.get()); } // assert it hasn't changed
+//          );
+//      state_->doWork(); // Now safe, if value did not change
+//  }
+//
+// or else this if the value really may change:
+//  void process() {
+//      auto const local = state_; // Take local copy first
+//      local->doWork();           // Now safe
+//  }
+```
+
+**Example non-violation**:
+```cpp
+class Handler {
+    std::shared_ptr<State> state_;
+
+    void process() { // ✅ OK - not a violation, state_ is asserted not to change
+        auto guard = std::experimental::scope_exit(
+            [this, old = state_.get()]
+            { assert(old == this->state_.get()); }
+            );
+        state_->doWork();
+    }
+};
+```

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -235,7 +235,7 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
 Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::shared_ptr<DataType>& indices_type,
     const std::vector<int64_t>& indices_shape,
-    const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data,
+    const std::vector<int64_t>& indices_strides, const std::shared_ptr<Buffer>& indices_data,
     bool is_canonical) {
   RETURN_NOT_OK(
       CheckSparseCOOIndexValidity(indices_type, indices_shape, indices_strides));
@@ -248,7 +248,7 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
 Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::shared_ptr<DataType>& indices_type,
     const std::vector<int64_t>& indices_shape,
-    const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data) {
+    const std::vector<int64_t>& indices_strides, const std::shared_ptr<Buffer>& indices_data) {
   RETURN_NOT_OK(
       CheckSparseCOOIndexValidity(indices_type, indices_shape, indices_strides));
   auto coords = std::make_shared<Tensor>(indices_type, indices_data, indices_shape,
@@ -259,7 +259,7 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
 
 Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
-    int64_t non_zero_length, std::shared_ptr<Buffer> indices_data, bool is_canonical) {
+    int64_t non_zero_length, const std::shared_ptr<Buffer>& indices_data, bool is_canonical) {
   auto ndim = static_cast<int64_t>(shape.size());
   if (!is_integer(indices_type->id())) {
     return Status::TypeError("Type of SparseCOOIndex indices must be integer");
@@ -273,7 +273,7 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
 
 Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
-    int64_t non_zero_length, std::shared_ptr<Buffer> indices_data) {
+    int64_t non_zero_length, const std::shared_ptr<Buffer>& indices_data) {
   auto ndim = static_cast<int64_t>(shape.size());
   if (!is_integer(indices_type->id())) {
     return Status::TypeError("Type of SparseCOOIndex indices must be integer");

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -123,13 +123,13 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   static Result<std::shared_ptr<SparseCOOIndex>> Make(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indices_shape,
-      const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data);
+      const std::vector<int64_t>& indices_strides, const std::shared_ptr<Buffer>& indices_data);
 
   /// \brief Make SparseCOOIndex from raw properties
   static Result<std::shared_ptr<SparseCOOIndex>> Make(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indices_shape,
-      const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data,
+      const std::vector<int64_t>& indices_strides, const std::shared_ptr<Buffer>& indices_data,
       bool is_canonical);
 
   /// \brief Make SparseCOOIndex from sparse tensor's shape properties and data
@@ -139,7 +139,7 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   /// use the raw properties constructor.
   static Result<std::shared_ptr<SparseCOOIndex>> Make(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
-      int64_t non_zero_length, std::shared_ptr<Buffer> indices_data);
+      int64_t non_zero_length, const std::shared_ptr<Buffer>& indices_data);
 
   /// \brief Make SparseCOOIndex from sparse tensor's shape properties and data
   ///
@@ -147,7 +147,7 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   /// use the raw properties constructor.
   static Result<std::shared_ptr<SparseCOOIndex>> Make(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
-      int64_t non_zero_length, std::shared_ptr<Buffer> indices_data, bool is_canonical);
+      int64_t non_zero_length, const std::shared_ptr<Buffer>& indices_data, bool is_canonical);
 
   /// \brief Construct SparseCOOIndex from column-major NumericTensor
   explicit SparseCOOIndex(const std::shared_ptr<Tensor>& coords, bool is_canonical);
@@ -231,7 +231,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
-      std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
+      const std::shared_ptr<Buffer>& indptr_data, const std::shared_ptr<Buffer>& indices_data) {
     ARROW_RETURN_NOT_OK(ValidateSparseCSXIndex(indptr_type, indices_type, indptr_shape,
                                                indices_shape,
                                                SparseIndexType::kTypeName));
@@ -244,7 +244,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
   static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
-      std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
+      const std::shared_ptr<Buffer>& indptr_data, const std::shared_ptr<Buffer>& indices_data) {
     return Make(indices_type, indices_type, indptr_shape, indices_shape, indptr_data,
                 indices_data);
   }
@@ -254,8 +254,8 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
   static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
-      int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
-      std::shared_ptr<Buffer> indices_data) {
+      int64_t non_zero_length, const std::shared_ptr<Buffer>& indptr_data,
+      const std::shared_ptr<Buffer>& indices_data) {
     ARROW_ASSIGN_OR_RAISE(auto indptr_length,
                           ComputeSparseCSXIndptrLength(COMPRESSED_AXIS, shape));
     std::vector<int64_t> indptr_shape({indptr_length});
@@ -268,8 +268,8 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
   /// data
   static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
-      int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
-      std::shared_ptr<Buffer> indices_data) {
+      int64_t non_zero_length, const std::shared_ptr<Buffer>& indptr_data,
+      const std::shared_ptr<Buffer>& indices_data) {
     return Make(indices_type, indices_type, shape, non_zero_length, indptr_data,
                 indices_data);
   }

--- a/cpp/src/arrow/testing/generator.cc
+++ b/cpp/src/arrow/testing/generator.cc
@@ -187,7 +187,7 @@ std::shared_ptr<RecordBatch> ConstantArrayGenerator::Zeroes(
 }
 
 std::shared_ptr<RecordBatchReader> ConstantArrayGenerator::Repeat(
-    int64_t n_batch, const std::shared_ptr<RecordBatch> batch) {
+    int64_t n_batch, const std::shared_ptr<RecordBatch>& batch) {
   std::vector<std::shared_ptr<RecordBatch>> batches(static_cast<size_t>(n_batch), batch);
   return *RecordBatchReader::Make(batches);
 }

--- a/cpp/src/arrow/testing/generator.h
+++ b/cpp/src/arrow/testing/generator.h
@@ -231,7 +231,7 @@ class ARROW_TESTING_EXPORT ConstantArrayGenerator {
   ///
   /// \return a generated RecordBatchReader
   static std::shared_ptr<RecordBatchReader> Repeat(
-      int64_t n_batch, const std::shared_ptr<RecordBatch> batch);
+      int64_t n_batch, const std::shared_ptr<RecordBatch>& batch);
 
   /// \brief Generates a RecordBatchReader of zeroes batches
   ///

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -427,7 +427,7 @@ struct SmallDecimalGenerator {
 
 }  // namespace
 
-std::shared_ptr<Array> RandomArrayGenerator::Decimal32(std::shared_ptr<DataType> type,
+std::shared_ptr<Array> RandomArrayGenerator::Decimal32(const std::shared_ptr<DataType>& type,
                                                        int64_t size,
                                                        double null_probability,
                                                        int64_t alignment,
@@ -436,7 +436,7 @@ std::shared_ptr<Array> RandomArrayGenerator::Decimal32(std::shared_ptr<DataType>
   return gen.MakeRandomArray(size, null_probability, alignment, memory_pool);
 }
 
-std::shared_ptr<Array> RandomArrayGenerator::Decimal64(std::shared_ptr<DataType> type,
+std::shared_ptr<Array> RandomArrayGenerator::Decimal64(const std::shared_ptr<DataType>& type,
                                                        int64_t size,
                                                        double null_probability,
                                                        int64_t alignment,
@@ -445,7 +445,7 @@ std::shared_ptr<Array> RandomArrayGenerator::Decimal64(std::shared_ptr<DataType>
   return gen.MakeRandomArray(size, null_probability, alignment, memory_pool);
 }
 
-std::shared_ptr<Array> RandomArrayGenerator::Decimal128(std::shared_ptr<DataType> type,
+std::shared_ptr<Array> RandomArrayGenerator::Decimal128(const std::shared_ptr<DataType>& type,
                                                         int64_t size,
                                                         double null_probability,
                                                         int64_t alignment,
@@ -454,7 +454,7 @@ std::shared_ptr<Array> RandomArrayGenerator::Decimal128(std::shared_ptr<DataType
   return gen.MakeRandomArray(size, null_probability, alignment, memory_pool);
 }
 
-std::shared_ptr<Array> RandomArrayGenerator::Decimal256(std::shared_ptr<DataType> type,
+std::shared_ptr<Array> RandomArrayGenerator::Decimal256(const std::shared_ptr<DataType>& type,
                                                         int64_t size,
                                                         double null_probability,
                                                         int64_t alignment,

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -310,7 +310,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] memory_pool memory pool to allocate memory from
   ///
   /// \return a generated Array
-  std::shared_ptr<Array> Decimal32(std::shared_ptr<DataType> type, int64_t size,
+  std::shared_ptr<Array> Decimal32(const std::shared_ptr<DataType>& type, int64_t size,
                                    double null_probability = 0,
                                    int64_t alignment = kDefaultBufferAlignment,
                                    MemoryPool* memory_pool = default_memory_pool());
@@ -325,7 +325,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] memory_pool memory pool to allocate memory from
   ///
   /// \return a generated Array
-  std::shared_ptr<Array> Decimal64(std::shared_ptr<DataType> type, int64_t size,
+  std::shared_ptr<Array> Decimal64(const std::shared_ptr<DataType>& type, int64_t size,
                                    double null_probability = 0,
                                    int64_t alignment = kDefaultBufferAlignment,
                                    MemoryPool* memory_pool = default_memory_pool());
@@ -340,7 +340,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] memory_pool memory pool to allocate memory from
   ///
   /// \return a generated Array
-  std::shared_ptr<Array> Decimal128(std::shared_ptr<DataType> type, int64_t size,
+  std::shared_ptr<Array> Decimal128(const std::shared_ptr<DataType>& type, int64_t size,
                                     double null_probability = 0,
                                     int64_t alignment = kDefaultBufferAlignment,
                                     MemoryPool* memory_pool = default_memory_pool());
@@ -355,7 +355,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] memory_pool memory pool to allocate memory from
   ///
   /// \return a generated Array
-  std::shared_ptr<Array> Decimal256(std::shared_ptr<DataType> type, int64_t size,
+  std::shared_ptr<Array> Decimal256(const std::shared_ptr<DataType>& type, int64_t size,
                                     double null_probability = 0,
                                     int64_t alignment = kDefaultBufferAlignment,
                                     MemoryPool* memory_pool = default_memory_pool());

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -225,7 +225,7 @@ class RandomNumericArrayTest : public ::testing::Test {
  protected:
   std::shared_ptr<Field> GetField() { return field("field0", std::make_shared<T>()); }
 
-  std::shared_ptr<NumericArray<T>> Downcast(std::shared_ptr<Array> array) {
+  std::shared_ptr<NumericArray<T>> Downcast(const std::shared_ptr<Array>& array) {
     return internal::checked_pointer_cast<NumericArray<T>>(array);
   }
 };

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1988,22 +1988,22 @@ void CheckListListTypeMetadata(ListListTypeFactory list_type_factory) {
 }
 
 TEST(TestListType, Metadata) {
-  CheckListListTypeMetadata([](std::shared_ptr<Field> field) { return list(field); });
+  CheckListListTypeMetadata([](const std::shared_ptr<Field>& field) { return list(field); });
 }
 
 TEST(TestLargeListType, Metadata) {
   CheckListListTypeMetadata(
-      [](std::shared_ptr<Field> field) { return large_list(field); });
+      [](const std::shared_ptr<Field>& field) { return large_list(field); });
 }
 
 TEST(TestListViewType, Metadata) {
   CheckListListTypeMetadata(
-      [](std::shared_ptr<Field> field) { return list_view(field); });
+      [](const std::shared_ptr<Field>& field) { return list_view(field); });
 }
 
 TEST(TestLargeListViewType, Metadata) {
   CheckListListTypeMetadata(
-      [](std::shared_ptr<Field> field) { return large_list_view(field); });
+      [](const std::shared_ptr<Field>& field) { return large_list_view(field); });
 }
 
 TEST(TestNestedType, Equals) {

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1764,7 +1764,7 @@ class BackgroundGenerator {
     State* state;
   };
 
-  static void WorkerTask(std::shared_ptr<State> state) {
+  static void WorkerTask(const std::shared_ptr<State>& state) {
     state->worker_thread_id.store(::arrow::internal::GetThreadId());
     // We need to capture the state to read while outside the mutex
     bool reading = true;

--- a/cpp/src/arrow/util/bitmap_test.cc
+++ b/cpp/src/arrow/util/bitmap_test.cc
@@ -1495,7 +1495,7 @@ TEST(Bitmap, ShiftingWordsOptimization) {
 
 namespace {
 
-static Bitmap Copy(const Bitmap& bitmap, std::shared_ptr<Buffer> storage) {
+static Bitmap Copy(const Bitmap& bitmap, const std::shared_ptr<Buffer>& storage) {
   int64_t i = 0;
   Bitmap bitmaps[] = {bitmap};
   auto min_offset = Bitmap::VisitWords(bitmaps, [&](std::array<uint64_t, 1> uint64s) {

--- a/cpp/src/arrow/util/cancel.cc
+++ b/cpp/src/arrow/util/cancel.cc
@@ -239,7 +239,7 @@ struct SignalStopState : public std::enable_shared_from_this<SignalStopState> {
     ReinstateSignalHandler(signum, &HandleSignal);
   }
 
-  static void ReceiveSignals(std::shared_ptr<SelfPipe> self_pipe) {
+  static void ReceiveSignals(const std::shared_ptr<SelfPipe>& self_pipe) {
     // Wait for signals on the self-pipe and propagate them to the current StopSource
     DCHECK(self_pipe);
     while (true) {

--- a/cpp/src/arrow/util/compression_test.cc
+++ b/cpp/src/arrow/util/compression_test.cc
@@ -224,8 +224,8 @@ void CheckStreamingDecompressor(Codec* codec, const std::vector<uint8_t>& data) 
 
 // Check the streaming compressor and decompressor together
 
-void CheckStreamingRoundtrip(std::shared_ptr<Compressor> compressor,
-                             std::shared_ptr<Decompressor> decompressor,
+void CheckStreamingRoundtrip(const std::shared_ptr<Compressor>& compressor,
+                             const std::shared_ptr<Decompressor>& decompressor,
                              const std::vector<uint8_t>& data) {
   std::default_random_engine engine(42);
   std::uniform_int_distribution<int> buf_size_distribution(10, 40);

--- a/cpp/src/arrow/util/delimiting.cc
+++ b/cpp/src/arrow/util/delimiting.cc
@@ -103,10 +103,10 @@ std::shared_ptr<BoundaryFinder> MakeNewlineBoundaryFinder() {
 
 Chunker::~Chunker() {}
 
-Chunker::Chunker(std::shared_ptr<BoundaryFinder> delimiter)
+Chunker::Chunker(const std::shared_ptr<BoundaryFinder>& delimiter)
     : boundary_finder_(delimiter) {}
 
-Status Chunker::Process(std::shared_ptr<Buffer> block, std::shared_ptr<Buffer>* whole,
+Status Chunker::Process(const std::shared_ptr<Buffer>& block, std::shared_ptr<Buffer>* whole,
                         std::shared_ptr<Buffer>* partial) {
   int64_t last_pos = -1;
   RETURN_NOT_OK(boundary_finder_->FindLast(std::string_view(*block), &last_pos));
@@ -122,8 +122,8 @@ Status Chunker::Process(std::shared_ptr<Buffer> block, std::shared_ptr<Buffer>* 
   return Status::OK();
 }
 
-Status Chunker::ProcessWithPartial(std::shared_ptr<Buffer> partial,
-                                   std::shared_ptr<Buffer> block,
+Status Chunker::ProcessWithPartial(const std::shared_ptr<Buffer>& partial,
+                                   const std::shared_ptr<Buffer>& block,
                                    std::shared_ptr<Buffer>* completion,
                                    std::shared_ptr<Buffer>* rest) {
   if (partial->size() == 0) {
@@ -145,7 +145,7 @@ Status Chunker::ProcessWithPartial(std::shared_ptr<Buffer> partial,
   }
 }
 
-Status Chunker::ProcessFinal(std::shared_ptr<Buffer> partial,
+Status Chunker::ProcessFinal(const std::shared_ptr<Buffer>& partial,
                              std::shared_ptr<Buffer> block,
                              std::shared_ptr<Buffer>* completion,
                              std::shared_ptr<Buffer>* rest) {
@@ -169,7 +169,7 @@ Status Chunker::ProcessFinal(std::shared_ptr<Buffer> partial,
   return Status::OK();
 }
 
-Status Chunker::ProcessSkip(std::shared_ptr<Buffer> partial,
+Status Chunker::ProcessSkip(const std::shared_ptr<Buffer>& partial,
                             std::shared_ptr<Buffer> block, bool final, int64_t* count,
                             std::shared_ptr<Buffer>* rest) {
   DCHECK_GT(*count, 0);

--- a/cpp/src/arrow/util/delimiting.h
+++ b/cpp/src/arrow/util/delimiting.h
@@ -82,7 +82,7 @@ std::shared_ptr<BoundaryFinder> MakeNewlineBoundaryFinder();
 /// which can only parse whole objects).
 class ARROW_EXPORT Chunker {
  public:
-  explicit Chunker(std::shared_ptr<BoundaryFinder> delimiter);
+  explicit Chunker(const std::shared_ptr<BoundaryFinder>& delimiter);
   ~Chunker();
 
   /// \brief Carve up a chunk in a block of data to contain only whole objects
@@ -104,7 +104,7 @@ class ARROW_EXPORT Chunker {
   /// \param[in] block data to be chunked
   /// \param[out] whole subrange of block containing whole delimited objects
   /// \param[out] partial subrange of block starting with a partial delimited object
-  Status Process(std::shared_ptr<Buffer> block, std::shared_ptr<Buffer>* whole,
+  Status Process(const std::shared_ptr<Buffer>& block, std::shared_ptr<Buffer>* whole,
                  std::shared_ptr<Buffer>* partial);
 
   /// \brief Carve the completion of a partial object out of a block
@@ -128,8 +128,8 @@ class ARROW_EXPORT Chunker {
   /// \param[in] block delimited data following partial
   /// \param[out] completion subrange of block containing the completion of partial
   /// \param[out] rest subrange of block containing what completion does not cover
-  Status ProcessWithPartial(std::shared_ptr<Buffer> partial,
-                            std::shared_ptr<Buffer> block,
+  Status ProcessWithPartial(const std::shared_ptr<Buffer>& partial,
+                            const std::shared_ptr<Buffer>& block,
                             std::shared_ptr<Buffer>* completion,
                             std::shared_ptr<Buffer>* rest);
 
@@ -148,7 +148,7 @@ class ARROW_EXPORT Chunker {
   /// - `completion` doesn't contain an entire delimited object
   ///   (IOW: `completion` is generally small)
   ///
-  Status ProcessFinal(std::shared_ptr<Buffer> partial, std::shared_ptr<Buffer> block,
+  Status ProcessFinal(const std::shared_ptr<Buffer>& partial, std::shared_ptr<Buffer> block,
                       std::shared_ptr<Buffer>* completion, std::shared_ptr<Buffer>* rest);
 
   /// \brief Skip count number of rows
@@ -169,7 +169,7 @@ class ARROW_EXPORT Chunker {
   /// \param[in] final whether this is the final chunk
   /// \param[in,out] count number of rows that need to be skipped
   /// \param[out] rest subrange of block containing what was not skipped
-  Status ProcessSkip(std::shared_ptr<Buffer> partial, std::shared_ptr<Buffer> block,
+  Status ProcessSkip(const std::shared_ptr<Buffer>& partial, std::shared_ptr<Buffer> block,
                      bool final, int64_t* count, std::shared_ptr<Buffer>* rest);
 
  protected:

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -1056,7 +1056,7 @@ std::vector<uint8_t> EncodeTestArray(const Array& data, int bit_width,
 ///         is valid.
 template <typename Type>
 void CheckRoundTrip(const Array& data, int bit_width, bool spaced, int32_t parts,
-                    std::shared_ptr<FloatArray> dict = {}) {
+                    const std::shared_ptr<FloatArray>& dict = {}) {
   using ArrayType = typename TypeTraits<Type>::ArrayType;
   using value_type = typename Type::c_type;
 

--- a/cpp/src/arrow/util/task_group_test.cc
+++ b/cpp/src/arrow/util/task_group_test.cc
@@ -50,7 +50,7 @@ static std::vector<double> RandomSleepDurations(int nsleeps, double min_seconds,
 }
 
 // Check TaskGroup behaviour with a bunch of all-successful tasks
-void TestTaskGroupSuccess(std::shared_ptr<TaskGroup> task_group) {
+void TestTaskGroupSuccess(const std::shared_ptr<TaskGroup>& task_group) {
   const int NTASKS = 10;
   auto sleeps = RandomSleepDurations(NTASKS, 1e-3, 4e-3);
 
@@ -73,7 +73,7 @@ void TestTaskGroupSuccess(std::shared_ptr<TaskGroup> task_group) {
 }
 
 // Check TaskGroup behaviour with some successful and some failing tasks
-void TestTaskGroupErrors(std::shared_ptr<TaskGroup> task_group) {
+void TestTaskGroupErrors(const std::shared_ptr<TaskGroup>& task_group) {
   const int NSUCCESSES = 2;
   const int NERRORS = 20;
 
@@ -115,7 +115,7 @@ void TestTaskGroupErrors(std::shared_ptr<TaskGroup> task_group) {
   ASSERT_RAISES(Invalid, task_group->Finish());
 }
 
-void TestTaskGroupCancel(std::shared_ptr<TaskGroup> task_group, StopSource* stop_source) {
+void TestTaskGroupCancel(const std::shared_ptr<TaskGroup>& task_group, StopSource* stop_source) {
   const int NSUCCESSES = 2;
   const int NCANCELS = 20;
 
@@ -186,7 +186,7 @@ class CopyCountingTask {
 };
 
 // Check TaskGroup behaviour with tasks spawning other tasks
-void TestTasksSpawnTasks(std::shared_ptr<TaskGroup> task_group) {
+void TestTasksSpawnTasks(const std::shared_ptr<TaskGroup>& task_group) {
   const int N = 6;
 
   std::atomic<int> count(0);
@@ -280,7 +280,7 @@ void StressFailingTaskGroupLifetime(std::function<std::shared_ptr<TaskGroup>()> 
   }
 }
 
-void TestNoCopyTask(std::shared_ptr<TaskGroup> task_group) {
+void TestNoCopyTask(const std::shared_ptr<TaskGroup>& task_group) {
   auto counter = std::make_shared<uint8_t>(0);
   CopyCountingTask task(counter);
   task_group->Append(std::move(task));
@@ -327,7 +327,7 @@ void TestFinishNotSticky(std::function<std::shared_ptr<TaskGroup>()> factory) {
   }
 }
 
-void TestFinishNeverStarted(std::shared_ptr<TaskGroup> task_group) {
+void TestFinishNeverStarted(const std::shared_ptr<TaskGroup>& task_group) {
   // If we call FinishAsync we are done adding tasks so if we never added any it should be
   // completed
   auto finished = task_group->FinishAsync();


### PR DESCRIPTION
This is a followup to #51147. (Context: I’m experimenting with writing a Claude skill that implements coding guidelines, and I picked "`shared_ptr` passed by value creating needless refcount inc/dec" because this has always been the top performance pitfall of using `shared_ptr`. When I asked Claude to list some popular GitHub repos that seemed to have a lot of violations, apache/arrow was one of the top five Claude flagged. **I reviewed the changes in this PR; this is not a blind dump of unreviewed random AI suggestions.**)

### Rationale for this change

When a `shared_ptr` parameter is passed by value but not moved from (or assigned to or otherwise modified), the unused refcount inc/dec traffic is wasted effort. See also #31567, "Overhead of `std::shared_ptr<DataType>` copies is causing thread contention."

Compilers don't optimize out this extra refcount traffic, so we need to remove it from the code. The least invasive fix is to pass the `shared_ptr` by `const&` instead.

### What changes are included in this PR?

This PR changes about 400 `shared_ptr` parameters from pass by value to pass by `const&`.

**I reviewed each change Claude suggested, so any mistakes are my fault.**

### Are these changes tested?

Only for clean compilation. I'm not familiar enough with the project (sorry) to run tests, especially performance tests (which I hope might improve); this is why I asked for help in #51147, and @pitrou and @rok graciously responded (thanks again!).

The main source of potential bugs I can think of that could be introduced by changing a parameter to pass-by-reference would be if the function body modified the parameter, in which case the change would become a side effect on the caller's argument; obviously that would be bad. This PR prevents that by ensuring all affected parameters are also `const`, and so the function body would not compile if it tried to modify the affected parameter.

### Are there any user-facing changes?

No.