### PR TITLE
GH-32438: [C++] Create target file when OpenAppendStream targets a nonexistent path

### DIFF
--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -346,7 +346,6 @@ class TestHadoopFileSystemGeneric : public ::testing::Test,
   bool allow_write_file_over_dir() const override { return true; }
   bool allow_move_dir_over_non_empty_dir() const override { return true; }
   bool have_implicit_directories() const override { return true; }
-  bool allow_append_to_new_file() const override { return false; }
 
   std::shared_ptr<FileSystem> GetEmptyFileSystem() override {
     // Since the HDFS contents are kept persistently between test runs,

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -529,7 +529,10 @@ class HadoopFileSystem::HadoopFileSystemImpl {
                       int16_t replication, int64_t default_block_size,
                       std::shared_ptr<HdfsOutputStream>* file) {
     int flags = O_WRONLY;
-    if (append) flags |= O_APPEND;
+    // FileSystem::append (unlike a POSIX O_CREAT|O_APPEND open) requires
+    // the target file to already exist, so only request append semantics if the
+    // file is actually there.
+    if (append && Exists(path)) flags |= O_APPEND;
 
     errno = 0;
     hdfsFile handle =

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -529,7 +529,7 @@ class HadoopFileSystem::HadoopFileSystemImpl {
                       int16_t replication, int64_t default_block_size,
                       std::shared_ptr<HdfsOutputStream>* file) {
     int flags = O_WRONLY;
-    // FileSystem::append (unlike a POSIX O_CREAT|O_APPEND open) requires
+    // Hadoop's FileSystem::append (unlike a POSIX O_CREAT|O_APPEND open) requires
     // the target file to already exist, so only request append semantics if the
     // file is actually there.
     if (append && Exists(path)) flags |= O_APPEND;


### PR DESCRIPTION
### Rationale for this change

`FileSystem::OpenAppendStream` is [documented](https://github.com/apache/arrow/blob/main/cpp/src/arrow/filesystem/filesystem.h#L339-L341) to create the target file if it doesn't already exist. On HDFS this instead raises a not-found error. `HadoopFileSystemImpl::OpenWritable` always opens in append mode when asked to append, but Hadoop's `FileSystem.append()` requires the file to already exist, unlike a local append-mode open. See #32438.

### What changes are included in this PR?

- `OpenWritable` now only sets append mode when the target already exists; otherwise it falls back to a plain create, matching every other backend. Adds an existence check against the NameNode before an append-mode open, since that's the only way to know which mode to request.
- Removed `TestHadoopFileSystemGeneric::allow_append_to_new_file`'s override to `false`, seemingly added when HDFS was first wired into the shared filesystem test suite. HDFS now runs the same append-to-new-file check as every other backend.

### Are these changes tested?

Yes. With the override removed, `TestHadoopFileSystemGeneric.OpenAppendStream` fails on the unpatched code with the same not-found error from the issue, and passes with this change, run against the Docker-based HDFS test setup (`ci/scripts/integration_hdfs.sh`). The rest of the HDFS C++ suite and `pyarrow.tests.test_fs` pass with no regressions.

Unrelated to this change: `ci/scripts/install_minio.sh` currently fails for anyone building the CI images locally, since MinIO discontinued the binary distribution it fetches from. I patched around it locally to get a working build. If this is fixed properly upstream and CI behaves differently as a result, I wouldn't have had visibility into that from my local setup.

### Are there any user-facing changes?

Yes: appending to a nonexistent file on HDFS now succeeds and creates the file, instead of raising an error.

**This PR contains a "Critical Fix".** It fixes a case where an operation documented to succeed instead raised an error.

* GitHub Issue: #32438
