### PR TITLE
GH-36010: [GLib][Ruby][Parquet] Add buffered reader properties

### DIFF
--- a/c_glib/parquet-glib/arrow-file-reader.cpp
+++ b/c_glib/parquet-glib/arrow-file-reader.cpp
@@ -25,6 +25,33 @@
 
 #include <parquet/file_reader.h>
 
+namespace {
+  GParquetArrowFileReader *
+  open_reader_with_properties(std::shared_ptr<arrow::io::RandomAccessFile> source,
+                              GParquetReaderProperties *properties,
+                              GError **error,
+                              const char *tag)
+  {
+    auto parquet_properties = properties ? gparquet_reader_properties_get_raw(properties)
+                                         : parquet::default_reader_properties();
+    parquet::arrow::FileReaderBuilder builder;
+    if (!garrow::check(error, builder.Open(source, parquet_properties), tag)) {
+      return NULL;
+    }
+    if (parquet_properties.is_buffered_stream_enabled()) {
+      // Read-ahead would bypass the buffered stream by caching whole column chunks.
+      auto arrow_properties = parquet::default_arrow_reader_properties();
+      arrow_properties.set_pre_buffer(false);
+      builder.properties(arrow_properties);
+    }
+    auto result = builder.Build();
+    if (!garrow::check(error, result, tag)) {
+      return NULL;
+    }
+    return gparquet_arrow_file_reader_new_raw(result->release());
+  }
+} // namespace
+
 G_BEGIN_DECLS
 
 /**
@@ -32,13 +59,145 @@ G_BEGIN_DECLS
  * @short_description: Arrow file reader class
  * @include: parquet-glib/parquet-glib.h
  *
+ * #GParquetReaderProperties is a class for configuring Parquet reads.
+ *
  * #GParquetArrowFileReader is a class for reading Apache Parquet data
  * from file and returns them as Apache Arrow data.
  */
 
+typedef struct GParquetReaderPropertiesPrivate_
+{
+  parquet::ReaderProperties properties;
+} GParquetReaderPropertiesPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GParquetReaderProperties,
+                           gparquet_reader_properties,
+                           G_TYPE_OBJECT)
+
+#define GPARQUET_READER_PROPERTIES_GET_PRIVATE(object)                                   \
+  static_cast<GParquetReaderPropertiesPrivate *>(                                        \
+    gparquet_reader_properties_get_instance_private(GPARQUET_READER_PROPERTIES(object)))
+
+static void
+gparquet_reader_properties_finalize(GObject *object)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(object);
+  priv->properties.~ReaderProperties();
+  G_OBJECT_CLASS(gparquet_reader_properties_parent_class)->finalize(object);
+}
+
+static void
+gparquet_reader_properties_init(GParquetReaderProperties *object)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(object);
+  new (&priv->properties) parquet::ReaderProperties(parquet::default_reader_properties());
+}
+
+static void
+gparquet_reader_properties_class_init(GParquetReaderPropertiesClass *klass)
+{
+  G_OBJECT_CLASS(klass)->finalize = gparquet_reader_properties_finalize;
+}
+
+/**
+ * gparquet_reader_properties_new:
+ *
+ * Returns: A newly created #GParquetReaderProperties.
+ *
+ * Since: 26.0.0
+ */
+GParquetReaderProperties *
+gparquet_reader_properties_new(void)
+{
+  return GPARQUET_READER_PROPERTIES(g_object_new(GPARQUET_TYPE_READER_PROPERTIES, NULL));
+}
+
+/**
+ * gparquet_reader_properties_enable_buffered_stream:
+ * @properties: A #GParquetReaderProperties.
+ *
+ * Enable buffered stream reading. Readers constructed with these properties
+ * disable read-ahead of whole column chunks to use buffered streams instead.
+ * This does not impose a limit on the memory used by decoded data.
+ *
+ * Since: 26.0.0
+ */
+void
+gparquet_reader_properties_enable_buffered_stream(GParquetReaderProperties *properties)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(properties);
+  priv->properties.enable_buffered_stream();
+}
+
+/**
+ * gparquet_reader_properties_disable_buffered_stream:
+ * @properties: A #GParquetReaderProperties.
+ *
+ * Disable buffered stream reading. This is the default.
+ *
+ * Since: 26.0.0
+ */
+void
+gparquet_reader_properties_disable_buffered_stream(GParquetReaderProperties *properties)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(properties);
+  priv->properties.disable_buffered_stream();
+}
+
+/**
+ * gparquet_reader_properties_is_buffered_stream_enabled:
+ * @properties: A #GParquetReaderProperties.
+ *
+ * Returns: %TRUE if buffered stream reading is enabled, %FALSE otherwise.
+ *
+ * Since: 26.0.0
+ */
+gboolean
+gparquet_reader_properties_is_buffered_stream_enabled(
+  GParquetReaderProperties *properties)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(properties);
+  return priv->properties.is_buffered_stream_enabled();
+}
+
+/**
+ * gparquet_reader_properties_set_buffer_size:
+ * @properties: A #GParquetReaderProperties.
+ * @buffer_size: The buffer size in bytes. This must be positive when buffering is
+ * enabled.
+ *
+ * Set the buffered stream size. This does not enable buffered stream reading.
+ * Reads required for a data page may exceed this size.
+ *
+ * Since: 26.0.0
+ */
+void
+gparquet_reader_properties_set_buffer_size(GParquetReaderProperties *properties,
+                                           gint64 buffer_size)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(properties);
+  priv->properties.set_buffer_size(buffer_size);
+}
+
+/**
+ * gparquet_reader_properties_get_buffer_size:
+ * @properties: A #GParquetReaderProperties.
+ *
+ * Returns: The buffered stream size in bytes.
+ *
+ * Since: 26.0.0
+ */
+gint64
+gparquet_reader_properties_get_buffer_size(GParquetReaderProperties *properties)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(properties);
+  return priv->properties.buffer_size();
+}
+
 typedef struct GParquetArrowFileReaderPrivate_
 {
   parquet::arrow::FileReader *arrow_file_reader;
+  GArrowSeekableInputStream *source;
 } GParquetArrowFileReaderPrivate;
 
 enum {
@@ -53,6 +212,14 @@ G_DEFINE_TYPE_WITH_PRIVATE(GParquetArrowFileReader,
 #define GPARQUET_ARROW_FILE_READER_GET_PRIVATE(obj)                                      \
   static_cast<GParquetArrowFileReaderPrivate *>(                                         \
     gparquet_arrow_file_reader_get_instance_private(GPARQUET_ARROW_FILE_READER(obj)))
+
+static void
+gparquet_arrow_file_reader_dispose(GObject *object)
+{
+  auto priv = GPARQUET_ARROW_FILE_READER_GET_PRIVATE(object);
+  g_clear_object(&priv->source);
+  G_OBJECT_CLASS(gparquet_arrow_file_reader_parent_class)->dispose(object);
+}
 
 static void
 gparquet_arrow_file_reader_finalize(GObject *object)
@@ -108,6 +275,7 @@ gparquet_arrow_file_reader_class_init(GParquetArrowFileReaderClass *klass)
 
   auto gobject_class = G_OBJECT_CLASS(klass);
 
+  gobject_class->dispose = gparquet_arrow_file_reader_dispose;
   gobject_class->finalize = gparquet_arrow_file_reader_finalize;
   gobject_class->set_property = gparquet_arrow_file_reader_set_property;
   gobject_class->get_property = gparquet_arrow_file_reader_get_property;
@@ -179,6 +347,63 @@ gparquet_arrow_file_reader_new_path(const gchar *path, GError **error)
   } else {
     return NULL;
   }
+}
+
+/**
+ * gparquet_arrow_file_reader_new_arrow_with_properties:
+ * @source: Arrow source to be read.
+ * @properties: (nullable): Reader properties or %NULL for the defaults.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * The reader copies @properties at construction. Later changes to @properties
+ * do not affect the reader. The native source is retained by the reader.
+ *
+ * Returns: (nullable): A newly created #GParquetArrowFileReader.
+ *
+ * Since: 26.0.0
+ */
+GParquetArrowFileReader *
+gparquet_arrow_file_reader_new_arrow_with_properties(GArrowSeekableInputStream *source,
+                                                     GParquetReaderProperties *properties,
+                                                     GError **error)
+{
+  auto reader = open_reader_with_properties(
+    garrow_seekable_input_stream_get_raw(source),
+    properties,
+    error,
+    "[parquet][arrow][file-reader][new-arrow-with-properties]");
+  if (reader) {
+    auto priv = GPARQUET_ARROW_FILE_READER_GET_PRIVATE(reader);
+    priv->source = GARROW_SEEKABLE_INPUT_STREAM(g_object_ref(source));
+  }
+  return reader;
+}
+
+/**
+ * gparquet_arrow_file_reader_new_path_with_properties:
+ * @path: Path to be read.
+ * @properties: (nullable): Reader properties or %NULL for the defaults.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * The reader copies @properties at construction. Later changes to @properties
+ * do not affect the reader. The file is memory mapped, as with
+ * gparquet_arrow_file_reader_new_path().
+ *
+ * Returns: (nullable): A newly created #GParquetArrowFileReader.
+ *
+ * Since: 26.0.0
+ */
+GParquetArrowFileReader *
+gparquet_arrow_file_reader_new_path_with_properties(const gchar *path,
+                                                    GParquetReaderProperties *properties,
+                                                    GError **error)
+{
+  const char *tag = "[parquet][arrow][file-reader][new-path-with-properties]";
+  auto source = arrow::io::MemoryMappedFile::Open(path, arrow::io::FileMode::READ);
+  if (!garrow::check(error, source, tag)) {
+    return NULL;
+  }
+  return open_reader_with_properties(*source, properties, error, tag);
 }
 
 /**
@@ -425,4 +650,11 @@ gparquet_arrow_file_reader_get_raw(GParquetArrowFileReader *arrow_file_reader)
 {
   auto priv = GPARQUET_ARROW_FILE_READER_GET_PRIVATE(arrow_file_reader);
   return priv->arrow_file_reader;
+}
+
+parquet::ReaderProperties
+gparquet_reader_properties_get_raw(GParquetReaderProperties *properties)
+{
+  auto priv = GPARQUET_READER_PROPERTIES_GET_PRIVATE(properties);
+  return priv->properties;
 }

--- a/c_glib/parquet-glib/arrow-file-reader.h
+++ b/c_glib/parquet-glib/arrow-file-reader.h
@@ -23,6 +23,41 @@
 
 G_BEGIN_DECLS
 
+#define GPARQUET_TYPE_READER_PROPERTIES (gparquet_reader_properties_get_type())
+GPARQUET_AVAILABLE_IN_26_0
+G_DECLARE_DERIVABLE_TYPE(GParquetReaderProperties,
+                         gparquet_reader_properties,
+                         GPARQUET,
+                         READER_PROPERTIES,
+                         GObject)
+struct _GParquetReaderPropertiesClass
+{
+  GObjectClass parent_class;
+};
+
+GPARQUET_AVAILABLE_IN_26_0
+GParquetReaderProperties *
+gparquet_reader_properties_new(void);
+
+GPARQUET_AVAILABLE_IN_26_0
+void
+gparquet_reader_properties_enable_buffered_stream(GParquetReaderProperties *properties);
+GPARQUET_AVAILABLE_IN_26_0
+void
+gparquet_reader_properties_disable_buffered_stream(GParquetReaderProperties *properties);
+GPARQUET_AVAILABLE_IN_26_0
+gboolean
+gparquet_reader_properties_is_buffered_stream_enabled(
+  GParquetReaderProperties *properties);
+
+GPARQUET_AVAILABLE_IN_26_0
+void
+gparquet_reader_properties_set_buffer_size(GParquetReaderProperties *properties,
+                                           gint64 buffer_size);
+GPARQUET_AVAILABLE_IN_26_0
+gint64
+gparquet_reader_properties_get_buffer_size(GParquetReaderProperties *properties);
+
 #define GPARQUET_TYPE_ARROW_FILE_READER (gparquet_arrow_file_reader_get_type())
 GPARQUET_AVAILABLE_IN_0_11
 G_DECLARE_DERIVABLE_TYPE(GParquetArrowFileReader,
@@ -42,6 +77,18 @@ gparquet_arrow_file_reader_new_arrow(GArrowSeekableInputStream *source, GError *
 GPARQUET_AVAILABLE_IN_0_11
 GParquetArrowFileReader *
 gparquet_arrow_file_reader_new_path(const gchar *path, GError **error);
+
+GPARQUET_AVAILABLE_IN_26_0
+GParquetArrowFileReader *
+gparquet_arrow_file_reader_new_arrow_with_properties(GArrowSeekableInputStream *source,
+                                                     GParquetReaderProperties *properties,
+                                                     GError **error);
+
+GPARQUET_AVAILABLE_IN_26_0
+GParquetArrowFileReader *
+gparquet_arrow_file_reader_new_path_with_properties(const gchar *path,
+                                                    GParquetReaderProperties *properties,
+                                                    GError **error);
 
 GPARQUET_AVAILABLE_IN_23_0
 void

--- a/c_glib/parquet-glib/arrow-file-reader.hpp
+++ b/c_glib/parquet-glib/arrow-file-reader.hpp
@@ -27,3 +27,5 @@ GParquetArrowFileReader *
 gparquet_arrow_file_reader_new_raw(parquet::arrow::FileReader *parquet_arrow_file_reader);
 parquet::arrow::FileReader *
 gparquet_arrow_file_reader_get_raw(GParquetArrowFileReader *arrow_file_reader);
+parquet::ReaderProperties
+gparquet_reader_properties_get_raw(GParquetReaderProperties *properties);

--- a/c_glib/test/parquet/test-arrow-file-reader.rb
+++ b/c_glib/test/parquet/test-arrow-file-reader.rb
@@ -39,6 +39,80 @@ class TestParquetArrowFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case(".new with properties") do
+    data("path" => :path, "stream" => :stream)
+    test("read") do |source_type|
+      properties = Parquet::ReaderProperties.new
+      properties.enable_buffered_stream
+      properties.buffer_size = 4096
+      source = if source_type == :path
+                 @file.path
+               else
+                 Arrow::FileInputStream.new(@file.path)
+               end
+      reader = Parquet::ArrowFileReader.new(source, properties)
+      begin
+        # The reader owns a copy of the properties and the native source.
+        properties.disable_buffered_stream
+        properties.buffer_size = 0
+        properties.unref
+        source.unref if source_type == :stream
+        assert_equal(@table, reader.read_table)
+        assert_equal(build_table("a" => @a_array.slice(1, 1),
+                                 "b" => @b_array.slice(1, 1)),
+                     reader.read_row_group(1))
+      ensure
+        reader.close
+        reader.unref
+      end
+    end
+
+    data("path" => :path, "stream" => :stream)
+    test("default properties") do |source_type|
+      source = if source_type == :path
+                 @file.path
+               else
+                 Arrow::FileInputStream.new(@file.path)
+               end
+      reader = Parquet::ArrowFileReader.new(source, nil)
+      begin
+        assert_equal(@table, reader.read_table)
+      ensure
+        reader.close
+        reader.unref
+        source.unref if source_type == :stream
+      end
+    end
+
+    test("missing path") do
+      properties = Parquet::ReaderProperties.new
+      assert_raise(Arrow::Error::Io) do
+        Parquet::ArrowFileReader.new("#{@file.path}.missing", properties)
+      end
+    end
+
+    data("path" => :path, "stream" => :stream)
+    test("invalid file") do |source_type|
+      Tempfile.create("invalid-parquet") do |file|
+        file.write("not a parquet file")
+        file.flush
+        source = if source_type == :path
+                   file.path
+                 else
+                   Arrow::FileInputStream.new(file.path)
+                 end
+        properties = Parquet::ReaderProperties.new
+        begin
+          assert_raise(Arrow::Error::Invalid) do
+            Parquet::ArrowFileReader.new(source, properties)
+          end
+        ensure
+          source.unref if source_type == :stream
+        end
+      end
+    end
+  end
+
   def test_schema
     assert_equal(<<-SCHEMA.chomp, @reader.schema.to_s)
 a: string

--- a/c_glib/test/parquet/test-reader-properties.rb
+++ b/c_glib/test/parquet/test-reader-properties.rb
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestParquetReaderProperties < Test::Unit::TestCase
+  def setup
+    omit("Parquet is required") unless defined?(::Parquet)
+    @properties = Parquet::ReaderProperties.new
+  end
+
+  def test_buffered_stream
+    assert_false(@properties.buffered_stream_enabled?)
+    @properties.enable_buffered_stream
+    assert_true(@properties.buffered_stream_enabled?)
+    @properties.disable_buffered_stream
+    assert_false(@properties.buffered_stream_enabled?)
+  end
+
+  def test_buffer_size
+    assert_equal(16 * 1024, @properties.buffer_size)
+    @properties.buffer_size = 32 * 1024
+    assert_equal(32 * 1024, @properties.buffer_size)
+    assert_false(@properties.buffered_stream_enabled?)
+  end
+end

--- a/ruby/red-parquet/test/test-arrow-file-reader.rb
+++ b/ruby/red-parquet/test/test-arrow-file-reader.rb
@@ -41,8 +41,10 @@ class TestArrowFileReader < Test::Unit::TestCase
                else
                  Arrow::FileInputStream.new(@file.path)
                end
+      reader = nil
       begin
-        Parquet::ArrowFileReader.open(source, properties) do |reader|
+        Parquet::ArrowFileReader.open(source, properties) do |opened_reader|
+          reader = opened_reader
           properties.disable_buffered_stream
           properties.buffer_size = 0
           assert_equal([
@@ -52,6 +54,8 @@ class TestArrowFileReader < Test::Unit::TestCase
                        reader.each_row_group.to_a)
         end
       ensure
+        # Release the memory-mapped path before Tempfile removes it on Windows.
+        reader&.unref
         source.close if source_type == :stream
       end
     end

--- a/ruby/red-parquet/test/test-arrow-file-reader.rb
+++ b/ruby/red-parquet/test/test-arrow-file-reader.rb
@@ -29,6 +29,34 @@ class TestArrowFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case(".open with properties") do
+    data("path" => :path, "stream" => :stream)
+    test("row groups") do |source_type|
+      properties = Parquet::ReaderProperties.new
+      properties.buffer_size = 4096
+      properties.enable_buffered_stream
+      assert_true(properties.buffered_stream_enabled?)
+      source = if source_type == :path
+                 @file.path
+               else
+                 Arrow::FileInputStream.new(@file.path)
+               end
+      begin
+        Parquet::ArrowFileReader.open(source, properties) do |reader|
+          properties.disable_buffered_stream
+          properties.buffer_size = 0
+          assert_equal([
+                         Arrow::Table.new(@schema, [[true]]),
+                         Arrow::Table.new(@schema, [[false]])
+                       ],
+                       reader.each_row_group.to_a)
+        end
+      ensure
+        source.close if source_type == :stream
+      end
+    end
+  end
+
   sub_test_case("#each_row_group") do
     test("block") do
       Arrow::FileInputStream.open(@file.path) do |input|


### PR DESCRIPTION
### Rationale for this change

GH-36010 requests Ruby bindings for `parquet::ReaderProperties`, following the buffered-read discussion in GH-36001. GLib currently opens readers with defaults, so Ruby cannot select buffered streams or their buffer size.

### What changes are included in this PR?

- Add `GParquetReaderProperties` with buffered-stream enable/disable/state and buffer-size get/set.
- Add source/path constructors accepting nullable reader properties. Existing constructor declarations and implementations remain unchanged. GI exposes the new overload as `Parquet::ArrowFileReader.new(source_or_path, properties)` without a Ruby adapter.
- Copy native properties into reader construction and retain the source GObject, whose disposal would otherwise close the shared native stream.
- When buffering is enabled, disable Arrow's whole-column read-ahead, which otherwise bypasses buffered streams. Default constructors and default properties retain their existing read-ahead behavior.

### Are these changes tested?

Fresh Debug C++/Parquet/GLib/introspection and native Ruby builds on macOS arm64, Ruby 4.0.6:

- Before the change: 9 focused GLib errors and 2 Ruby errors for the missing type/constructors.
- Focused GLib reader/properties tests: **14 tests, 20 assertions**, passing. These cover defaults, toggles, size, nullable properties, source/path reads, property mutation/destruction, source release and constructor errors.
- Full red-parquet: **18 tests, 24 assertions**, passing; full red-arrow: **2,667 tests, 2,675 assertions**, passing with two ORC omissions.
- Full GLib in the local core+Parquet configuration: **2,247 tests, 2,384 assertions**, passing with 173 optional/platform omissions. The local runner excludes incompatible installed Arrow 25 optional typelibs.
- A compiled C client exercises both old and both new constructor signatures. An instrumented native source used through the new Ruby overload verifies 10 real row-group/table reads, including unchanged defaults and property snapshots after mutation/destruction. For 100,000 uncompressed int64 values, default reading makes one 801,421-byte data read; 4 KiB buffering makes 50 reads (largest 16,413 bytes), and 32 KiB buffering makes 27 (largest 32,826 bytes). All read the same bytes and return the same table. This is an I/O behavior check, not an RSS measurement or a hard read-size cap.
- Clang-format 18.1.8, repository RuboCop 1.71.0, Ruby syntax, diff checks and the repository RAT audit pass.

### Are there any user-facing changes?

Ruby/GLib callers can opt into buffered Parquet reading and configure the buffer size. The API documentation explains the read-ahead interaction and that decoded data and individual page reads can exceed that size.

### AI assistance

OpenAI Codex generated the implementation, regression tests and local validation harnesses, and ran the checks described above.

* GitHub Issue: #36010