### PR TITLE
GH-51273: [Ruby] Add FixedSizeListArray values constructor

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -1093,7 +1093,15 @@ module ArrowFormat
 
   class FixedSizeListArray < Array
     attr_reader :child
-    def initialize(type, size, validity_buffer, child)
+    def initialize(type, *args)
+      if args.size == 1
+        args = build_data(type, args.first)
+      elsif args.size != 3
+        raise ArgumentError,
+              "wrong number of arguments (given #{args.size + 1}, expected 2 or 4)"
+      end
+
+      size, validity_buffer, child = args
       super(type, size, validity_buffer)
       @child = child
     end
@@ -1112,6 +1120,36 @@ module ArrowFormat
     end
 
     private
+    def build_data(type, data)
+      n = 0
+      validity_buffer_builder = nil
+
+      child_values = []
+      data.each_with_index do |value, i|
+        if value.nil?
+          validity_buffer_builder ||= SparseBitmapBuilder.new
+          validity_buffer_builder.unset(i)
+          child_values.concat([nil] * type.size)
+        else
+          unless value.size == type.size
+            message = "list size must be #{type.size}: #{value.inspect}"
+            raise ArgumentError, message
+          end
+          child_values.concat(value)
+        end
+        n += 1
+      end
+
+      validity_buffer = validity_buffer_builder&.finish(n)
+      child = type.child.type.build_array(child_values)
+
+      [
+        n,
+        validity_buffer,
+        child,
+      ]
+    end
+
     def slice!(offset, size)
       super
       @child = @child.slice(@type.size * @offset,

--- a/ruby/red-arrow-format/test/test-fixed-size-list-array.rb
+++ b/ruby/red-arrow-format/test/test-fixed-size-list-array.rb
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeListArray < Test::Unit::TestCase
+  def setup
+    child = ArrowFormat::Field.new("item", ArrowFormat::Int16Type.singleton)
+    @type = ArrowFormat::FixedSizeListType.new(child, 2)
+  end
+
+  sub_test_case("#initialize") do
+    def test_no_null
+      values = [[-1, 0], [1, 2]]
+      array = ArrowFormat::FixedSizeListArray.new(@type, values)
+      assert_same(@type, array.type)
+      assert_same(@type.child.type, array.child.type)
+      assert_equal(values, array.to_a)
+    end
+
+    def test_null_list
+      values = [[1, 2], nil, [3, 4]]
+      array = ArrowFormat::FixedSizeListArray.new(@type, values)
+      assert_equal(1, array.n_nulls)
+      assert_equal([1, 2, nil, nil, 3, 4], array.child.to_a)
+      assert_equal(values, array.to_a)
+    end
+
+    def test_null_child
+      values = [[1, nil], [nil, 2]]
+      array = ArrowFormat::FixedSizeListArray.new(@type, values)
+      assert_equal(2, array.child.n_nulls)
+      assert_equal(values, array.to_a)
+    end
+
+    def test_invalid_list_size
+      message = "list size must be 2: [1]"
+      assert_raise(ArgumentError.new(message)) do
+        ArrowFormat::FixedSizeListArray.new(@type, [[1]])
+      end
+    end
+
+    def test_empty
+      array = ArrowFormat::FixedSizeListArray.new(@type, [])
+      assert_equal([], array.child.to_a)
+      assert_equal([], array.to_a)
+    end
+
+    def test_low_level
+      child = ArrowFormat::Int16Array.new([1, 2])
+      array = ArrowFormat::FixedSizeListArray.new(@type, 1, nil, child)
+      assert_equal([[1, 2]], array.to_a)
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change

GH-50382 requests explicit value constructors for all existing `ArrowFormat::Type` subclasses before the broader builder API is exposed. Fixed-size lists still require callers to manually construct the parent validity buffer and flattened child array.

This is the focused fixed-size-list prerequisite requested in the GH-50382 maintainer discussion. It is distinct from variable-size `ListArray` support in GH-51262.

### What changes are included in this PR?

- Add `ArrowFormat::FixedSizeListArray.new(type, values)` while preserving the existing low-level four-argument constructor.
- Build the parent validity bitmap and the child array from nested Ruby values.
- Preserve exactly `type.size` child slots for null parent lists.
- Reject non-null lists whose size differs from the declared fixed size.
- Delegate child construction to the declared child field type.
- Add focused coverage for typed construction, parent and child nulls, invalid sizes, empty input, and the low-level constructor.

### Are these changes tested?

Yes.

```console
RUBYLIB=/opt/homebrew/lib/ruby/gems/4.0.0/gems/red-arrow-25.0.1/lib GI_TYPELIB_PATH=/opt/homebrew/lib/girepository-1.0 bundle exec ruby test/run.rb test-fixed-size-list-array.rb
# 6 tests, 12 assertions, 0 failures, 0 errors

RUBYLIB=/opt/homebrew/lib/ruby/gems/4.0.0/gems/red-arrow-25.0.1/lib GI_TYPELIB_PATH=/opt/homebrew/lib/girepository-1.0 bundle exec rake test
# 696 tests, 705 assertions, 0 failures, 0 errors
```

I also wrote an Arrow IPC file containing `[[1, 2], nil, [3, nil]]` with the new constructor and loaded it with the native Arrow reader; the values round-tripped unchanged.

The tests use the current `red-arrow-format` sources with the locally installed Arrow 25.0.1 native extension. Upstream CI remains authoritative for the matching main-branch native runtime.

### Are there any user-facing changes?

Yes. `ArrowFormat::FixedSizeListArray` gains a two-argument values constructor. The existing low-level constructor remains supported.

### AI assistance disclosure

OpenAI Codex assisted with issue research, implementation, test generation, validation commands, and drafting this pull request. The submitted behavior is supported by the focused regression, full package suite, and IPC round-trip results above.
* GitHub Issue: #51273