### PR TITLE
GH-51278: [C++] Fix build error in acero tests with gcc 16

### DIFF
--- a/cpp/src/arrow/acero/test_util_internal.cc
+++ b/cpp/src/arrow/acero/test_util_internal.cc
@@ -121,7 +121,7 @@ struct DummyNode : ExecNode {
  private:
   void AssertIsOutput(ExecNode* output) { ASSERT_EQ(output->output(), nullptr); }
 
-  std::shared_ptr<Schema> dummy_schema() const {
+  static std::shared_ptr<Schema> dummy_schema() {
     return schema({field("dummy", null())});
   }
 


### PR DESCRIPTION
### Rationale for this change

Fixes a "may be used uninitialized" build error encountered with gcc 16.2.1 (see #51278)

### What changes are included in this PR?

Change a test method to static.

### Are these changes tested?

Yes, I've built and run the acero tests.

### Are there any user-facing changes?

No

* GitHub Issue: #51278