### PR TITLE
GH-51198: [R] ALTREP crash in base R due to use-after-free

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,6 +19,10 @@
 
 # arrow 25.0.1.9000
 
+## Minor improvements and fixes
+
+- Fixed a use-after-free crash when base R held an element of an unmaterialized ALTREP character vector across an allocation. Strings accessed element-wise are now kept alive for the lifetime of the vector, so element-wise passes over ALTREP character columns may use more memory than before (#51198).
+
 # arrow 25.0.1
 
 ## Minor improvements and fixes

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,10 +19,6 @@
 
 # arrow 25.0.1.9000
 
-## Minor improvements and fixes
-
-- Fixed a use-after-free crash when base R held an element of an unmaterialized ALTREP character vector across an allocation. Strings accessed element-wise are now kept alive for the lifetime of the vector, so element-wise passes over ALTREP character columns may use more memory than before (#51198).
-
 # arrow 25.0.1
 
 ## Minor improvements and fixes

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -857,12 +857,76 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     std::string_view view_;
   };
 
-  // Get a single string as a CHARSXP SEXP
-  static SEXP Elt(SEXP alt, R_xlen_t i) {
-    if (Base::IsMaterialized(alt)) {
-      return STRING_ELT(Representation(alt), i);
+  // Strings created by Elt() must stay reachable for as long as the altrep
+  // vector does: base R may hold the CHARSXP returned by STRING_ELT() across
+  // a later allocation, and a CHARSXP that nothing references is collected
+  // (GH-51198). Until the vector is materialized they are kept in fixed-size
+  // STRSXP blocks hanging off a VECSXP stored in the protected slot of the
+  // data1 external pointer. Blocks are allocated on first touch, so sparse
+  // access costs one block rather than a full-length vector. Within a block,
+  // R_BlankString marks a slot that has not been converted yet: the empty
+  // string is a permanent singleton, so converting it again is harmless.
+  static constexpr R_xlen_t kCacheBlockShift = 10;
+  static constexpr R_xlen_t kCacheBlockSize = R_xlen_t(1) << kCacheBlockShift;
+  static constexpr R_xlen_t kCacheBlockMask = kCacheBlockSize - 1;
+
+  // The cache block holding element i, allocating it (and the list of
+  // blocks) on first use. Only valid while the vector is not materialized.
+  static SEXP CacheBlock(SEXP alt, R_xlen_t i) {
+    SEXP data1 = R_altrep_data1(alt);
+    R_xlen_t length = GetChunkedArray(alt)->length();
+
+    SEXP blocks = R_ExternalPtrProtected(data1);
+    if (Rf_isNull(blocks)) {
+      R_xlen_t n_blocks = (length + kCacheBlockMask) >> kCacheBlockShift;
+      blocks = PROTECT(Rf_allocVector(VECSXP, n_blocks));
+      R_SetExternalPtrProtected(data1, blocks);
+      UNPROTECT(1);
     }
 
+    R_xlen_t b = i >> kCacheBlockShift;
+    SEXP block = VECTOR_ELT(blocks, b);
+    if (Rf_isNull(block)) {
+      R_xlen_t block_length = std::min(kCacheBlockSize, length - (b << kCacheBlockShift));
+      block = PROTECT(Rf_allocVector(STRSXP, block_length));
+      SET_VECTOR_ELT(blocks, b, block);
+      UNPROTECT(1);
+    }
+
+    return block;
+  }
+
+  // Copy every string already produced by Elt() into `data2`, so that
+  // materializing does not convert them a second time and so that CHARSXPs
+  // handed out earlier stay reachable once the cache is dropped.
+  static void CopyCacheInto(SEXP alt, SEXP data2) {
+    SEXP blocks = R_ExternalPtrProtected(R_altrep_data1(alt));
+    if (Rf_isNull(blocks)) {
+      return;
+    }
+
+    R_xlen_t n_blocks = Rf_xlength(blocks);
+    for (R_xlen_t b = 0; b < n_blocks; b++) {
+      SEXP block = VECTOR_ELT(blocks, b);
+      if (Rf_isNull(block)) {
+        continue;
+      }
+
+      R_xlen_t offset = b << kCacheBlockShift;
+      R_xlen_t block_length = Rf_xlength(block);
+      for (R_xlen_t j = 0; j < block_length; j++) {
+        SEXP s = STRING_ELT(block, j);
+        if (s != R_BlankString) {
+          SET_STRING_ELT(data2, offset + j, s);
+        }
+      }
+    }
+  }
+
+  // Convert the i'th string of the (not materialized) vector to a CHARSXP.
+  // The result is not reachable from anywhere: the caller must anchor it
+  // before doing anything that can allocate.
+  static SEXP ConvertElt(SEXP alt, R_xlen_t i) {
     auto altrep_data =
         reinterpret_cast<ArrowAltrepData*>(R_ExternalPtrAddr(R_altrep_data1(alt)));
     auto resolve = altrep_data->locate(i);
@@ -870,7 +934,6 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
         altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
     auto j = resolve.index_in_chunk;
 
-    SEXP s = NA_STRING;
     RStringViewer& r_string_viewer = string_viewer();
     r_string_viewer.SetArray(array);
     // Note: we don't check GetBoolOption("arrow.skip_nul", false) here
@@ -878,8 +941,27 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     // an altrep string; however, there is a chance that this value could
     // be out of date by the time a value in the vector is accessed.
     r_string_viewer.reset_null_was_stripped();
-    s = r_string_viewer.Convert(j);
-    if (r_string_viewer.nul_was_stripped()) {
+    return r_string_viewer.Convert(j);
+  }
+
+  // Get a single string as a CHARSXP SEXP
+  static SEXP Elt(SEXP alt, R_xlen_t i) {
+    if (Base::IsMaterialized(alt)) {
+      return STRING_ELT(Representation(alt), i);
+    }
+
+    SEXP block = CacheBlock(alt, i);
+    R_xlen_t j = i & kCacheBlockMask;
+    SEXP s = STRING_ELT(block, j);
+    if (s != R_BlankString) {
+      return s;
+    }
+
+    s = PROTECT(ConvertElt(alt, i));
+    SET_STRING_ELT(block, j, s);
+    UNPROTECT(1);  // s: now reachable through the cache
+
+    if (string_viewer().nul_was_stripped()) {
       Rf_warning("Stripping '\\0' (nul) from character vector");
     }
 
@@ -899,6 +981,11 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     SEXP data2 = PROTECT(Rf_allocVector(STRSXP, chunked_array->length()));
     MARK_NOT_MUTABLE(data2);
 
+    // Reuse what Elt() has already converted, then fill in the rest. The
+    // cache is dropped together with data1 below, so the CHARSXPs it holds
+    // must be in data2 by then.
+    CopyCacheInto(alt, data2);
+
     R_xlen_t i = 0;
     RStringViewer& r_string_viewer = string_viewer();
     r_string_viewer.reset_null_was_stripped();
@@ -908,7 +995,9 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
 
       auto ni = array->length();
       for (R_xlen_t j = 0; j < ni; j++, i++) {
-        SET_STRING_ELT(data2, i, r_string_viewer.Convert(j));
+        if (STRING_ELT(data2, i) == R_BlankString) {
+          SET_STRING_ELT(data2, i, r_string_viewer.Convert(j));
+        }
       }
     }
 

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -661,6 +661,7 @@ test_that("strings returned by ALTREP Elt() survive garbage collection", {
   # handed out reachable (GH-51198). Reproducer adapted from
   # https://gist.github.com/traversc/a5204821451198d457edc38cceda9d90
   withr::local_options(list(arrow.use_altrep = TRUE))
+  skip_on_cran()
 
   # Build the string inside Arrow so that this R session never holds a CHARSXP
   # with these contents: the only one is the one Elt() creates. It is large so

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -662,7 +662,6 @@ test_that("strings returned by ALTREP Elt() survive garbage collection", {
   # https://gist.github.com/traversc/a5204821451198d457edc38cceda9d90
   withr::local_options(list(arrow.use_altrep = TRUE))
   skip_on_cran()
-  skip_on_cran()
 
   # Build the string inside Arrow so that this R session never holds a CHARSXP
   # with these contents: the only one is the one Elt() creates. It is large so

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -654,3 +654,63 @@ test_that("Materialized ALTREP arrays don't cause arrow to crash when attempting
   expect_equal(infer_type(b_int), int32())
   expect_equal(as_arrow_array(b_int), a_int)
 })
+
+test_that("strings returned by ALTREP Elt() survive garbage collection", {
+  # Base R may hold the CHARSXP returned by STRING_ELT() across an allocation,
+  # so an unmaterialized ALTREP string vector must keep every string it has
+  # handed out reachable (GH-51198). Reproducer adapted from
+  # https://gist.github.com/traversc/a5204821451198d457edc38cceda9d90
+  withr::local_options(list(arrow.use_altrep = TRUE))
+
+  # Build the string inside Arrow so that this R session never holds a CHARSXP
+  # with these contents: the only one is the one Elt() creates. It is large so
+  # that R returns its memory to the OS when it is freed, which turns a silent
+  # read of freed memory into a crash.
+  input <- call_function(
+    "binary_repeat",
+    Array$create("a"),
+    Array$create(16L * 1024L * 1024L)
+  )$as_vector()
+  expect_true(is_arrow_altrep(input))
+  expect_false(test_arrow_altrep_is_materialized(input))
+
+  # A latin1 target makes charmatch() allocate (for UTF-8 translation) while
+  # it still holds the pointer to the element of `input`.
+  target <- rawToChar(as.raw(c(rep.int(0x61L, 64L), 0xe9L)))
+  Encoding(target) <- "latin1"
+  target <- rep.int(target, 256L)
+
+  gctorture(TRUE)
+  on.exit(gctorture(FALSE), add = TRUE)
+  observed <- charmatch(input, target, nomatch = NA_integer_)
+  gctorture(FALSE)
+
+  expect_identical(observed, NA_integer_)
+})
+
+test_that("ALTREP string vectors reuse cached strings when materializing", {
+  withr::local_options(list(arrow.use_altrep = TRUE))
+  values <- c("a", NA, "", "d", NA, "f")
+
+  for (x in list(Array$create(values), ChunkedArray$create(values[1:2], values[3:6]))) {
+    alt <- x$as_vector()
+    expect_true(is_arrow_altrep(alt))
+
+    # Element access goes through Elt() and fills the cache
+    expect_identical(alt[c(1, 2, 3)], values[c(1, 2, 3)])
+    expect_false(test_arrow_altrep_is_materialized(alt))
+
+    # Materializing must reuse the cached strings and convert only the rest
+    expect_true(test_arrow_altrep_force_materialize(alt))
+    expect_true(test_arrow_altrep_is_materialized(alt))
+    expect_identical(alt, values)
+    expect_identical(test_arrow_altrep_copy_by_element(alt), values)
+  }
+
+  # Large string type shares the implementation
+  alt <- Array$create(values, type = large_utf8())$as_vector()
+  expect_true(is_arrow_altrep(alt))
+  expect_identical(alt[c(6, 1)], values[c(6, 1)])
+  expect_true(test_arrow_altrep_force_materialize(alt))
+  expect_identical(alt, values)
+})

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -662,6 +662,7 @@ test_that("strings returned by ALTREP Elt() survive garbage collection", {
   # https://gist.github.com/traversc/a5204821451198d457edc38cceda9d90
   withr::local_options(list(arrow.use_altrep = TRUE))
   skip_on_cran()
+  skip_on_cran()
 
   # Build the string inside Arrow so that this R session never holds a CHARSXP
   # with these contents: the only one is the one Elt() creates. It is large so


### PR DESCRIPTION
### Rationale for this change

Segfault triggered in certain circumstances when creating an ALTREP string column and garbage collection runs

### What changes are included in this PR?

Cache string ALTREP value pointer to prevent problematic reallocation after garbage collection

### Are these changes tested?

Yeah

### Are there any user-facing changes?

Increased memory usage in some circumstances but see benchmarks below

* GitHub Issue: #51198