### PR TITLE
GH-51297: [Dev] Fix SC2035 shellcheck errors in the cpp/src/arrow/vendored directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -287,7 +287,7 @@ repos:
           ?^cpp/build-support/.*\.sh$|
           ?^cpp/examples/minimal_build/run\.sh$|
           ?^cpp/examples/tutorial_examples/run\.sh$|
-          ?^cpp/src/arrow/flight/.*\.sh$|
+          ?^cpp/src/.*\.sh$|
           ?^cpp/thirdparty/download_dependencies\.sh$|
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/07-flightsqlodbc-upload\.sh$|

--- a/cpp/src/arrow/vendored/datetime/update.sh
+++ b/cpp/src/arrow/vendored/datetime/update.sh
@@ -45,12 +45,12 @@ rm -rf date
 sed -i.bak -E \
     -e 's/namespace date/namespace arrow_vendored::date/g' \
     -e 's,include "date/,include ",g' \
-    *.{cpp,h,mm}
+    ./*.{cpp,h,mm}
 sed -i.bak -E \
     -e 's/(#ifndef |#define |#endif *\/\/ )(DATE_H|ios_hpp|TZ_H|TZ_PRIVATE_H)/\1ARROW_VENDORED_\2/g' \
-    *.h
+    ./*.h
 sed -i.bak -E \
     -e "s/changeset [0-9a-f]+/changeset ${commit_id}/g" \
     README.md
-rm *.bak
+rm ./*.bak
 popd

--- a/cpp/src/arrow/vendored/double-conversion/update.sh
+++ b/cpp/src/arrow/vendored/double-conversion/update.sh
@@ -47,6 +47,6 @@ namespace arrow_vendored {' \
     -e '/^}  \/\/ namespace double_conversion/ a\
 }  // namespace arrow_vendored' \
     ./*.{h,cc}
-rm *.bak
+rm ./*.bak
 
 popd

--- a/cpp/src/arrow/vendored/double-conversion/update.sh
+++ b/cpp/src/arrow/vendored/double-conversion/update.sh
@@ -35,18 +35,18 @@ git clone \
     --branch "v${version}" \
     --depth 1 \
     https://github.com//google/double-conversion.git
-rm *.cc *.h
+rm ./*.cc ./*.h
 for f in double-conversion/double-conversion/*{.h,.cc}; do
   mv "${f}" ./
 done
 rm -rf double-conversion
-sed -i.bak -E -e "s/v[0-9.]+/v${version}/g" *.md
+sed -i.bak -E -e "s/v[0-9.]+/v${version}/g" ./*.md
 sed -i.bak -E \
     -e '/^namespace double_conversion \{/ i\
 namespace arrow_vendored {' \
     -e '/^}  \/\/ namespace double_conversion/ a\
 }  // namespace arrow_vendored' \
-    *.{h,cc}
+    ./*.{h,cc}
 rm *.bak
 
 popd

--- a/cpp/src/arrow/vendored/fast_float/update.sh
+++ b/cpp/src/arrow/vendored/fast_float/update.sh
@@ -37,10 +37,10 @@ git clone \
     https://github.com/fastfloat/fast_float.git
 mv fast_float/include/fast_float/* ./
 rm -rf fast_float
-sed -i.bak -E -e "s/v[0-9.]+/v${version}/g" *.h
+sed -i.bak -E -e "s/v[0-9.]+/v${version}/g" ./*.h
 sed -i.bak -E \
     -e '/^namespace fast_float \{/ i namespace arrow_vendored {' \
     -e '/^} \/\/ namespace fast_float/ a } // namespace arrow_vendored' \
-    *.h
-rm *.bak
+    ./*.h
+rm ./*.bak
 popd


### PR DESCRIPTION
### Rationale for this change

* Use `./*glob*` or `-- *glob*` so names with dashes won't become options.

```
In cpp/src/arrow/vendored/fast_float/update.sh line 40:
sed -i.bak -E -e "s/v[0-9.]+/v${version}/g" *.h
                                            ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/fast_float/update.sh line 44:
    *.h
    ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/fast_float/update.sh line 45:
rm *.bak
   ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/datetime/update.sh line 48:
    *.{cpp,h,mm}
    ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/datetime/update.sh line 51:
    *.h
    ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/datetime/update.sh line 55:
rm *.bak
   ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/double-conversion/update.sh line 38:
rm *.cc *.h
   ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.
        ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/double-conversion/update.sh line 43:
sed -i.bak -E -e "s/v[0-9.]+/v${version}/g" *.md
                                            ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/double-conversion/update.sh line 49:
    *.{h,cc}
    ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.


In cpp/src/arrow/vendored/double-conversion/update.sh line 50:
rm *.bak
   ^-- SC2035 (info): Use ./*glob* or -- *glob* so names with dashes won't become options.

For more information:
  https://www.shellcheck.net/wiki/SC2035 -- Use ./*glob* or -- *glob* so name...
```  

### What changes are included in this PR?

Use `./*glob` instead of `*glob`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #51297