### PR TITLE
GH-51300: Fix deprecation warnings for `null_placement`

### DIFF
--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -138,8 +138,7 @@ def test_exported_option_classes():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:pyarrow.CumulativeSumOptions is deprecated as of 14.0",
-    "ignore:Specifying null_placement in RankOptions is deprecated"
+    "ignore:pyarrow.CumulativeSumOptions is deprecated as of 14.0"
 )
 def test_option_class_equality(request):
     options = [
@@ -173,10 +172,9 @@ def test_option_class_equality(request):
         pc.PivotWiderOptions(["height"], unexpected_key_behavior="raise"),
         pc.QuantileOptions(),
         pc.RandomOptions(),
-        pc.RankOptions(sort_keys="ascending",
-                       null_placement="at_end", tiebreaker="max"),
-        pc.RankQuantileOptions(sort_keys="ascending",
-                               null_placement="at_end"),
+        pc.RankOptions(sort_keys=[("", "ascending", "at_end")],
+                       tiebreaker="max"),
+        pc.RankQuantileOptions(sort_keys=[("", "ascending", "at_end")]),
         pc.ReplaceSliceOptions(0, 1, "a"),
         pc.ReplaceSubstringOptions("a", "b"),
         pc.RoundOptions(2, "towards_infinity"),
@@ -3881,22 +3879,15 @@ def test_random():
      ("first", [3, 1, 4, 6, 5, 7, 2]),
      ("dense", [2, 1, 3, 4, 3, 4, 1])]
 )
-@pytest.mark.filterwarnings(
-    "ignore:Specifying null_placement in RankOptions is deprecated"
-)
 def test_rank_options_tiebreaker(tiebreaker, expected_values):
     arr = pa.array([1.2, 0.0, 5.3, None, 5.3, None, 0.0])
-    rank_options = pc.RankOptions(sort_keys="ascending",
-                                  null_placement="at_end",
+    rank_options = pc.RankOptions(sort_keys=[("", "ascending", "at_end")],
                                   tiebreaker=tiebreaker)
     result = pc.rank(arr, options=rank_options)
     expected = pa.array(expected_values, type=pa.uint64())
     assert result.equals(expected)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Specifying null_placement in RankOptions is deprecated"
-)
 def test_rank_options():
     arr = pa.array([1.2, 0.0, 5.3, None, 5.3, None, 0.0])
     expected = pa.array([3, 1, 4, 6, 5, 7, 2], type=pa.uint64())
@@ -3915,7 +3906,7 @@ def test_rank_options():
     )
     assert result.equals(expected)
 
-    result = pc.rank(arr, null_placement="at_start")
+    result = pc.rank(arr, sort_keys=[("", "ascending", "at_start")])
     expected_at_start = pa.array([5, 3, 6, 1, 7, 2, 4], type=pa.uint64())
     assert result.equals(expected_at_start)
 
@@ -3925,14 +3916,10 @@ def test_rank_options():
 
     with pytest.raises(ValueError,
                        match=r'"NonExisting" is not a valid tiebreaker'):
-        pc.RankOptions(sort_keys="descending",
-                       null_placement="at_end",
+        pc.RankOptions(sort_keys=[("", "descending", "at_end")],
                        tiebreaker="NonExisting")
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Specifying null_placement in RankOptions is deprecated"
-)
 def test_rank_quantile_options():
     arr = pa.array([None, 1, None, 2, None])
     expected = pa.array([0.7, 0.1, 0.7, 0.3, 0.7], type=pa.float64())
@@ -3951,7 +3938,7 @@ def test_rank_quantile_options():
     )
     assert result.equals(expected)
 
-    result = pc.rank_quantile(arr, null_placement="at_start")
+    result = pc.rank_quantile(arr, sort_keys=[("", "ascending", "at_start")])
     expected_at_start = pa.array([0.3, 0.7, 0.3, 0.9, 0.3], type=pa.float64())
     assert result.equals(expected_at_start)
 
@@ -3963,9 +3950,6 @@ def test_rank_quantile_options():
         pc.rank_quantile(arr, sort_keys="XXX")
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Specifying null_placement in RankOptions is deprecated"
-)
 def test_rank_normal_options():
     arr = pa.array([None, 1, None, 2, None])
 
@@ -3974,7 +3958,7 @@ def test_rank_normal_options():
          -0.5244005127080409, 0.5244005127080407])
     result = pc.rank_normal(arr)
     assert result.to_pylist() == expected
-    result = pc.rank_normal(arr, null_placement="at_end", sort_keys="ascending")
+    result = pc.rank_normal(arr, sort_keys=[("", "ascending", "at_end")])
     assert result.to_pylist() == expected
     result = pc.rank_normal(arr, options=pc.RankQuantileOptions())
     assert result.to_pylist() == expected
@@ -3982,11 +3966,12 @@ def test_rank_normal_options():
     expected = pytest.approx(
         [-0.5244005127080409, 1.2815515655446004, -0.5244005127080409,
          0.5244005127080407, -0.5244005127080409])
-    result = pc.rank_normal(arr, null_placement="at_start", sort_keys="descending")
+    result = pc.rank_normal(arr, sort_keys=[("", "descending", "at_start")])
     assert result.to_pylist() == expected
     result = pc.rank_normal(arr,
-                            options=pc.RankQuantileOptions(null_placement="at_start",
-                                                           sort_keys="descending"))
+                            options=pc.RankQuantileOptions(
+                                sort_keys=[("", "descending", "at_start")])
+                            )
     assert result.to_pylist() == expected
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -138,7 +138,8 @@ def test_exported_option_classes():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:pyarrow.CumulativeSumOptions is deprecated as of 14.0"
+    "ignore:pyarrow.CumulativeSumOptions is deprecated as of 14.0",
+    "ignore:Specifying null_placement in RankOptions is deprecated"
 )
 def test_option_class_equality(request):
     options = [
@@ -3880,6 +3881,9 @@ def test_random():
      ("first", [3, 1, 4, 6, 5, 7, 2]),
      ("dense", [2, 1, 3, 4, 3, 4, 1])]
 )
+@pytest.mark.filterwarnings(
+    "ignore:Specifying null_placement in RankOptions is deprecated"
+)
 def test_rank_options_tiebreaker(tiebreaker, expected_values):
     arr = pa.array([1.2, 0.0, 5.3, None, 5.3, None, 0.0])
     rank_options = pc.RankOptions(sort_keys="ascending",
@@ -3890,6 +3894,9 @@ def test_rank_options_tiebreaker(tiebreaker, expected_values):
     assert result.equals(expected)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Specifying null_placement in RankOptions is deprecated"
+)
 def test_rank_options():
     arr = pa.array([1.2, 0.0, 5.3, None, 5.3, None, 0.0])
     expected = pa.array([3, 1, 4, 6, 5, 7, 2], type=pa.uint64())
@@ -3923,6 +3930,9 @@ def test_rank_options():
                        tiebreaker="NonExisting")
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Specifying null_placement in RankOptions is deprecated"
+)
 def test_rank_quantile_options():
     arr = pa.array([None, 1, None, 2, None])
     expected = pa.array([0.7, 0.1, 0.7, 0.3, 0.7], type=pa.float64())
@@ -3953,6 +3963,9 @@ def test_rank_quantile_options():
         pc.rank_quantile(arr, sort_keys="XXX")
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Specifying null_placement in RankOptions is deprecated"
+)
 def test_rank_normal_options():
     arr = pa.array([None, 1, None, 2, None])
 


### PR DESCRIPTION
### Rationale for this change

Resolves #51300, which mentioned that deprecation warnings were being printed when executing the python tests.

### What changes are included in this PR?

This migrates the test suite to use the non-deprecated api for `null_placement`

### Are these changes tested?

Yes, python compute tests are still passing

### Are there any user-facing changes?

No.