### PR TITLE
GH-29839: [C++][Python][R] Rename binary set lookup functions

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -579,7 +579,7 @@ const FunctionDoc is_in_doc{
     "SetLookupOptions",
     /*options_required=*/true};
 
-const FunctionDoc is_in_meta_doc{
+const FunctionDoc is_in_binary_doc{
     "Find each element in a set of values",
     ("For each element in `values`, return true if it is found in `value_set`,\n"
      "false otherwise."),
@@ -596,38 +596,38 @@ const FunctionDoc index_in_doc{
     "SetLookupOptions",
     /*options_required=*/true};
 
-const FunctionDoc index_in_meta_doc{
+const FunctionDoc index_in_binary_doc{
     "Return index of each element in a set of values",
     ("For each element in `values`, return its index in the `value_set`,\n"
      "or null if it is not found there."),
     {"values", "value_set"}};
 
 // Enables calling is_in with CallFunction as though it were binary.
-class IsInMetaBinary : public MetaFunction {
+class IsInBinary : public MetaFunction {
  public:
-  IsInMetaBinary() : MetaFunction("is_in_meta_binary", Arity::Binary(), is_in_meta_doc) {}
+  IsInBinary() : MetaFunction("is_in_binary", Arity::Binary(), is_in_binary_doc) {}
 
   Result<Datum> ExecuteImpl(const std::vector<Datum>& args,
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
     if (options != nullptr) {
-      return Status::Invalid("Unexpected options for 'is_in_meta_binary' function");
+      return Status::Invalid("Unexpected options for 'is_in_binary' function");
     }
     return IsIn(args[0], args[1], ctx);
   }
 };
 
 // Enables calling index_in with CallFunction as though it were binary.
-class IndexInMetaBinary : public MetaFunction {
+class IndexInBinary : public MetaFunction {
  public:
-  IndexInMetaBinary()
-      : MetaFunction("index_in_meta_binary", Arity::Binary(), index_in_meta_doc) {}
+  IndexInBinary()
+      : MetaFunction("index_in_binary", Arity::Binary(), index_in_binary_doc) {}
 
   Result<Datum> ExecuteImpl(const std::vector<Datum>& args,
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
     if (options != nullptr) {
-      return Status::Invalid("Unexpected options for 'index_in_meta_binary' function");
+      return Status::Invalid("Unexpected options for 'index_in_binary' function");
     }
     return IndexIn(args[0], args[1], ctx);
   }
@@ -659,7 +659,8 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
     DCHECK_OK(is_in->AddKernel(isin_base));
     DCHECK_OK(registry->AddFunction(is_in));
 
-    DCHECK_OK(registry->AddFunction(std::make_shared<IsInMetaBinary>()));
+    DCHECK_OK(registry->AddFunction(std::make_shared<IsInBinary>()));
+    DCHECK_OK(registry->AddAlias("is_in_meta_binary", "is_in_binary"));
   }
 
   // IndexIn writes its int32 output into preallocated memory
@@ -677,7 +678,8 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
     DCHECK_OK(index_in->AddKernel(index_in_base));
     DCHECK_OK(registry->AddFunction(index_in));
 
-    DCHECK_OK(registry->AddFunction(std::make_shared<IndexInMetaBinary>()));
+    DCHECK_OK(registry->AddFunction(std::make_shared<IndexInBinary>()));
+    DCHECK_OK(registry->AddAlias("index_in_meta_binary", "index_in_binary"));
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -76,71 +76,71 @@ static void SetLookupBenchmarkNumeric(benchmark::State& state,
 }
 
 static void IndexInStringSmallSet(benchmark::State& state) {
-  SetLookupBenchmarkString(state, "index_in_meta_binary", state.range(0));
+  SetLookupBenchmarkString(state, "index_in_binary", state.range(0));
 }
 
 static void IsInStringSmallSet(benchmark::State& state) {
-  SetLookupBenchmarkString(state, "is_in_meta_binary", state.range(0));
+  SetLookupBenchmarkString(state, "is_in_binary", state.range(0));
 }
 
 static void IndexInStringLargeSet(benchmark::State& state) {
-  SetLookupBenchmarkString(state, "index_in_meta_binary", 1 << 10);
+  SetLookupBenchmarkString(state, "index_in_binary", 1 << 10);
 }
 
 static void IsInStringLargeSet(benchmark::State& state) {
-  SetLookupBenchmarkString(state, "is_in_meta_binary", 1 << 10);
+  SetLookupBenchmarkString(state, "is_in_binary", 1 << 10);
 }
 
 static constexpr int64_t kArrayLengthWithSmallSet = 1 << 18;
 static constexpr int64_t kArrayLengthWithLargeSet = 1000;
 
 static void IndexInInt8SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int8Type>(state, "index_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int8Type>(state, "index_in_binary", state.range(0),
                                       kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt16SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int16Type>(state, "index_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int16Type>(state, "index_in_binary", state.range(0),
                                        kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt32SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_binary", state.range(0),
                                        kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt64SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int64Type>(state, "index_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int64Type>(state, "index_in_binary", state.range(0),
                                        kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt32LargeSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_binary", state.range(0),
                                        kArrayLengthWithLargeSet);
 }
 
 static void IsInInt8SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int8Type>(state, "is_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int8Type>(state, "is_in_binary", state.range(0),
                                       kArrayLengthWithSmallSet);
 }
 
 static void IsInInt16SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int16Type>(state, "is_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int16Type>(state, "is_in_binary", state.range(0),
                                        kArrayLengthWithSmallSet);
 }
 
 static void IsInInt32SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_binary", state.range(0),
                                        kArrayLengthWithSmallSet);
 }
 
 static void IsInInt64SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int64Type>(state, "is_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int64Type>(state, "is_in_binary", state.range(0),
                                        kArrayLengthWithSmallSet);
 }
 
 static void IsInInt32LargeSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0),
+  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_binary", state.range(0),
                                        kArrayLengthWithLargeSet);
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -169,10 +169,13 @@ TEST_F(TestIsInKernel, CallBinary) {
   auto value_set = ArrayFromJSON(int8(), "[2, 3, 5, 7]");
   ASSERT_RAISES(Invalid, CallFunction("is_in", {input, value_set}));
 
-  ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("is_in_meta_binary", {input, value_set}));
   auto expected = ArrayFromJSON(boolean(), ("[false, false, true, true, false,"
                                             "true, false, true, false]"));
-  AssertArraysEqual(*expected, *out.make_array());
+  for (const std::string& function_name : {"is_in_binary", "is_in_meta_binary"}) {
+    SCOPED_TRACE(function_name);
+    ASSERT_OK_AND_ASSIGN(Datum out, CallFunction(function_name, {input, value_set}));
+    AssertArraysEqual(*expected, *out.make_array());
+  }
 }
 
 TEST_F(TestIsInKernel, ImplicitlyCastValueSet) {
@@ -1127,11 +1130,13 @@ TEST_F(TestIndexInKernel, CallBinary) {
   auto value_set = ArrayFromJSON(int8(), "[2, 3, 5, 7]");
   ASSERT_RAISES(Invalid, CallFunction("index_in", {input, value_set}));
 
-  ASSERT_OK_AND_ASSIGN(Datum out,
-                       CallFunction("index_in_meta_binary", {input, value_set}));
   auto expected = ArrayFromJSON(int32(), ("[null, null, 0, 1, null, 2, null, 3, null,"
                                           " null, null]"));
-  AssertArraysEqual(*expected, *out.make_array());
+  for (const std::string& function_name : {"index_in_binary", "index_in_meta_binary"}) {
+    SCOPED_TRACE(function_name);
+    ASSERT_OK_AND_ASSIGN(Datum out, CallFunction(function_name, {input, value_set}));
+    AssertArraysEqual(*expected, *out.make_array());
+  }
 }
 
 template <typename Type>

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1237,7 +1237,13 @@ Containment tests
 | index_in              | Unary | Boolean, Null, Numeric, Temporal, | Int32          | :struct:`SetLookupOptions`      | \(4)  |
 |                       |       | Binary- and String-like           |                |                                 |       |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
+| index_in_binary       | Binary| Boolean, Null, Numeric, Temporal, | Int32          |                                 | \(4)  |
+|                       |       | Binary- and String-like           |                |                                 |       |
++-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | is_in                 | Unary | Boolean, Null, Numeric, Temporal, | Boolean        | :struct:`SetLookupOptions`      | \(5)  |
+|                       |       | Binary- and String-like           |                |                                 |       |
++-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
+| is_in_binary          | Binary| Boolean, Null, Numeric, Temporal, | Boolean        |                                 | \(5)  |
 |                       |       | Binary- and String-like           |                |                                 |       |
 +-----------------------+-------+-----------------------------------+----------------+---------------------------------+-------+
 | match_like            | Unary | Binary- or String-like            | Boolean        | :struct:`MatchSubstringOptions` | \(6)  |
@@ -1262,12 +1268,15 @@ Containment tests
   string, otherwise -1. Output type is Int32 for Binary/String, Int64
   for LargeBinary/LargeString.
 
-* \(4) Output is the index of the corresponding input element in
-  :member:`SetLookupOptions::value_set`, if found there.  Otherwise,
-  output is null.
+* \(4) Output is the index of the corresponding input element in the
+  value set, if found there. The value set is provided as the second input to
+  ``index_in_binary`` or as :member:`SetLookupOptions::value_set` to
+  ``index_in``. Otherwise, output is null.
 
 * \(5) Output is true iff the corresponding input element is equal to one
-  of the elements in :member:`SetLookupOptions::value_set`.
+  of the elements in the value set. The value set is provided as the second
+  input to ``is_in_binary`` or as :member:`SetLookupOptions::value_set` to
+  ``is_in``.
 
 * \(6) Output is true iff the SQL-style LIKE pattern
   :member:`MatchSubstringOptions::pattern` fully matches the

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -399,7 +399,9 @@ Containment Tests
    find_substring
    find_substring_regex
    index_in
+   index_in_binary
    is_in
+   is_in_binary
    match_like
    match_substring
    match_substring_regex

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -320,10 +320,14 @@ def test_pickle_global_functions(pickle_module):
 
 def test_function_attributes():
     # Sanity check attributes of registered functions
+    aliases = {
+        "index_in_meta_binary": "index_in_binary",
+        "is_in_meta_binary": "is_in_binary",
+    }
     for name in pc.list_functions():
         func = pc.get_function(name)
         assert isinstance(func, pc.Function)
-        assert func.name == name
+        assert func.name == aliases.get(name, name)
         kernels = func.kernels
         assert func.num_kernels == len(kernels)
         assert all(isinstance(ker, pc.Kernel) for ker in kernels)
@@ -3340,6 +3344,19 @@ def test_is_in():
     assert result.to_pylist() == [True, False, False, True, False, True]
 
 
+@pytest.mark.parametrize("function_name", [
+    "is_in_binary",
+    "is_in_meta_binary",
+])
+def test_is_in_binary(function_name):
+    values = pa.array([1, 2, None, 3])
+    value_set = pa.array([1, 3, None])
+
+    result = getattr(pc, function_name)(values, value_set)
+
+    assert result.to_pylist() == [True, False, True, True]
+
+
 def test_index_in():
     arr = pa.array([1, 2, None, 1, 2, 3])
 
@@ -3359,6 +3376,19 @@ def test_index_in():
     # Positional value_set
     result = pc.index_in(arr, pa.array([1, 3]), skip_nulls=True)
     assert result.to_pylist() == [0, None, None, 0, None, 1]
+
+
+@pytest.mark.parametrize("function_name", [
+    "index_in_binary",
+    "index_in_meta_binary",
+])
+def test_index_in_binary(function_name):
+    values = pa.array([1, 2, None, 3])
+    value_set = pa.array([1, 3, None])
+
+    result = getattr(pc, function_name)(values, value_set)
+
+    assert result.to_pylist() == [0, None, 2, 1]
 
 
 def test_quantile():

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -268,7 +268,7 @@ match_arrow <- function(x, table, ...) {
   if (!inherits(table, c("Array", "ChunkedArray"))) {
     table <- Array$create(table)
   }
-  call_function("index_in_meta_binary", x, table)
+  call_function("index_in_binary", x, table)
 }
 
 #' @rdname match_arrow
@@ -281,7 +281,7 @@ is_in <- function(x, table, ...) {
   if (!inherits(table, c("Array", "DictionaryArray", "ChunkedArray"))) {
     table <- Array$create(table)
   }
-  call_function("is_in_meta_binary", x, table)
+  call_function("is_in_binary", x, table)
 }
 
 #' `table` for Arrow objects

--- a/r/R/dplyr-funcs-conditional.R
+++ b/r/R/dplyr-funcs-conditional.R
@@ -180,7 +180,7 @@ parse_value_mapping <- function(x, formulas = list(), from = NULL, to = NULL, ma
 
 register_bindings_conditional <- function() {
   register_binding("%in%", function(x, table) {
-    # We use `is_in` here, unlike with Arrays, which use `is_in_meta_binary`
+    # We use `is_in` here, unlike with Arrays, which use `is_in_binary`
     value_set <- Array$create(table)
     # If possible, `table` should be the same type as `x`
     # Try downcasting here; otherwise Acero may upcast x to table's type


### PR DESCRIPTION
### Rationale for this change

The public compute function names `is_in_meta_binary` and
`index_in_meta_binary` expose the internal `MetaFunction` implementation
detail. 

### What changes are included in this PR?

- Register `is_in_binary` and `index_in_binary` as the canonical names.
- Retain `is_in_meta_binary` and `index_in_meta_binary` as compatibility
  aliases.
- Update Arrow-owned R callers and C++ benchmarks to use the canonical names.
- Add C++ and Python coverage for both canonical and compatibility names.
- Add the canonical names to the C++ and Python compute documentation.
- Update the PyArrow registry-name test to account for canonical names returned
  through aliases.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Closes #29839
* GitHub Issue: #29839