### PR TITLE
GH-51283: [CI][Dev] Fix shellcheck errors in cpp/thirdparty/download_dependencies.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -287,10 +287,8 @@ repos:
           ?^cpp/build-support/.*\.sh$|
           ?^cpp/examples/minimal_build/run\.sh$|
           ?^cpp/examples/tutorial_examples/run\.sh$|
-          ?^cpp/src/arrow/flight/sql/odbc/install/mac/postinstall$|
-          ?^cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc\.sh$|
-          ?^cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc_ini\.sh$|
-          ?^cpp/src/arrow/flight/sql/odbc/tests/dremio/set_up_dremio_instance\.sh$|
+          ?^cpp/src/arrow/flight/.*\.sh$|
+          ?^cpp/thirdparty/download_dependencies\.sh$|
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/07-flightsqlodbc-upload\.sh$|
           ?^dev/release/08-publish-gh-release\.sh$|

--- a/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc_ini.sh
+++ b/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc_ini.sh
@@ -31,7 +31,7 @@ DRIVER_NAME="Apache Arrow Flight SQL ODBC Driver"
 DSN_NAME="Apache Arrow Flight SQL ODBC DSN"
 
 if ! touch "$SYSTEM_ODBC_FILE"; then
-  echo "ERROR: Cannot access or create $SYSTEM_ODBC_FILE" >&2
+  echo ERROR: Cannot access or create $SYSTEM_ODBC_FILE >&2
   exit 1
 fi
 

--- a/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc_ini.sh
+++ b/cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc_ini.sh
@@ -31,7 +31,7 @@ DRIVER_NAME="Apache Arrow Flight SQL ODBC Driver"
 DSN_NAME="Apache Arrow Flight SQL ODBC DSN"
 
 if ! touch "$SYSTEM_ODBC_FILE"; then
-  echo ERROR: Cannot access or create $SYSTEM_ODBC_FILE >&2
+  echo "ERROR: Cannot access or create $SYSTEM_ODBC_FILE" >&2
   exit 1
 fi
 

--- a/cpp/thirdparty/download_dependencies.sh
+++ b/cpp/thirdparty/download_dependencies.sh
@@ -48,7 +48,7 @@ main() {
   mkdir -p "${DESTDIR}"
 
   # Load `DEPENDENCIES` variable.
-  source ${SOURCE_DIR}/versions.txt
+  source "${SOURCE_DIR}/versions.txt"
 
   echo "# Environment variables for offline Arrow build"
   for ((i = 0; i < ${#DEPENDENCIES[@]}; i++)); do


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2086: Double quote to prevent globbing and word splitting.

```
shellcheck cpp/thirdparty/download_dependencies.sh

In cpp/thirdparty/download_dependencies.sh line 49:
  source ${SOURCE_DIR}/versions.txt
         ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  source "${SOURCE_DIR}"/versions.txt

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```


### What changes are included in this PR?

* SC2086: Quote variables.
* Use wildcard file matching instead of specifying each file individually.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No.
* GitHub Issue: #51283