### PR TITLE
GH-38444: [Python] Handle out-of-range date scalar repr

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -671,6 +671,19 @@ cdef class Date32Scalar(Scalar):
         else:
             return None
 
+    def __repr__(self):
+        try:
+            return Scalar.__repr__(self)
+        except OverflowError:
+            value = frombytes(self.wrapped.get().ToString())
+            return f'<pyarrow.{self.__class__.__name__}: {value}>'
+
+    def __str__(self):
+        try:
+            return Scalar.__str__(self)
+        except OverflowError:
+            return frombytes(self.wrapped.get().ToString())
+
 
 cdef class Date64Scalar(Scalar):
     """
@@ -701,6 +714,19 @@ cdef class Date64Scalar(Scalar):
             )
         else:
             return None
+
+    def __repr__(self):
+        try:
+            return Scalar.__repr__(self)
+        except OverflowError:
+            value = frombytes(self.wrapped.get().ToString())
+            return f'<pyarrow.{self.__class__.__name__}: {value}>'
+
+    def __str__(self):
+        try:
+            return Scalar.__str__(self)
+        except OverflowError:
+            return frombytes(self.wrapped.get().ToString())
 
 
 def _datetime_from_int(int64_t value, TimeUnit unit, tzinfo=None):

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -136,6 +136,34 @@ def test_basics_np_required(pickle_module):
     assert wr() is None
 
 
+@pytest.mark.parametrize(('value', 'ty'), [
+    (-(2 ** 31), pa.date32()),
+    (2 ** 31 - 1, pa.date32()),
+    (-(2 ** 63), pa.date64()),
+    (2 ** 63 - 1, pa.date64()),
+])
+def test_date_scalar_repr_outside_python_range(value, ty):
+    scalar = pa.scalar(value, type=ty)
+    out_of_range = f'<value out of range: {value}>'
+
+    assert str(scalar) == out_of_range
+    assert repr(scalar) == (
+        f'<pyarrow.{scalar.__class__.__name__}: {out_of_range}>'
+    )
+
+
+@pytest.mark.parametrize('ty', [pa.date32(), pa.date64()])
+def test_date_scalar_repr_in_python_range(ty):
+    scalar = pa.scalar(datetime.date(2020, 2, 29), type=ty)
+
+    assert str(scalar) == '2020-02-29'
+    assert repr(scalar) == (
+        '<pyarrow.{}: datetime.date(2020, 2, 29)>'.format(
+            scalar.__class__.__name__
+        )
+    )
+
+
 def test_invalid_scalar():
     s = pc.cast(pa.scalar(b"\xff"), pa.string(), safe=False)
     s.validate()


### PR DESCRIPTION
### Rationale for this change

Valid Date32 and Date64 values can fall outside Python's datetime.date range. Their scalar str and repr paths currently call as_py() and raise OverflowError, even though Arrow can format the values safely.

### What changes are included in this PR?

Date32Scalar and Date64Scalar now preserve their existing formatting for Python-representable dates and fall back to the Arrow C++ scalar representation only when conversion raises OverflowError. The as_py() behavior is unchanged.

Boundary regressions cover the minimum and maximum storage values for both date types, plus an in-range leap-day case.

### Are these changes tested?

Yes.

- Rebuilt the PyArrow extension against the matching Arrow C++ source revision.
- python -m pytest python/pyarrow/tests/test_scalars.py -q: 144 passed, 45 skipped.
- File-scoped pre-commit hooks passed, including Python format, Python lint, and Cython lint.

### Are there any user-facing changes?

Date32 and Date64 scalars outside Python's calendar range now render as <value out of range: ...> instead of raising from str() or repr(). This is not a breaking API change.

Closes #38444.

### AI assistance

This PR was prepared with OpenAI Codex assistance for investigation, implementation, and test execution. The change is limited to the date scalar formatting paths and their regression tests.

* GitHub Issue: #38444