### PR TITLE
GH-51285: [CI] Fix AMD64 Conda Integration Test failure

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -35,6 +35,7 @@ RUN mamba install -q -y \
         numpy \
         compilers \
         go \
+        go-cgo \
         maven=${maven} \
         nodejs=${node} \
         yarn=${yarn} \

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -43,14 +43,6 @@ RUN mamba install -q -y \
         zstd && \
     mamba clean --yes --all --force-pkgs-dirs
 
-RUN echo "========== !!! CHECK GO/CGO !!! ==========" && \
-    conda list | grep -E '^go[[:space:]-]' && \
-    echo "go path: $(which go)" && \
-    go version && \
-    echo "CGO_ENABLED=$(go env CGO_ENABLED)" && \
-    echo "CC=$(go env CC)" && \
-    echo "========== !!! CHECK END !!! =========="
-
 # Install Rust with only the needed components
 # (rustfmt is needed for tonic-build to compile the protobuf definitions)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y && \

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -34,8 +34,7 @@ RUN mamba install -q -y \
         --file arrow/ci/conda_env_archery.txt \
         numpy \
         compilers \
-        go \
-        go-cgo \
+        "go[build=cgo_*]" \
         maven=${maven} \
         nodejs=${node} \
         yarn=${yarn} \

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -43,6 +43,14 @@ RUN mamba install -q -y \
         zstd && \
     mamba clean --yes --all --force-pkgs-dirs
 
+RUN echo "========== !!! CHECK GO/CGO !!! ==========" && \
+    conda list | grep -E '^go[[:space:]-]' && \
+    echo "go path: $(which go)" && \
+    go version && \
+    echo "CGO_ENABLED=$(go env CGO_ENABLED)" && \
+    echo "CC=$(go env CC)" && \
+    echo "========== !!! CHECK END !!! =========="
+
 # Install Rust with only the needed components
 # (rustfmt is needed for tonic-build to compile the protobuf definitions)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y && \

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -34,7 +34,7 @@ RUN mamba install -q -y \
         --file arrow/ci/conda_env_archery.txt \
         numpy \
         compilers \
-        "go[build=cgo_*]" \
+        go-cgo \
         maven=${maven} \
         nodejs=${node} \
         yarn=${yarn} \


### PR DESCRIPTION
### Rationale for this change

AMD64 Conda Integration Test failure

https://github.com/apache/arrow/actions/runs/34469696916/job/102846552090?pr=51284

```
  ++ uname
  + go_lib=arrow_go_integration.so
  + go build -buildvcs=false -tags cdata_integration,assert -buildmode=c-shared -o arrow_go_integration.so .
  package github.com/apache/arrow-go/v18/arrow/internal/cdata_integration: build constraints exclude all Go files in /arrow/go/arrow/internal/cdata_integration
  
  Error: `docker compose --file=/home/runner/work/arrow/arrow/compose.yaml run --rm -e ARCHERY_DEFAULT_BRANCH=main -e ARCHERY_INTEGRATION_WITH_DOTNET=1 -e ARCHERY_INTEGRATION_WITH_GO=1 -e ARCHERY_INTEGRATION_WITH_JAVA=1 -e ARCHERY_INTEGRATION_WITH_JS=1 -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 -e ARCHERY_INTEGRATION_WITH_RUST=1 -e RUST_BACKTRACE=1 conda-integration` exited with a non-zero exit code 1, see the process log above.
```

The Conda integration test requires cgo, but `mamba install go` currently selects the `nocgo` variant by default.

### What changes are included in this PR?

Selects the cgo-enabled Go package for the Conda integration test.

Before this change, `mamba` selected the `nocgo` variant:

```text
go  1.27.1  nocgo_h8a70693_5  conda-forge
go version go1.27.1 linux/amd64
CGO_ENABLED=0
CC=/dev/null
```

After this change, mamba installs the Go package with cgo support:

```
go  1.27.1  cgo_haf5475a_5  conda-forge
go version go1.27.1 linux/amd64
CGO_ENABLED=1
CC=x86_64-conda-linux-gnu-cc
```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #51285